### PR TITLE
Add build-tests target to build tests separately from make-check

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -166,3 +166,7 @@ nsoperation_LDFLAGS=-framework Foundation
 bench_SOURCES=Foundation/bench.mm func.c
 bench_LDFLAGS=-framework Foundation
 endif
+
+# For use by swift/utils/build-script to force test cases to be
+# built during the build phase of CI
+build-tests: $(TESTS) $(check_PROGRAMS)


### PR DESCRIPTION
For Swift CI integration it is desirable to have a target
specifically to build the test cases and test utility programs.