### PR TITLE
Bug fix in testing of return code of sem_timedwait

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -348,7 +348,7 @@ again:
 			ret = slowpath(sem_timedwait(&dsema->dsema_sem, &_timeout));
 		} while (ret == -1 && errno == EINTR);
 
-		if (ret == -1 && errno != ETIMEDOUT) {
+		if (!(ret == -1 && errno == ETIMEDOUT)) {
 			DISPATCH_SEMAPHORE_VERIFY_RET(ret);
 			break;
 		}


### PR DESCRIPTION
Code was not properly handling a return code of 0 from sem_timedwait
(it would interpret it as a timeout).  Change logic of test to match
that used after the other call to sem_timedwait in this file.