### PR TITLE
Initial integration of Swift overlay into libdispatch build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,20 @@ AS_IF([test "x$enable_apple_tsd_optimizations" = "xyes"],
     [Define to use non-portable pthread TSD optimizations for Mac OS X)])]
 )
 
+#
+# Enable building Swift overlay support into libdispatch
+#
+AC_ARG_WITH([swift-toolchain],
+  [AS_HELP_STRING([--with-swift-toolchain], [Specify path to Swift toolchain])],
+  [swift_toolchain_path=${withval}
+   AC_DEFINE(HAVE_SWIFT, 1, [Define if building for Swift])
+   SWIFTC="$swift_toolchain_path/bin/swiftc"
+   have_swift=true],
+  [have_swift=false]
+)
+AM_CONDITIONAL(HAVE_SWIFT, $have_swift)
+AC_SUBST([SWIFTC])
+
 AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([foreign no-dependencies subdir-objects])
 LT_INIT([disable-static])

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,9 @@
 provider.h
+module.map
+module.build.map
 .libs
 *.lo
 *.la
-
+*.o
+*.swiftmodule
+*.swiftdoc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,6 +46,9 @@ libdispatch_la_SOURCES=		\
 	shims/tsd.h				\
 	shims/yield.h
 
+EXTRA_libdispatch_la_SOURCES=
+EXTRA_libdispatch_la_DEPENDENCIES=
+
 AM_CPPFLAGS=-I$(top_builddir) -I$(top_srcdir) \
 	-I$(top_srcdir)/private -I$(top_srcdir)/os
 
@@ -103,8 +106,39 @@ DTRACE_SOURCES=provider.h
 	$(DTRACE) -h -s $< -o $@
 endif
 
-BUILT_SOURCES=$(MIG_SOURCES) $(DTRACE_SOURCES)
+if HAVE_SWIFT
+libdispatch_la_SOURCES+=swift/swift_wrappers.c
+EXTRA_libdispatch_la_SOURCES+=swift/Dispatch.swift
+EXTRA_libdispatch_la_DEPENDENCIES+=$(abs_builddir)/Dispatch.o $(abs_builddir)/Dispatch.swiftmodule
+libdispatch_la_LIBADD+=$(abs_builddir)/Dispatch.o
+
+SWIFT_MODULEMAPS=$(abs_builddir)/module.map $(abs_builddir)/module.build.map
+SWIFTMODULE_OBJECTS=	\
+	$(abs_builddir)/Dispatch.swiftmodule \
+	$(abs_builddir)/Dispatch.swiftdoc \
+	$(abs_builddir)/Dispatch.o
+
+SWIFTC_FLAGS = -I$(abs_top_srcdir) -parse-as-library -Xcc -fblocks -Xcc -fmodule-map-file=module.build.map
+
+$(abs_builddir)/module.build.map:	 $(abs_srcdir)/swift/module.map.in
+	m4 -DPREFIX=$(abs_top_srcdir) $<  > $@
+
+$(abs_builddir)/module.map:	 $(abs_srcdir)/swift/module.map.in
+	m4 -DPREFIX=$(includedir) $<  > $@
+
+$(abs_builddir)/Dispatch.o: $(abs_srcdir)/swift/Dispatch.swift $(abs_builddir)/module.build.map
+	$(SWIFTC) $(SWIFTC_FLAGS) -c -o $@ $<
+
+$(abs_builddir)/Dispatch.swiftmodule: $(abs_srcdir)/swift/Dispatch.swift $(abs_builddir)/module.build.map
+	$(SWIFTC) $(SWIFTC_FLAGS) -emit-module -emit-module-path $@ $<
+
+swiftdir=$(includedir)/Dispatch
+swift_HEADERS=$(abs_builddir)/module.map $(abs_builddir)/Dispatch.swiftmodule $(abs_builddir)/Dispatch.swiftdoc
+
+endif
+
+BUILT_SOURCES=$(MIG_SOURCES) $(DTRACE_SOURCES) $(SWIFT_MODULEMAPS)
 nodist_libdispatch_la_SOURCES=$(BUILT_SOURCES)
-CLEANFILES=$(BUILT_SOURCES)
+CLEANFILES=$(BUILT_SOURCES) $(SWIFTMODULE_OBJECTS)
 DISTCLEANFILES=pthread_machdep.h pthread System mach objc
 

--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Dispatch
+
+/// The type of blocks submitted to dispatch queues, which take no arguments
+/// and have no return value.
+///
+/// The dispatch_block_t typealias is different from usual closures in that it
+/// uses @convention(block). This is to avoid unnecessary bridging between
+/// C blocks and Swift closures, which interferes with Grand Central Dispatch
+/// APIs that depend on the referential identity of a block.
+public typealias dispatch_block_t = @convention(block) () -> Void
+
+//===----------------------------------------------------------------------===//
+// Macros
+// FIXME: rdar://16851050 update API so these import better
+//===----------------------------------------------------------------------===//
+
+// dispatch/io.h
+public var DISPATCH_IO_STREAM: dispatch_io_type_t {
+  return 0
+}
+public var DISPATCH_IO_RANDOM: dispatch_io_type_t {
+  return 1
+}
+
+public var DISPATCH_IO_STOP: dispatch_io_close_flags_t {
+  return 1
+}
+public var DISPATCH_IO_STRICT_INTERVAL: dispatch_io_interval_flags_t {
+  return 1
+}
+
+public var DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t {
+  return nil
+}
+public var DISPATCH_CURRENT_QUEUE_LABEL: dispatch_queue_t {
+  return nil
+}
+public var DISPATCH_TARGET_QUEUE_DEFAULT: dispatch_queue_t {
+  return nil
+}
+public var DISPATCH_QUEUE_PRIORITY_HIGH: dispatch_queue_priority_t {
+  return 2
+}
+public var DISPATCH_QUEUE_PRIORITY_DEFAULT: dispatch_queue_priority_t {
+  return 0
+}
+public var DISPATCH_QUEUE_PRIORITY_LOW: dispatch_queue_priority_t {
+  return -2
+}
+public var DISPATCH_QUEUE_PRIORITY_BACKGROUND: dispatch_queue_priority_t {
+  return -32768
+}
+
+/*
+FIXME: LINUX_PORT:  qos_class_t not being imported
+@warn_unused_result
+public func dispatch_get_global_queue(identifier: qos_class_t,
+                                      _ flags: UInt) -> dispatch_queue_t {
+  return dispatch_get_global_queue(Int(identifier.rawValue), flags)
+}
+*/
+
+public var DISPATCH_QUEUE_CONCURRENT: dispatch_queue_attr_t {
+  return _swift_dispatch_queue_concurrent()
+}
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_queue_concurrent")
+internal func _swift_dispatch_queue_concurrent() -> dispatch_queue_attr_t
+
+// dispatch/data.h
+public var dispatch_data_empty: dispatch_data_t {
+  return _swift_dispatch_data_empty()
+}
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_data_empty")
+internal func _swift_dispatch_data_empty() -> dispatch_data_t
+
+// dispatch/source.h
+// FIXME: DISPATCH_SOURCE_TYPE_*
+public var DISPATCH_PROC_EXIT: dispatch_source_proc_flags_t {
+  return 0x80000000
+}
+public var DISPATCH_PROC_FORK: dispatch_source_proc_flags_t { return 0x40000000 }
+public var DISPATCH_PROC_EXEC: dispatch_source_proc_flags_t { return 0x20000000 }
+public var DISPATCH_PROC_SIGNAL: dispatch_source_proc_flags_t { return 0x08000000 }
+public var DISPATCH_VNODE_DELETE: dispatch_source_vnode_flags_t { return 0x1 }
+public var DISPATCH_VNODE_WRITE:  dispatch_source_vnode_flags_t { return 0x2 }
+public var DISPATCH_VNODE_EXTEND: dispatch_source_vnode_flags_t { return 0x4 }
+public var DISPATCH_VNODE_ATTRIB: dispatch_source_vnode_flags_t { return 0x8 }
+public var DISPATCH_VNODE_LINK:   dispatch_source_vnode_flags_t { return 0x10 }
+public var DISPATCH_VNODE_RENAME: dispatch_source_vnode_flags_t { return 0x20 }
+public var DISPATCH_VNODE_REVOKE: dispatch_source_vnode_flags_t { return 0x40 }
+public var DISPATCH_TIMER_STRICT: dispatch_source_timer_flags_t { return 1 }
+
+public var DISPATCH_SOURCE_TYPE_DATA_ADD: dispatch_source_type_t {
+  return _swift_dispatch_source_type_data_add()
+}
+public var DISPATCH_SOURCE_TYPE_DATA_OR: dispatch_source_type_t {
+  return _swift_dispatch_source_type_data_or()
+}
+public var DISPATCH_SOURCE_TYPE_READ: dispatch_source_type_t {
+  return _swift_dispatch_source_type_read()
+}
+public var DISPATCH_SOURCE_TYPE_PROC: dispatch_source_type_t {
+  return _swift_dispatch_source_type_proc()
+}
+public var DISPATCH_SOURCE_TYPE_SIGNAL: dispatch_source_type_t {
+  return _swift_dispatch_source_type_signal()
+}
+public var DISPATCH_SOURCE_TYPE_TIMER: dispatch_source_type_t {
+  return _swift_dispatch_source_type_timer()
+}
+public var DISPATCH_SOURCE_TYPE_VNODE: dispatch_source_type_t {
+  return _swift_dispatch_source_type_vnode()
+}
+public var DISPATCH_SOURCE_TYPE_WRITE: dispatch_source_type_t {
+  return _swift_dispatch_source_type_write()
+}
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_DATA_ADD")
+internal func _swift_dispatch_source_type_data_add() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_DATA_OR")
+internal func _swift_dispatch_source_type_data_or() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_PROC")
+internal func _swift_dispatch_source_type_proc() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_READ")
+internal func _swift_dispatch_source_type_read() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_SIGNAL")
+internal func _swift_dispatch_source_type_signal() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_TIMER")
+internal func _swift_dispatch_source_type_timer() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_VNODE")
+internal func _swift_dispatch_source_type_vnode() -> dispatch_source_type_t
+
+@warn_unused_result
+@_silgen_name("_swift_dispatch_source_type_WRITE")
+internal func _swift_dispatch_source_type_write() -> dispatch_source_type_t
+
+// dispatch/time.h
+// DISPATCH_TIME_NOW: ok
+// DISPATCH_TIME_FOREVER: ok

--- a/src/swift/module.map.in
+++ b/src/swift/module.map.in
@@ -1,0 +1,7 @@
+module Dispatch [system] {
+    umbrella header "PREFIX/dispatch/dispatch.h"
+    requires blocks
+    export *
+    link "dispatch"
+    link "BlocksRuntime"
+}

--- a/src/swift/swift_wrappers.c
+++ b/src/swift/swift_wrappers.c
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <dispatch/dispatch.h>
+
+DISPATCH_EXPORT
+dispatch_queue_attr_t 
+_swift_dispatch_queue_serial(void) {
+  return DISPATCH_QUEUE_SERIAL;
+}
+
+DISPATCH_EXPORT
+dispatch_queue_attr_t 
+_swift_dispatch_queue_concurrent(void) {
+  return DISPATCH_QUEUE_CONCURRENT;
+}
+
+DISPATCH_EXPORT
+dispatch_data_t
+_swift_dispatch_data_empty(void) {
+  return dispatch_data_empty;
+}
+
+#define SOURCE(t)                               \
+  DISPATCH_EXPORT                               \
+  dispatch_source_type_t                        \
+  _swift_dispatch_source_type_##t(void) {       \
+    return DISPATCH_SOURCE_TYPE_##t;            \
+  }
+
+SOURCE(DATA_ADD)
+SOURCE(DATA_OR)
+SOURCE(PROC)
+SOURCE(READ)
+SOURCE(SIGNAL)
+SOURCE(TIMER)
+SOURCE(VNODE)
+SOURCE(WRITE)


### PR DESCRIPTION
This commit adds a src/swift directory that contains
Dispatch.swift and Dispatch.c (based on existing files in
swift/stdlib/public/SDK/Dispatch) and a module.map.in template.
We made some initial changes to Dispatch.swift and Dispatch.c to
adapt them to Linux by dropping MACH API functions/adapters.

The libdispatch build process is extended to include Dispatch.o
in libdispatch.so and to generate Dispatch.swiftmodule,
Dispatch.swiftdoc and a module.map file when configure is
given a --with-swift-sdk argument.

Swift programs that import Dispatch can be compiled, linked,
and run against the generated files, but must include some
extra command line arguments due to the use of @convention(block)
to bridge from Swift blocks to the -fblocks expected by dispatch.
In particular, the following flags are currently needed to compile
a Swift program: -Xcc -fblocks  -Xlinker -lBlocksRuntime