### PR TITLE
Port most of libdispatch tests to Linux (31 compile; 21 pass).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,8 +115,11 @@ AS_IF([test "x$DTRACE" != "x"], [use_dtrace=true],[
 AM_CONDITIONAL(USE_DTRACE, $use_dtrace)
 AC_PATH_PROG(LEAKS, leaks)
 AS_IF([test "x$LEAKS" != "x"],
-  [AC_DEFINE(HAVE_LEAKS, 1, [Define if Apple leaks program is present])]
+  [AC_DEFINE(HAVE_LEAKS, 1, [Define if Apple leaks program is present])
+   have_leaks=true],
+  [have_leaks=false]
 )
+AM_CONDITIONAL(HAVE_LEAKS, $have_leaks)
 
 DISPATCH_C_ATOMIC_BUILTINS
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,13 +19,55 @@ check_PROGRAMS=					\
 
 noinst_SCRIPTS=leaks-wrapper.sh
 
-TESTS=							\
+UNPORTED_TESTS=					\
+	dispatch_deadname			\
+	dispatch_proc				\
+	dispatch_vm				\
+	dispatch_vnode				\
+	dispatch_select
+
+PORTED_TESTS_FAILED=				\
+	dispatch_group				\
+	dispatch_priority			\
+	dispatch_priority2			\
+	dispatch_concur				\
+	dispatch_context_for_key		\
+	dispatch_read				\
+	dispatch_read2				\
+	dispatch_readsync			\
+	dispatch_io				\
+	dispatch_io_net				
+
+PORTED_TESTS_PASSED=				\
+	dispatch_apply				\
+	dispatch_api				\
+	dispatch_c99				\
+	dispatch_debug				\
+	dispatch_queue_finalizer	\
+	dispatch_overcommit			\
+	dispatch_pingpong			\
+	dispatch_plusplus			\
+	dispatch_after				\
+	dispatch_timer				\
+	dispatch_timer_short			\
+	dispatch_timer_timeout			\
+	dispatch_sema				\
+	dispatch_suspend_timer			\
+	dispatch_timer_bit31			\
+	dispatch_timer_bit63			\
+	dispatch_timer_set_time			\
+	dispatch_starfish			\
+	dispatch_cascade			\
+	dispatch_drift				\
+	dispatch_data
+
+ORIGINAL_LIST_OF_TESTS=				\
 	dispatch_apply				\
 	dispatch_api				\
 	dispatch_c99				\
 	dispatch_deadname			\
 	dispatch_debug				\
-	dispatch_queue_finalizer	\
+	dispatch_queue_finalizer		\
 	dispatch_group				\
 	dispatch_overcommit			\
 	dispatch_pingpong			\
@@ -57,6 +99,8 @@ TESTS=							\
 	dispatch_vnode				\
 	dispatch_select
 
+TESTS=$(PORTED_TESTS_PASSED) $(PORTED_TESTS_FAILED)
+
 dispatch_c99_CFLAGS=$(AM_CFLAGS) -std=c99
 dispatch_plusplus_SOURCES=dispatch_plusplus.cpp
 dispatch_priority2_SOURCES=dispatch_priority.c
@@ -65,15 +109,27 @@ dispatch_priority2_CPPFLAGS=$(AM_CPPFLAGS) -DUSE_SET_TARGET_QUEUE=1
 AM_CPPFLAGS=-I$(top_builddir) -I$(top_srcdir)
 
 DISPATCH_TESTS_CFLAGS=-Wall -Wno-deprecated-declarations $(MARCH_FLAGS)
-AM_CFLAGS=$(DISPATCH_TESTS_CFLAGS) $(CBLOCKS_FLAGS)
+AM_CFLAGS=$(DISPATCH_TESTS_CFLAGS) $(CBLOCKS_FLAGS) $(KQUEUE_CFLAGS)
 AM_OBJCFLAGS=$(DISPATCH_TESTS_CFLAGS) $(CBLOCKS_FLAGS)
 AM_CXXFLAGS=$(DISPATCH_TESTS_CFLAGS) $(CXXBLOCKS_FLAGS)
 AM_OBJCXXFLAGS=$(DISPATCH_TESTS_CFLAGS) $(CXXBLOCKS_FLAGS)
 
-LDADD=libbsdtests.la ../src/libdispatch.la
+if HAVE_PTHREAD_WORKQUEUES
+PTHREAD_WORKQUEUE_LIBS=-lpthread_workqueue
+endif
+
+LDADD=libbsdtests.la ../src/libdispatch.la $(KQUEUE_LIBS) $(PTHREAD_WORKQUEUE_LIBS) $(BSD_OVERLAY_LIBS)
 libbsdtests_la_LDFLAGS=-avoid-version
 
+bsdtestsummarize_LDADD=-lm
+dispatch_timer_short_LDADD=-lm $(LDADD)
+dispatch_group_LDADD=-lm $(LDADD)
+
+if HAVE_LEAKS
 TESTS_ENVIRONMENT=./bsdtestharness
+else
+TESTS_ENVIRONMENT=NOLEAKS=1 ./bsdtestharness
+endif
 DISTCLEAN=Foundation/bench.cc
 
 if HAVE_COREFOUNDATION
@@ -82,6 +138,7 @@ TESTS+=							\
 	dispatch_transform			\
 	dispatch_sync_on_main		\
 	cffd
+AM_CFLAGS+=-DHAVE_COREFOUNDATION
 
 dispatch_cf_main_LDFLAGS=-framework CoreFoundation
 dispatch_transform_LDFLAGS=-framework CoreFoundation -framework Security
@@ -95,6 +152,7 @@ TESTS+=							\
 	dispatch_apply_gc			\
 	nsoperation					\
 	bench
+AM_CFLAGS+=-DHAVE_FOUNDATION
 
 dispatch_sync_gc_SOURCES=Foundation/dispatch_sync_gc.m
 dispatch_sync_gc_LDFLAGS=-framework Foundation

--- a/tests/bsdtests.h
+++ b/tests/bsdtests.h
@@ -22,8 +22,17 @@
 #define __BSD_TEST_H__
 
 #include <errno.h>
+#ifdef __APPLE__
 #include <mach/error.h>
+#endif
+#if defined(__APPLE__) || defined(HAVE_COREFOUNDATION)
 #include <CoreFoundation/CoreFoundation.h>
+#endif
+
+#ifdef __linux__
+#define __printflike(a,b) __attribute__((format(printf, a, b)))
+#include <inttypes.h>
+#endif
 
 static inline const char*
 __BASENAME__(const char *_str_)
@@ -121,12 +130,16 @@ void _test_errno(const char* file, long line, const char* desc, long actual, lon
 #define test_errno(a,b,c) _test_errno(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_errno_format(long actual, long expected, const char *format, ...) __printflike(3,4);
 
+#ifndef __linux__
 void _test_mach_error(const char* file, long line, const char* desc, mach_error_t actual, mach_error_t expected);
 #define test_mach_error(a,b,c) _test_mach_error(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_mach_error_format(mach_error_t actual, mach_error_t expected, const char *format, ...) __printflike(3,4);
+#endif
 
+#if defined(__APPLE__) || defined(HAVE_COREFOUNDATION)
 void test_cferror(const char* desc, CFErrorRef actual, CFIndex expectedCode);
 void test_cferror_format(CFErrorRef actual, CFIndex expectedCode, const char *format, ...) __printflike(3,4);
+#endif
 
 void _test_skip(const char* file, long line, const char* desc);
 #define test_skip(m) _test_skip(__SOURCE_FILE__, __LINE__, m)

--- a/tests/bsdtestsummarize.c
+++ b/tests/bsdtestsummarize.c
@@ -24,6 +24,20 @@
 #include <string.h>
 #include <sys/param.h>
 
+#ifndef __APPLE__
+static char*
+fgetln(FILE *stream, size_t *len)
+{
+	static char buf[1024];
+	char *cp = fgets(buf,1024,stream);
+	if (cp)
+		*len = strlen(cp);
+	else
+		*len = 0;
+	return cp;
+}
+#endif
+
 int
 has_prefix(const char* str, const char* prefix)
 {

--- a/tests/dispatch_after.c
+++ b/tests/dispatch_after.c
@@ -23,7 +23,9 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
+#endif
 
 #include <bsdtests.h>
 #include <Block.h>
@@ -31,7 +33,7 @@
 #include "dispatch_test.h"
 
 void
-done(void *arg __unused)
+done(void *arg /*__unused */)
 {
 	sleep(1);
 	test_stop();

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -23,7 +23,9 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
+#endif
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
@@ -74,8 +76,12 @@ void busythread(void *ignored)
 void test_apply_contended(dispatch_queue_t dq)
 {
 	uint32_t activecpu;
+#ifdef __linux__
+	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
+#else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
+#endif
 	int tIndex, n_threads = activecpu;
 	dispatch_group_t grp = dispatch_group_create();
 

--- a/tests/dispatch_cf_main.c
+++ b/tests/dispatch_cf_main.c
@@ -21,7 +21,9 @@
 #include <dispatch/dispatch.h>
 #include <stdio.h>
 #include <CoreFoundation/CoreFoundation.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
+#endif
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -202,8 +202,12 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	dispatch_test_start("Dispatch Private Concurrent/Wide Queue"); // <rdar://problem/8049506&8169448&8186485>
 
 	uint32_t activecpu;
+#ifdef __linux__
+	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
+#else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
+#endif
 	size_t n = activecpu / 2 > 1 ? activecpu / 2 : 1, w = activecpu * 2;
 	dispatch_queue_t tq, ttq;
 	long qw, tqw, ttqw;

--- a/tests/dispatch_data.c
+++ b/tests/dispatch_data.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 
 #include <dispatch/dispatch.h>
+#ifdef __APPLE__
 #include <TargetConditionals.h>
+#endif
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_deadname.c
+++ b/tests/dispatch_deadname.c
@@ -20,7 +20,9 @@
 
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
+#ifdef __APPLE__
 #include <mach/mach.h>
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/tests/dispatch_drift.c
+++ b/tests/dispatch_drift.c
@@ -18,13 +18,17 @@
  * @APPLE_APACHE_LICENSE_HEADER_END@
  */
 
+#ifdef __APPLE__
 #include <mach/mach_time.h>
+#endif
 #include <dispatch/dispatch.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef __APPLE__
 #include <TargetConditionals.h>
+#endif
 #include <bsdtests.h>
 #include "dispatch_test.h"
 

--- a/tests/dispatch_group.c
+++ b/tests/dispatch_group.c
@@ -24,8 +24,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
-
+#endif
+#include <math.h>
 #include <bsdtests.h>
 #include "dispatch_test.h"
 

--- a/tests/dispatch_overcommit.c
+++ b/tests/dispatch_overcommit.c
@@ -24,7 +24,9 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
+#endif
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_plusplus.cpp
+++ b/tests/dispatch_plusplus.cpp
@@ -20,6 +20,7 @@
 
 #include <dispatch/dispatch.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -24,7 +24,9 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef __APPLE__
 #include <TargetConditionals.h>
+#endif
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
@@ -75,9 +77,13 @@ n_blocks(void)
 	static dispatch_once_t pred;
 	static int n;
 	dispatch_once(&pred, ^{
+#ifdef __linux__
+		n = sysconf(_SC_NPROCESSORS_CONF);
+#else
 		size_t l = sizeof(n);
 		int rc = sysctlbyname("hw.ncpu", &n, &l, NULL, 0);
 		assert(rc == 0);
+#endif
 		n *= 32;
 	});
 	return n;

--- a/tests/dispatch_proc.c
+++ b/tests/dispatch_proc.c
@@ -25,7 +25,9 @@
 #include <assert.h>
 #include <spawn.h>
 #include <signal.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
+#endif
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -28,10 +28,12 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fts.h>
+#ifdef __APPLE__
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #include <libkern/OSAtomic.h>
 #include <TargetConditionals.h>
+#endif
 #include <Block.h>
 
 #include <dispatch/dispatch.h>
@@ -122,10 +124,15 @@ test_read(void)
 		test_errno("open", errno, 0);
 		test_stop();
 	}
+#ifdef F_NOCACHE
 	if (fcntl(fd, F_NOCACHE, 1)) {
 		test_errno("fcntl F_NOCACHE", errno, 0);
 		test_stop();
 	}
+#else
+	// investigate what the impact of lack of file cache disabling has 
+	// for this test
+#endif
 	struct stat sb;
 	if (fstat(fd, &sb)) {
 		test_errno("fstat", errno, 0);

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -133,10 +133,15 @@ main(void)
 	dispatch_test_start("Dispatch Reader/Writer Queues");
 
 	uint32_t activecpu, wq_max_threads;
+#ifdef __linux__
+	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
+	wq_max_threads = sysconf(_SC_NPROCESSORS_CONF); // LINUX_PORT_HDD FIXME: Is this correct?
+#else
 	size_t s = sizeof(uint32_t);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
 	s = sizeof(uint32_t);
 	sysctlbyname("kern.wq_max_threads", &wq_max_threads, &s, NULL, 0);
+#endif
 
 	// cap at wq_max_threads - one wq thread for dq - one wq thread for manager
 	size_t n = MIN(activecpu * NTHREADS, wq_max_threads - 2);

--- a/tests/dispatch_starfish.c
+++ b/tests/dispatch_starfish.c
@@ -18,13 +18,18 @@
  * @APPLE_APACHE_LICENSE_HEADER_END@
  */
 
+
+#ifdef __APPLE__
 #include <mach/mach.h>
 #include <mach/mach_time.h>
+#endif
 #include <dispatch/dispatch.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef __APPLE__
 #include <TargetConditionals.h>
+#endif
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_test.h
+++ b/tests/dispatch_test.h
@@ -22,6 +22,10 @@
 #include <stdbool.h>
 #include <dispatch/dispatch.h>
 
+#ifdef __linux__
+#include <linux_port.h>
+#endif
+
 #define test_group_wait(g) do { \
 	if (dispatch_group_wait(g, dispatch_time(DISPATCH_TIME_NOW, \
 			25ull * NSEC_PER_SEC))) { \
@@ -37,5 +41,10 @@ bool dispatch_test_check_evfilt_read_for_fd(int fd);
 
 void _dispatch_test_current(const char* file, long line, const char* desc, dispatch_queue_t expected);
 #define dispatch_test_current(a,b) _dispatch_test_current(__SOURCE_FILE__, __LINE__, a, b)
+
+#ifndef __linux__
+int sysctlbyname(const char *name, void *oldp, size_t *oldlenp, void *newp,
+		size_t *newpl);
+#endif
 
 __END_DECLS

--- a/tests/dispatch_timer_short.c
+++ b/tests/dispatch_timer_short.c
@@ -23,8 +23,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#ifdef __APPLE__
 #include <mach/mach_time.h>
 #include <libkern/OSAtomic.h>
+#endif
 
 #include <dispatch/dispatch.h>
 

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -22,7 +22,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifdef __APPLE__
 #include <libkern/OSAtomic.h>
+#endif
 #include <assert.h>
 #include <sys/sysctl.h>
 #include <stdarg.h>
@@ -111,9 +113,13 @@ main(void)
 	}
 	initial = time(NULL);
 	uint64_t memsize;
+#ifdef __linux__
+	memsize = sysconf(_SC_PAGESIZE) * sysconf(_SC_PHYS_PAGES);
+#else
 	size_t s = sizeof(memsize);
 	int rc = sysctlbyname("hw.memsize", &memsize, &s, NULL, 0);
 	assert(rc == 0);
+#endif
 	max_page_count = MIN(memsize, MAXMEM) / ALLOC_SIZE;
 	pages = calloc(max_page_count, sizeof(char*));
 

--- a/tests/linux_port.h
+++ b/tests/linux_port.h
@@ -4,19 +4,19 @@
 static inline int32_t
 OSAtomicIncrement32(volatile int32_t *var)
 {
-    return __sync_add_and_fetch(var,1);
+  return __c11_atomic_fetch_add((_Atomic(int)*)var, 1, __ATOMIC_RELAXED)+1;
 }
 
 static inline int32_t
 OSAtomicIncrement32Barrier(volatile int32_t *var)
 {
-    return __sync_add_and_fetch(var,1);
+    return __c11_atomic_fetch_add((_Atomic(int)*)var, 1, __ATOMIC_SEQ_CST)+1;
 }
 
 static inline int32_t
 OSAtomicAdd32(volatile int32_t *var, int32_t val)
 {
-    return __sync_add_and_fetch(var,val);
+    return __c11_atomic_fetch_add((_Atomic(int)*)var, val, __ATOMIC_RELAXED)+val;
 }
 
 // Simulation of mach_absolute_time related infrastructure

--- a/tests/linux_port.h
+++ b/tests/linux_port.h
@@ -1,0 +1,54 @@
+#include <limits.h>
+#include <sys/param.h>
+
+static inline int32_t
+OSAtomicIncrement32(volatile int32_t *var)
+{
+    return __sync_add_and_fetch(var,1);
+}
+
+static inline int32_t
+OSAtomicIncrement32Barrier(volatile int32_t *var)
+{
+    return __sync_add_and_fetch(var,1);
+}
+
+static inline int32_t
+OSAtomicAdd32(volatile int32_t *var, int32_t val)
+{
+    return __sync_add_and_fetch(var,val);
+}
+
+// Simulation of mach_absolute_time related infrastructure
+// For now, use gettimeofday.
+// Consider using clockgettime(CLOCK_MONOTONIC) instead.
+
+#include <sys/time.h>
+
+struct mach_timebase_info {
+  uint32_t numer;
+  uint32_t denom;
+};
+
+typedef struct mach_timebase_info *mach_timebase_info_t;
+typedef struct mach_timebase_info mach_timebase_info_data_t;
+
+typedef int kern_return_t;
+
+static inline
+uint64_t
+mach_absolute_time()
+{
+	struct timeval tv;
+	gettimeofday(&tv,NULL);
+	return (1000ull)*((unsigned long long)tv.tv_sec*(1000000ull)+ tv.tv_usec);
+}
+
+static inline
+int
+mach_timebase_info(mach_timebase_info_t tbi)
+{
+	tbi->numer = 1;
+	tbi->denom = 1;
+	return 0;
+}


### PR DESCRIPTION
Made an initial sweep through the test suite to resolve
the easy compilation issues.

Summary of changes:
 (a) Guard mach specific code with #ifdef __APPLE__
 (b) Changes to tests/Makefile.am to preserve
     information from configure to guide test selection,
     compilation, and execution.
 (c) Map sysctlbyname calls to sysconf
 (d) Simulate mach_absolute_time APIs
 (e) Guard code using F_NOCACHE and F_GLOBAL_NOCACHE
 (f) On Linux, simplify bsdtestharness.c to not use
     libdispatch to execute the test cases (some of the
     needed libdispatch functionality is not yet working).

To track progress, we broke the TESTS list in tests/Makefile.am
into UNPORTED_TESTS, PORTED_TESTS_FAILED, PORTED_TESTS_PASSED.
TESTS is defined as the union of PORTED_TESTS_PASSED and
PORTED_TESTS_FAILED.
If the automake testing harness is only being used on Linux,
it would be nice to merge this change back to coordinate progress.
If you use this test harness on OS X too, we can do something
different like tracking progress in a side file instead.