### PR TITLE
Propagate linker flags for kqueue and pthread_workqueue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,8 +157,11 @@ AS_IF([test -n "$apple_libpthread_source_path" -a -n "$apple_xnu_source_osfmk_pa
 ])
 AC_CHECK_HEADERS([pthread_machdep.h pthread/qos.h])
 AC_CHECK_HEADERS([pthread/workqueue_private.h pthread_workqueue.h],
-  [AC_DEFINE(HAVE_PTHREAD_WORKQUEUES, 1, [Define if pthread work queues are present])]
+  [AC_DEFINE(HAVE_PTHREAD_WORKQUEUES, 1, [Define if pthread work queues are present])
+   have_pthread_workqueues=true],
+  [have_pthread_workqueues=false]
 )
+AM_CONDITIONAL(HAVE_PTHREAD_WORKQUEUES, $have_pthread_workqueues)
 AC_CHECK_HEADERS([libproc_internal.h], [], [], [#include <mach/mach.h>])
 AC_CHECK_FUNCS([pthread_workqueue_setdispatch_np _pthread_workqueue_init])
 AS_IF([test -n "$apple_libpthread_source_path" -a -n "$apple_xnu_source_osfmk_path"], [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,6 +57,11 @@ AM_CXXFLAGS=$(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
 AM_OBJCXXFLAGS=$(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
 
 libdispatch_la_LDFLAGS=-avoid-version
+libdispatch_la_LIBADD=$(KQUEUE_LIBS) $(PTHREAD_WORKQUEUE_LIBS)
+
+if HAVE_PTHREAD_WORKQUEUES
+PTHREAD_WORKQUEUE_LIBS=-lpthread_workqueue
+endif
 
 if HAVE_DARWIN_LD
 libdispatch_la_LDFLAGS+=-Wl,-compatibility_version,1 \


### PR DESCRIPTION
If libdispatch is using functions found in libkqueue or
libpthread_workqueue, then we want libdispatch.so to
depend on those libraries so we don't have to specify
them explictly in the application linking command.
This change does that by adding KQUEUE_LIBS and
PTHREAD_WORKQUEUE_LIBS to the linking command for libdispatch.la
and exposing HAVE_PTHREAD_WORKQUEUE as a variable to automake.