### PR TITLE
sem_timedwait on Linux needs epoch-based timeout

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -528,6 +528,7 @@ void _dispatch_vtable_init(void);
 char *_dispatch_get_build(void);
 
 uint64_t _dispatch_timeout(dispatch_time_t when);
+uint64_t _dispatch_time_to_epoch_time(dispatch_time_t when);
 
 extern bool _dispatch_safe_fork, _dispatch_child_of_unsafe_fork;
 

--- a/src/time.c
+++ b/src/time.c
@@ -145,3 +145,19 @@ _dispatch_timeout(dispatch_time_t when)
 	now = _dispatch_absolute_time();
 	return now >= when ? 0 : _dispatch_time_mach2nano(when - now);
 }
+
+uint64_t
+_dispatch_time_to_epoch_time(dispatch_time_t when)
+{
+	if (when == DISPATCH_TIME_FOREVER) {
+		return DISPATCH_TIME_FOREVER;
+	}
+	if (when == 0) {
+		return 0;
+	}
+	if ((int64_t)when < 0) {
+		// time in nanoseconds since the POSIX epoch already
+		return -(int64_t)when;
+	}
+	return _dispatch_get_nanoseconds() + _dispatch_timeout(when);
+}


### PR DESCRIPTION
sem_timedwait expects a timeout argument based on epoch time;
the code was converting from dispatch_time to a relative timeout,
but failing to further convert that relative time to an
epoch-based absolute time before calling sem_timedwait.

This fix localizes the change, but is not very efficient.
Arguably it would be better to compute a conversion from
dispatch_time to epoch time during initialization and simply
apply that instead of recomputing it every time we need it.