### PR TITLE
Add clean failure for EVFILT_PROC usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,8 +139,31 @@ AC_SEARCH_LIBS(pthread_create, pthread)
 #
 # Prefer native kqueue(2); otherwise use libkqueue if present.
 #
-AC_CHECK_HEADER(sys/event.h, [],
+AC_CHECK_HEADER(kqueue/sys/event.h,
+  [kqueue_include="#include <kqueue/sys/event.h>"
+   kqueue_lib="-lkqueue"]
+)
+
+AC_CHECK_HEADER(sys/event.h,
+  [kqueue_include="#include <sys/event.h>"],
   [PKG_CHECK_MODULES(KQUEUE, libkqueue)]
+)
+
+AC_SUBST([LIBS],["${LIBS} $kqueue_lib"])
+AC_RUN_IFELSE(
+        [AC_LANG_PROGRAM([
+                $kqueue_include
+                #include <stdlib.h>], [
+                int kq, i;
+                struct kevent ke;
+                kq = kqueue();
+                if (kq == -1) return(1);
+                EV_SET(&ke, 1, EVFILT_PROC, EV_ADD, NOTE_EXIT | NOTE_FORK | NOTE_EXEC, 0, NULL);
+                i = kevent(kq, &ke, 1, NULL, 0, NULL);
+                if (i == -1) return(1);
+                return(0);])],
+        [AC_DEFINE(HAVE_EVFILT_PROC, 1, [Define if EVFILT_PROC available])],
+        [AC_DEFINE(HAVE_EVFILT_PROC, 0, [Define if EVFILT_PROC available])]
 )
 
 AC_CHECK_FUNCS([strlcpy getprogname], [],

--- a/src/source.c
+++ b/src/source.c
@@ -106,6 +106,13 @@ dispatch_source_create(dispatch_source_type_t type,
 	}
 
 	switch (type->ke.filter) {
+#if !HAVE_EVFILT_PROC
+	// return null if not supported
+	case EVFILT_PROC:
+		return NULL;
+		break;
+#endif
+
 	case EVFILT_SIGNAL:
 		if (handle >= NSIG) {
 			return NULL;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,12 +21,12 @@ noinst_SCRIPTS=leaks-wrapper.sh
 
 UNPORTED_TESTS=					\
 	dispatch_deadname			\
-	dispatch_proc				\
 	dispatch_vm				\
 	dispatch_vnode				\
 	dispatch_select
 
 PORTED_TESTS_FAILED=				\
+	dispatch_proc				\
 	dispatch_group				\
 	dispatch_priority			\
 	dispatch_priority2			\

--- a/tests/dispatch_proc.c
+++ b/tests/dispatch_proc.c
@@ -50,8 +50,12 @@ test_proc(pid_t bad_pid)
 	posix_spawnattr_t attr;
 	res = posix_spawnattr_init(&attr);
 	assert(res == 0);
-	res = posix_spawnattr_setflags(&attr, POSIX_SPAWN_START_SUSPENDED);
-	assert(res == 0);
+
+#if HAVE_POSIX_SPAWN_START_SUSPENDED
+    short spawnflags = POSIX_SPAWN_START_SUSPENDED;
+    res = posix_spawnattr_setflags(&attr, spawnflags);
+    assert(res == 0);
+#endif
 
 	char* args[] = {
 		"/bin/sleep", "2", NULL


### PR DESCRIPTION
The pull request does a couple of things:
1. Enables the `dispatch_proc` test by resolving the compile issue around the usage of `POSIX_SPAWN_START_SUSPENDED` by wrapping it in a `#if` preprocessor
2. Modifies `source.c` to return `NULL` for calls to `dispatch_source_create()` with `DISPATCH_SOURCE_TYPE_PROC` if the underlying usage of `EVFILT_PROC` isn't supported by the `kqueue` implementation available.
The second part is implemented in autoconf by using `AC_RUN_PROGRAM`. 

I looked at whether the `ENOSYS` reported by `kevent64()` could be percolated up to `dispatch_source_create()` at runtime, but I couldn't seen an elegant way to so so. 

Additionally, `EVFILT_PROC` is correctly defined in `queue\sys\event.h` even though its usage is not supported, so it wasn't possible to do a simple definition check.

Let me know what you think, and if you have any suggestions for alternative approaches.