### PR TITLE
Fix up dispatch_io tests

### DIFF
--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -393,15 +393,11 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 			break;
 		case DISPATCH_IO_READ_ON_CONCURRENT_QUEUE:
 		case DISPATCH_IO_READ_FROM_PATH_ON_CONCURRENT_QUEUE: {
-			__block bool is_done = false;
 			__block dispatch_data_t d = dispatch_data_empty;
 			void (^cleanup_handler)(int error) = ^(int error) {
 				if (error) {
 					test_errno("dispatch_io_create error", error, 0);
 					test_stop();
-				}
-				if (!is_done) {
-					test_long("dispatch_io_read done", is_done, true);
 				}
 				close(fd);
 				process_data(dispatch_data_get_size(d));
@@ -443,7 +439,6 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 						test_stop();
 					}
 				}
-				is_done = done;
 			});
 			dispatch_release(io);
 			break;

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -351,6 +351,11 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 {
 	int fd = open(path, O_RDONLY);
 	if (fd == -1) {
+			// Don't stop for access permission issues
+			if (errno == EACCES) {
+				process_data(size);
+				return;
+			}
 		test_errno("Failed to open file", errno, 0);
 		test_stop();
 	}

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -240,13 +240,19 @@ test_io_read_write(void)
 {
 	const char *path_in = "/usr/share/dict/words";
 	char path_out[] = "/tmp/dispatchtest_io.XXXXXX";
-	const size_t siz_in = 1024 * 1024;
 
 	int in = open(path_in, O_RDONLY);
 	if (in == -1) {
 		test_errno("open", errno, 0);
 		test_stop();
 	}
+    struct stat sb;
+    if (fstat(in, &sb)) {
+            test_errno("fstat", errno, 0);
+            test_stop();
+    }
+    const size_t siz_in = MIN(1024 * 1024, sb.st_size);
+
 	int out = mkstemp(path_out);
 	if (out == -1) {
 		test_errno("mkstemp", errno, 0);

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -635,7 +635,7 @@ test_io_from_io(void) // rdar://problem/8388909
                 test_stop();
         }
 #endif
-	const char *path_in = "/dev/random";
+	const char *path_in = "/dev/urandom";
 	int in = open(path_in, O_RDONLY);
 	if (in == -1) {
 		test_errno("open", errno, 0);


### PR DESCRIPTION
This PR fixes up the dispatch_io tests so that that pass. I've submitted this as a collection of commits as each fixes a different area. If you rather I squashed them, let me know.

* Add equivalent to immutable write test for Linux
There's currently a test that sets a directory as immutable, then runs a write test against it and checks that the write fails and the correct amount of data is still pending to write. As immutable isn't available in Linux, I've replaced this with setting the directory as non-writeable (and retaining the use of immutable on Mac OS).

* Limit data read in to the size of the file
The IO read/write test reads in 1024 * 1024 bytes of data from `/usr/share/dict/words` however there isn't necessarily that much data available (there isn't on my Linux install), so I've switched the amount of data to be the min of 1024 * 1024 or the file size.

* Switch to using random rather than random for consistency
As for PR #24, the use of random on Linux means that we don't read in the expected level of data. Switching to random gives us the same expected behaviour on Linux and Mac OS.

* Allow for access permission issues when walking /usr/lib
The read many files test walks `/usr/lib` as its source of files, however they are not necessarily all readable. I certainly hit any issue trying to read `/usr/lib/cups/backend/serial` so this allows for EACCES to occur and ignores the file.

* Remove is_done check for concurrent reads
The concurrent async read test checks to see wether `is_done` is set (by the read callbacks) inside the cleanup handler. This presumes that the read callbacks will occur before close down happens, but there doesn't look to be a reason for that assumption - its not documented, and you aren't expected to clean up anything that the read callback requires. I've removed the `is_done` check because it doesn't appear to be valid. 