### PR TITLE
Switch libpwq submodule to upstream repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libpwq"]
 	path = libpwq
-	url = https://github.com/dgrove-oss/libpwq.git
+	url = https://github.com/mheily/libpwq.git

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,7 @@ AC_CHECK_HEADERS([pthread_machdep.h pthread/qos.h])
 # Look for own version first, then system version.
 AS_IF([test -f $srcdir/libpwq/configure.ac],
   [AC_DEFINE(BUILD_OWN_PTHREAD_WORKQUEUES, 1, [Define if building pthread work queues from source])
+   ac_configure_args="--disable-libpwq-install $ac_configure_args"
    AC_CONFIG_SUBDIRS([libpwq])
    build_own_pthread_workqueue=true,
    AC_DEFINE(HAVE_PTHREAD_WORKQUEUES, 1, [Define if pthread work queues are present])


### PR DESCRIPTION
Switch to mheily repository (all the needed changes from
dgrove-oss have been merged upstream). Tweak libdispatch's
configure.ac so that if we are building our own libpwq
from source, the primary configure passes down an argument to
libpwq's configure to modify libpwq's install targets
so that libpthread_workqueue.la is built as a libtool
convenience library and libpwg's man pages and header
files are not installed when libdispatch is installed.