### PR TITLE
autotools fixes for build/test outside src dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,6 +339,6 @@ AC_CONFIG_FILES([Makefile dispatch/Makefile man/Makefile os/Makefile private/Mak
 #
 # Generate testsuite links
 #
-AC_CONFIG_LINKS([tests/dispatch:${x:+}private tests/leaks-wrapper:tests/leaks-wrapper.sh])
+AC_CONFIG_LINKS([tests/dispatch:$top_srcdir/private tests/leaks-wrapper:tests/leaks-wrapper.sh])
 
 AC_OUTPUT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -118,7 +118,7 @@ if HAVE_PTHREAD_WORKQUEUES
 PTHREAD_WORKQUEUE_LIBS=-lpthread_workqueue
 endif
 
-LDADD=libbsdtests.la ../src/libdispatch.la $(KQUEUE_LIBS) $(PTHREAD_WORKQUEUE_LIBS) $(BSD_OVERLAY_LIBS)
+LDADD=libbsdtests.la $(top_builddir)/src/libdispatch.la $(KQUEUE_LIBS) $(PTHREAD_WORKQUEUE_LIBS) $(BSD_OVERLAY_LIBS)
 libbsdtests_la_LDFLAGS=-avoid-version
 
 bsdtestsummarize_LDADD=-lm $(BSD_OVERLAY_LIBS)


### PR DESCRIPTION
Two small fixes needed to enable build/test to happen
in an external directory (for example when building
libdispatch under the control of swift/utils/build-script).