### PR TITLE
Fix Typos

### DIFF
--- a/dispatch/io.h
+++ b/dispatch/io.h
@@ -38,7 +38,7 @@ __BEGIN_DECLS
  * The application may set policies on the dispatch I/O channel to indicate the
  * desired frequency of I/O handlers for long-running operations.
  *
- * Dispatch I/O also provides a memory managment model for I/O buffers that
+ * Dispatch I/O also provides a memory management model for I/O buffers that
  * avoids unnecessary copying of data when pipelined between channels. Dispatch
  * I/O monitors the overall memory pressure and I/O access patterns for the
  * application to optimize resource utilization.
@@ -168,7 +168,7 @@ DISPATCH_DECL(dispatch_io);
  * bytes. Read and write operations on a channel of this type are performed
  * serially (in order of creation) and read/write data at the file pointer
  * position that is current at the time the operation starts executing.
- * Operations of different type (read vs. write) may be perfomed simultaneously.
+ * Operations of different type (read vs. write) may be performed simultaneously.
  * Offsets passed to operations on a channel of this type are ignored.
  *
  * @const DISPATCH_IO_RANDOM	A dispatch I/O channel representing a random

--- a/dispatch/queue.h
+++ b/dispatch/queue.h
@@ -920,7 +920,7 @@ dispatch_barrier_sync_f(dispatch_queue_t queue,
  * The key to set the context for, typically a pointer to a static variable
  * specific to the subsystem. Keys are only compared as pointers and never
  * dereferenced. Passing a string constant directly is not recommended.
- * The NULL key is reserved and attemps to set a context for it are ignored.
+ * The NULL key is reserved and attempts to set a context for it are ignored.
  *
  * @param context
  * The new subsystem-specific context for the object. This may be NULL.

--- a/dispatch/semaphore.h
+++ b/dispatch/semaphore.h
@@ -44,7 +44,7 @@ __BEGIN_DECLS
  *
  * @discussion
  * Passing zero for the value is useful for when two threads need to reconcile
- * the completion of a particular event. Passing a value greather than zero is
+ * the completion of a particular event. Passing a value greater than zero is
  * useful for managing a finite pool of resources, where the pool size is equal
  * to the value.
  *

--- a/dispatch/source.h
+++ b/dispatch/source.h
@@ -64,7 +64,7 @@ __BEGIN_DECLS
  * is being monitored by the dispatch source. Constants of this type are
  * passed as a parameter to dispatch_source_create() and determine how the
  * handle argument is interpreted (i.e. as a file descriptor, mach port,
- * signal number, process identifer, etc.), and how the mask arugment is
+ * signal number, process identifier, etc.), and how the mask argument is
  * interpreted.
  */
 typedef const struct dispatch_source_type_s *dispatch_source_type_t;

--- a/dispatch/time.h
+++ b/dispatch/time.h
@@ -102,7 +102,7 @@ dispatch_time(dispatch_time_t when, int64_t delta);
  * On Mac OS X the wall clock is based on gettimeofday(3).
  *
  * @param when
- * A struct timespect to add time to. If NULL is passed, then
+ * A struct timespec to add time to. If NULL is passed, then
  * dispatch_walltime() will use the result of gettimeofday(3).
  *
  * @param delta

--- a/private/data_private.h
+++ b/private/data_private.h
@@ -159,7 +159,7 @@ dispatch_data_apply_f(dispatch_data_t data, void *context,
  *
  * @param data		The data object to make a memory entry for.
  * @result		A mach port for the newly made memory entry, or
- *			MACH_PORT_NULL if an error ocurred.
+ *			MACH_PORT_NULL if an error occurred.
  */
 __OSX_AVAILABLE_STARTING(__MAC_10_9,__IPHONE_6_0)
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
@@ -286,7 +286,7 @@ DISPATCH_DATA_FORMAT_TYPE_DECL(utf_any);
  * Flags specifying the input format of the source dispatch_data_t
  *
  * @param output_type
- * Flags specifying the expected output format of the resulting transfomation.
+ * Flags specifying the expected output format of the resulting transformation.
  *
  * @result
  * A newly created dispatch data object, dispatch_data_empty if no has been

--- a/private/introspection_private.h
+++ b/private/introspection_private.h
@@ -535,7 +535,7 @@ typedef void (*dispatch_introspection_hook_queue_item_complete_t)(
  * @typedef dispatch_introspection_hooks_s
  *
  * @abstract
- * A structure of function pointer hoooks into libdispatch.
+ * A structure of function pointer hooks into libdispatch.
  */
 
 typedef struct dispatch_introspection_hooks_s {

--- a/private/voucher_activity_private.h
+++ b/private/voucher_activity_private.h
@@ -198,7 +198,7 @@ voucher_activity_start_with_location(voucher_activity_trace_id_t trace_id,
  * @function voucher_activity_end
  *
  * @abstract
- * Unmarks the current thread if it is marked as particpating in the activity
+ * Unmarks the current thread if it is marked as participating in the activity
  * with the specified identifier.
  *
  * @discussion

--- a/private/voucher_private.h
+++ b/private/voucher_private.h
@@ -151,7 +151,7 @@ voucher_replace_default_voucher(void);
  *
  * @discussion
  * This is only intended for use by CoreFoundation to explicitly manage the
- * App Nap state of an application following receiption of a de-nap IPC message.
+ * App Nap state of an application following reception of a de-nap IPC message.
  *
  * CAUTION: Do NOT use this SPI without contacting the Darwin Runtime team.
  */

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -35,7 +35,7 @@
 // once to non-zero. They are not marked volatile. There is a small risk that
 // some thread may see a stale 0 value and enter try_create_heap. It will
 // waste some time in an allocate syscall, but eventually it will try to
-// cmpxchg, expecting to overwite 0 with an address. This will fail
+// cmpxchg, expecting to overwrite 0 with an address. This will fail
 // (because another thread already did this), the thread will deallocate the
 // unused allocated memory, and continue with the new value.
 //

--- a/src/allocator_internal.h
+++ b/src/allocator_internal.h
@@ -218,7 +218,7 @@ struct dispatch_magazine_header_s {
 	// Link to the next heap in the chain. Only used in magazine 0's header
 	dispatch_heap_t dh_next;
 
-	// Points to the first bitmap in the page where this CPU succesfully
+	// Points to the first bitmap in the page where this CPU successfully
 	// allocated a continuation last time. Only used in the first heap.
 	bitmap_t *last_found_page;
 };

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -79,7 +79,7 @@ _dispatch_data_leaf(struct dispatch_data_s *dd)
  * This is about the number of records required to hold that dispatch data
  * if it's not a leaf. Callers either want that value, or have to special
  * case the case when the dispatch data *is* a leaf before (and that the actual
- * embeded record count of that dispatch data is 0)
+ * embedded record count of that dispatch data is 0)
  */
 DISPATCH_ALWAYS_INLINE
 static inline size_t

--- a/src/inline_internal.h
+++ b/src/inline_internal.h
@@ -552,8 +552,8 @@ _dispatch_reset_defaultpriority(pthread_priority_t priority)
 {
 #if HAVE_PTHREAD_WORKQUEUE_QOS
 	pthread_priority_t old_priority = _dispatch_get_defaultpriority();
-	// if an inner-loop or'd in the override flag to the per-thread priority,
-	// it needs to be propogated up the chain
+	// If an inner-loop or'd in the override flag to the per-thread priority,
+	// it needs to be propagated up the chain.
 	priority |= old_priority & _PTHREAD_PRIORITY_OVERRIDE_FLAG;
 
 	if (slowpath(priority != old_priority)) {

--- a/src/object.c
+++ b/src/object.c
@@ -64,7 +64,7 @@ _os_object_retain_with_resurrect(_os_object_t obj)
 {
 	int xref_cnt = _os_object_xrefcnt_inc(obj);
 	if (slowpath(xref_cnt < 0)) {
-		_OS_OBJECT_CLIENT_CRASH("Resurrection of an overreleased object");
+		_OS_OBJECT_CLIENT_CRASH("Resurrection of an over-released object");
 	}
 	if (slowpath(xref_cnt == 0)) {
 		_os_object_retain_internal(obj);

--- a/src/provider.d
+++ b/src/provider.d
@@ -66,7 +66,7 @@ provider dispatch {
  *
  * Timer configuration indicates that dispatch_source_set_timer() was called.
  * Timer programming indicates that the dispatch manager is about to sleep
- * for 'deadline' ns (but may wake up earlier if non-timer events occur).
+ * for 'deadline' (but may wake up earlier if non-timer events occur).
  * Time parameters are in nanoseconds, a value of -1 means "forever".
  *
  * dispatch$target:libdispatch*.dylib::timer-configure

--- a/src/source.c
+++ b/src/source.c
@@ -3144,11 +3144,11 @@ _dispatch_mach_notify_update(dispatch_kevent_t dk, uint32_t new_flags,
 		switch(krr) {
 		case KERN_INVALID_NAME:
 		case KERN_INVALID_RIGHT:
-			// Supress errors & clear registration state
+			// Suppress errors & clear registration state
 			dk->dk_kevent.data &= ~mask;
 			break;
 		default:
-			// Else, we dont expect any errors from mach. Log any errors
+			// Else, we don't expect any errors from mach. Log any errors
 			if (dispatch_assume_zero(krr)) {
 				// log the error & clear registration state
 				dk->dk_kevent.data &= ~mask;
@@ -4814,9 +4814,6 @@ _dispatch_kevent_debugger2(void *context)
 	fprintf(debug_stream, "<html>\n");
 	fprintf(debug_stream, "<head><title>PID %u</title></head>\n", getpid());
 	fprintf(debug_stream, "<body>\n<ul>\n");
-
-	//fprintf(debug_stream, "<tr><td>DK</td><td>DK</td><td>DK</td><td>DK</td>"
-	//		"<td>DK</td><td>DK</td><td>DK</td></tr>\n");
 
 	for (i = 0; i < DSL_HASH_SIZE; i++) {
 		if (TAILQ_EMPTY(&_dispatch_sources[i])) {

--- a/src/voucher.c
+++ b/src/voucher.c
@@ -188,8 +188,8 @@ _voucher_find_and_retain(mach_voucher_t kv)
 			int xref_cnt = dispatch_atomic_inc2o(v, os_obj_xref_cnt, relaxed);
 			_dispatch_voucher_debug("retain  -> %d", v, xref_cnt + 1);
 			if (slowpath(xref_cnt < 0)) {
-				_dispatch_voucher_debug("overrelease", v);
-				DISPATCH_CRASH("Voucher overrelease");
+				_dispatch_voucher_debug("over-release", v);
+				DISPATCH_CRASH("Voucher over-release");
 			}
 			if (xref_cnt == 0) {
 				// resurrection: raced with _voucher_remove
@@ -1398,8 +1398,8 @@ _voucher_activity_try_retain(_voucher_activity_t act)
 	int use_cnt = dispatch_atomic_inc2o(act, va_refcnt, relaxed);
 	_dispatch_voucher_activity_debug("retain  -> %d", act, use_cnt + 1);
 	if (slowpath(use_cnt < 0)) {
-		_dispatch_voucher_activity_debug("overrelease", act);
-		DISPATCH_CRASH("Activity overrelease");
+		_dispatch_voucher_activity_debug("over-release", act);
+		DISPATCH_CRASH("Activity over-release");
 	}
 	return use_cnt > 0;
 }
@@ -1427,8 +1427,8 @@ _voucher_activity_release(_voucher_activity_t act)
 		return;
 	}
 	if (slowpath(use_cnt < -1)) {
-		_dispatch_voucher_activity_debug("overrelease", act);
-		DISPATCH_CRASH("Activity overrelease");
+		_dispatch_voucher_activity_debug("over-release", act);
+		DISPATCH_CRASH("Activity over-release");
 	}
 	_voucher_activity_remove(act);
 	_voucher_activity_dispose(act);
@@ -1661,8 +1661,8 @@ _voucher_atm_try_retain(_voucher_atm_t vatm)
 	int refcnt = dispatch_atomic_inc2o(vatm, vatm_refcnt, relaxed);
 	_dispatch_voucher_atm_debug("retain  -> %d", vatm, refcnt + 1);
 	if (slowpath(refcnt < 0)) {
-		_dispatch_voucher_atm_debug("overrelease", vatm);
-		DISPATCH_CRASH("ATM overrelease");
+		_dispatch_voucher_atm_debug("over-release", vatm);
+		DISPATCH_CRASH("ATM over-release");
 	}
 	return refcnt > 0;
 }
@@ -1690,8 +1690,8 @@ _voucher_atm_release(_voucher_atm_t vatm)
 		return;
 	}
 	if (slowpath(refcnt < -1)) {
-		_dispatch_voucher_atm_debug("overrelease", vatm);
-		DISPATCH_CRASH("ATM overrelease");
+		_dispatch_voucher_atm_debug("over-release", vatm);
+		DISPATCH_CRASH("ATM over-release");
 	}
 	_voucher_atm_remove(vatm);
 	_voucher_atm_dispose(vatm, true);

--- a/src/voucher_internal.h
+++ b/src/voucher_internal.h
@@ -271,8 +271,8 @@ _voucher_release(voucher_t voucher)
 		return;
 	}
 	if (slowpath(xref_cnt < -1)) {
-		_dispatch_voucher_debug("overrelease", voucher);
-		DISPATCH_CRASH("Voucher overrelease");
+		_dispatch_voucher_debug("over-release", voucher);
+		DISPATCH_CRASH("Voucher over-release");
 	}
 	return _os_object_xref_dispose((_os_object_t)voucher);
 #else


### PR DESCRIPTION
*Fix misspellings*
There were minor typos on a couple comments.

*Remove ns abbreviation for nanoseconds*
The time parameters are clearly described as being in nanoseconds.

*Unify over-release spelling*
We were using "overrelease" and "over-release". I changed everything to the later.