### PR TITLE
posix sem_timedwait requires epoch-based timeout

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -528,6 +528,7 @@ void _dispatch_vtable_init(void);
 char *_dispatch_get_build(void);
 
 uint64_t _dispatch_timeout(dispatch_time_t when);
+uint64_t _dispatch_time_to_nanoseconds(dispatch_time_t when);
 
 extern bool _dispatch_safe_fork, _dispatch_child_of_unsafe_fork;
 

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -342,7 +342,7 @@ again:
 		}
 #elif USE_POSIX_SEM
 		do {
-			uint64_t nsec = _dispatch_timeout(timeout);
+			uint64_t nsec = _dispatch_time_to_nanoseconds(timeout);
 			_timeout.tv_sec = (typeof(_timeout.tv_sec))(nsec / NSEC_PER_SEC);
 			_timeout.tv_nsec = (typeof(_timeout.tv_nsec))(nsec % NSEC_PER_SEC);
 			ret = slowpath(sem_timedwait(&dsema->dsema_sem, &_timeout));
@@ -582,7 +582,7 @@ again:
 		}
 #elif USE_POSIX_SEM
 		do {
-			uint64_t nsec = _dispatch_timeout(timeout);
+			uint64_t nsec = _dispatch_time_to_nanoseconds(timeout);
 			_timeout.tv_sec = (typeof(_timeout.tv_sec))(nsec / NSEC_PER_SEC);
 			_timeout.tv_nsec = (typeof(_timeout.tv_nsec))(nsec % NSEC_PER_SEC);
 			ret = slowpath(sem_timedwait(&dsema->dsema_sem, &_timeout));

--- a/src/time.c
+++ b/src/time.c
@@ -145,3 +145,16 @@ _dispatch_timeout(dispatch_time_t when)
 	now = _dispatch_absolute_time();
 	return now >= when ? 0 : _dispatch_time_mach2nano(when - now);
 }
+
+uint64_t
+_dispatch_time_to_nanoseconds(dispatch_time_t when)
+{
+	if (when == DISPATCH_TIME_FOREVER) {
+		return DISPATCH_TIME_FOREVER;
+	}
+	if ((int64_t)when < 0) {
+		// time in nanoseconds since the POSIX epoch already
+		return -(int64_t)when;
+	}
+	return _dispatch_get_nanoseconds() + _dispatch_timeout(when);
+}


### PR DESCRIPTION
add _dispatch_time_to_nanoseconds helper function to
encapsulate the conversion and use it in the two
places in semaphore.c where sem_timedwait is called.

fix enables dispatch_group test to pass