### PR TITLE
Switch to using /dev/urandom as file source

### DIFF
--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -179,7 +179,7 @@ test_read(void)
 static void
 test_read_write(void)
 {
-	const char *path_in = "/dev/random";
+	const char *path_in = "/dev/urandom";
 	char path_out[] = "/tmp/dispatchtest_io.XXXXXX";
 	const size_t siz_in = 10240;
 
@@ -246,7 +246,7 @@ test_read_write(void)
 static void
 test_read_writes(void) // <rdar://problem/7785143>
 {
-	const char *path_in = "/dev/random";
+	const char *path_in = "/dev/urandom";
 	char path_out[] = "/tmp/dispatchtest_io.XXXXXX";
 	const size_t chunks_out = 320;
 	const size_t siz_chunk = 32, siz_in = siz_chunk * chunks_out;
@@ -333,7 +333,7 @@ test_read_writes(void) // <rdar://problem/7785143>
 static void
 test_writes_reads_eagain(void) // rdar://problem/8333366
 {
-	int in = open("/dev/random", O_RDONLY);
+	int in = open("/dev/urandom", O_RDONLY);
 	if (in == -1) {
 		test_errno("open", errno, 0);
 		test_stop();


### PR DESCRIPTION
The dispatch_read2 tests currently fail in two places due to the use of /dev/random as the source file. The issue in both cases is that the source file descriptor does not supply enough bytes of data to satisfy the read request from the test case.

On Darwin, /dev/random is the same as /dev/urandom, which provides a continuous stream of (pseudo)random data. On Linux, /dev/random provides limited data before blocking until more entropy is available.

Moving to /dev/urandom provides equivalent function on both Linux and Darwin and is the same as the existing use of /dev/random on Darwin. 