### PR TITLE
SR-438: 'make distcheck' fails for libdispatch on Linux

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,8 +57,8 @@ AM_CXXFLAGS=$(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
 AM_OBJCXXFLAGS=$(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
 
 if BUILD_OWN_PTHREAD_WORKQUEUES
-  PTHREAD_WORKQUEUE_LIBS=../libpwq/libpthread_workqueue.la
-  PTHREAD_WORKQUEUE_CFLAGS=-I../libpwq/include
+  PTHREAD_WORKQUEUE_LIBS=$(top_builddir)/libpwq/libpthread_workqueue.la
+  PTHREAD_WORKQUEUE_CFLAGS=-I$(top_srcdir)/libpwq/include
 else
   if HAVE_PTHREAD_WORKQUEUES
     PTHREAD_WORKQUEUE_LIBS=-lpthread_workqueue

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,8 @@ libbsdtests_la_SOURCES=				\
 	bsdtests.c				\
 	bsdtests.h				\
 	dispatch_test.c				\
-	dispatch_test.h
+	dispatch_test.h				\
+	linux_port.h
 
 check_PROGRAMS=					\
 	bsdtestharness				\


### PR DESCRIPTION
Small fixes to (a) use proper paths to libpwq when building
out-of-tree and (b) include tests/linux_port.h in list of
test sources (needed for distcheck).  With these changes
'make distcheck' works as expected.