### PR TITLE
if building Swift overlay, install into Swift toolchain dir structure

### DIFF
--- a/dispatch/Makefile.am
+++ b/dispatch/Makefile.am
@@ -2,7 +2,11 @@
 #
 #
 
+if HAVE_SWIFT
+dispatchdir=${prefix}/lib/swift/dispatch
+else
 dispatchdir=$(includedir)/dispatch
+endif
 
 dispatch_HEADERS=	\
 	base.h			\
@@ -18,4 +22,8 @@ dispatch_HEADERS=	\
 	semaphore.h		\
 	source.h		\
 	time.h
+
+if HAVE_SWIFT
+dispatch_HEADERS+=module.map
+endif
 

--- a/dispatch/module.map
+++ b/dispatch/module.map
@@ -1,5 +1,5 @@
 module Dispatch [system] {
-    umbrella header "PREFIX/dispatch/dispatch.h"
+    umbrella header "dispatch.h"
     requires blocks
     export *
     link "dispatch"

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -2,6 +2,7 @@
 #
 #
 
+if !HAVE_SWIFT
 dist_man3_MANS=					\
 	dispatch.3					\
 	dispatch_after.3			\
@@ -148,3 +149,4 @@ uninstall-hook:
 			dispatch_io_barrier.3	\
 			dispatch_io_write.3	\
 			dispatch_write.3
+endif

--- a/os/Makefile.am
+++ b/os/Makefile.am
@@ -2,7 +2,11 @@
 #
 #
 
+if HAVE_SWIFT
+osdir=${prefix}/lib/swift/os
+else
 osdir=$(includedir)/os
+endif
 
 os_HEADERS=	\
 	object.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,12 @@
 #
 #
 
+if HAVE_SWIFT
+swiftlibdir=${prefix}/lib/swift/linux
+swiftlib_LTLIBRARIES=libdispatch.la
+else
 lib_LTLIBRARIES=libdispatch.la
+endif
 
 libdispatch_la_SOURCES=		\
 	allocator.c				\
@@ -112,33 +117,28 @@ EXTRA_libdispatch_la_SOURCES+=swift/Dispatch.swift
 EXTRA_libdispatch_la_DEPENDENCIES+=$(abs_builddir)/Dispatch.o $(abs_builddir)/Dispatch.swiftmodule
 libdispatch_la_LIBADD+=$(abs_builddir)/Dispatch.o
 
-SWIFT_MODULEMAPS=$(abs_builddir)/module.map $(abs_builddir)/module.build.map
-SWIFTMODULE_OBJECTS=	\
+SWIFT_OBJECTS=	\
 	$(abs_builddir)/Dispatch.swiftmodule \
 	$(abs_builddir)/Dispatch.swiftdoc \
 	$(abs_builddir)/Dispatch.o
 
-SWIFTC_FLAGS = -I$(abs_top_srcdir) -parse-as-library -Xcc -fblocks -Xcc -fmodule-map-file=module.build.map
+SWIFTC_FLAGS = -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.map -I$(abs_top_srcdir) -parse-as-library -Xcc -fblocks
 
-$(abs_builddir)/module.build.map:	 $(abs_srcdir)/swift/module.map.in
-	m4 -DPREFIX=$(abs_top_srcdir) $<  > $@
-
-$(abs_builddir)/module.map:	 $(abs_srcdir)/swift/module.map.in
-	m4 -DPREFIX=$(includedir) $<  > $@
-
-$(abs_builddir)/Dispatch.o: $(abs_srcdir)/swift/Dispatch.swift $(abs_builddir)/module.build.map
+$(abs_builddir)/Dispatch.o: $(abs_srcdir)/swift/Dispatch.swift
 	$(SWIFTC) $(SWIFTC_FLAGS) -c -o $@ $<
 
-$(abs_builddir)/Dispatch.swiftmodule: $(abs_srcdir)/swift/Dispatch.swift $(abs_builddir)/module.build.map
+$(abs_builddir)/Dispatch.swiftmodule: $(abs_srcdir)/swift/Dispatch.swift
 	$(SWIFTC) $(SWIFTC_FLAGS) -emit-module -emit-module-path $@ $<
 
-swiftdir=$(includedir)/Dispatch
-swift_HEADERS=$(abs_builddir)/module.map $(abs_builddir)/Dispatch.swiftmodule $(abs_builddir)/Dispatch.swiftdoc
+if HAVE_SWIFT
+swiftmoddir=${prefix}/lib/swift/linux/${build_cpu}
+swiftmod_HEADERS=$(abs_builddir)/Dispatch.swiftmodule $(abs_builddir)/Dispatch.swiftdoc
+endif
 
 endif
 
-BUILT_SOURCES=$(MIG_SOURCES) $(DTRACE_SOURCES) $(SWIFT_MODULEMAPS)
+BUILT_SOURCES=$(MIG_SOURCES) $(DTRACE_SOURCES)
 nodist_libdispatch_la_SOURCES=$(BUILT_SOURCES)
-CLEANFILES=$(BUILT_SOURCES) $(SWIFTMODULE_OBJECTS)
+CLEANFILES=$(BUILT_SOURCES) $(SWIFT_OBJECTS)
 DISTCLEANFILES=pthread_machdep.h pthread System mach objc
 


### PR DESCRIPTION
Simplify the build/install logic for the Swift overlay portion of
libdispatch to assume that if the Swift overlay is being built
then the intended install target is a Swift toolchain.

In conjunction with the change to swift/utils/build-script-impl
in https://github.com/apple/swift/pull/1212, this change enables Swift programs compiled using
the resulting built toolchain to successfully import
Dispatch with only -Xcc -fblocks as extra arguments to swiftc
(no longer need to also specify -I<path-to-dispatch-module>).