### PR TITLE
enable subdir-objects for automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ AS_IF([test "x$enable_apple_tsd_optimizations" = "xyes"],
 )
 
 AC_USE_SYSTEM_EXTENSIONS
-AM_INIT_AUTOMAKE([foreign no-dependencies])
+AM_INIT_AUTOMAKE([foreign no-dependencies subdir-objects])
 LT_INIT([disable-static])
 
 AC_PROG_INSTALL


### PR DESCRIPTION
Enable subdir-objects to silence warning caused by the addition
of linux_stubs.c to src/shims.  This seems like the most contained
fix to allow a .c file in the shims subdir without warnings.