### PR TITLE
Fix prototype for OSAtomicAdd32

### DIFF
--- a/tests/linux_port.h
+++ b/tests/linux_port.h
@@ -14,7 +14,7 @@ OSAtomicIncrement32Barrier(volatile int32_t *var)
 }
 
 static inline int32_t
-OSAtomicAdd32(volatile int32_t *var, int32_t val)
+OSAtomicAdd32(int32_t val, volatile int32_t *var)
 {
     return __c11_atomic_fetch_add((_Atomic(int)*)var, val, __ATOMIC_RELAXED)+val;
 }


### PR DESCRIPTION
The prototype for OSAtomicAdd32 is defined as:
```c
int32_t
     OSAtomicAdd32(int32_t theAmount, volatile int32_t *theValue);
```
however the implementation in `linux_port.h` has the arguments inverted.

Correcting it doesn't cause any new tests to fail, but it required for fixing the dispatch_io tests (which I'm currently working on).