### PR TITLE
Add AC_SEARCH_LIBS stanzas for kqueue and pthread_workqueue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,7 @@ AC_SEARCH_LIBS(pthread_create, pthread)
 AC_CHECK_HEADER(sys/event.h, [],
   [PKG_CHECK_MODULES(KQUEUE, libkqueue)]
 )
+AC_SEARCH_LIBS(kevent, kqueue)
 
 #
 # Checks for header files.
@@ -157,7 +158,8 @@ AS_IF([test -n "$apple_libpthread_source_path" -a -n "$apple_xnu_source_osfmk_pa
 ])
 AC_CHECK_HEADERS([pthread_machdep.h pthread/qos.h])
 AC_CHECK_HEADERS([pthread/workqueue_private.h pthread_workqueue.h],
-  [AC_DEFINE(HAVE_PTHREAD_WORKQUEUES, 1, [Define if pthread work queues are present])]
+  [AC_DEFINE(HAVE_PTHREAD_WORKQUEUES, 1, [Define if pthread work queues are present])
+   AC_SEARCH_LIBS(pthread_workqueue_create_np, pthread_workqueue)]
 )
 AC_CHECK_HEADERS([libproc_internal.h], [], [], [#include <mach/mach.h>])
 AC_CHECK_FUNCS([pthread_workqueue_setdispatch_np _pthread_workqueue_init])


### PR DESCRIPTION
If libdispatch is using functions found in libkqueue or
libpthread_workqueue, then we want libdispatch.so to
depend on those libraries. Putting in AC_SEARCH_LIBS
stanzas results in the proper linker flags being added when
libdispatch.so is built. Therefore the application compilation
command can simply say -ldispatch and not need to explicitly
mention -lkqueue and -lpthread_workqueue.