### PR TITLE
Initialise dispatch_queue_attr_concurrent on Linux

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -260,6 +260,13 @@ const struct dispatch_queue_attr_s _dispatch_queue_attrs[]
 	DISPATCH_QUEUE_ATTR_QOS_INITIALIZER(USER_INTERACTIVE),
 };
 
+// _dispatch_queue_attr_concurrent is aliased using libdispatch.aliases
+// and the -alias_list linker option on Darwin but needs to be done manually
+// for other platforms.
+#ifndef __APPLE__
+extern struct dispatch_queue_attr_s _dispatch_queue_attr_concurrent
+	__attribute__((__alias__("_dispatch_queue_attrs")));
+#endif
 
 #pragma mark -
 #pragma mark dispatch_vtables


### PR DESCRIPTION
Three of the tests are failing because the `DISPATCH_QUEUE_CONCURRENT` structure hasn't been initialised (the value for `DISPATCH_QUEUE_CONCURRENT->do_vtable` is `NULL`.

This is occurring because `DISPATCH_QUEUE_CONCURRENT` is aliased to `_dispatch_queue_attrs` in `xcodeconf/libdispatch.aliases`, but aliasing (the use of the `-alias_list` linker option) is only supported on Darwin.

Up until libdispatch-4xx, `DISPATCH_QUEUE_CONCURRENT` was initialised explicitly in init.c. Taking that approach for non-Apple platforms certainly solves the issue, but there may be a better approach to doing the equivalent of aliasing on Linux.