### PR TITLE
resolve all compiler warnings

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -531,7 +531,7 @@ _dispatch_logv_init(void *context DISPATCH_UNUSED)
 #endif
 			dprintf(dispatch_logfile, "=== log file opened for %s[%u] at "
 					"%ld.%06u ===\n", getprogname() ?: "", getpid(),
-					tv.tv_sec, tv.tv_usec);
+					tv.tv_sec, (int)tv.tv_usec);
 		}
 	}
 }

--- a/src/io.c
+++ b/src/io.c
@@ -1601,7 +1601,7 @@ _dispatch_disk_init(dispatch_fd_entry_t fd_entry, dev_t dev)
 	TAILQ_INIT(&disk->operations);
 	disk->cur_rq = TAILQ_FIRST(&disk->operations);
 	char label[45];
-	snprintf(label, sizeof(label), "com.apple.libdispatch-io.deviceq.%d", dev);
+	snprintf(label, sizeof(label), "com.apple.libdispatch-io.deviceq.%d", (int)dev);
 	disk->pick_queue = dispatch_queue_create(label, NULL);
 	TAILQ_INSERT_TAIL(&_dispatch_io_devs[hash], disk, disk_list);
 out:
@@ -2367,7 +2367,7 @@ _dispatch_io_debug_attr(dispatch_io_t channel, char* buf, size_t bufsiz)
 			channel->barrier_group, channel->err, channel->params.low,
 			channel->params.high, channel->params.interval_flags &
 			DISPATCH_IO_STRICT_INTERVAL ? "(strict)" : "",
-			channel->params.interval);
+			(unsigned long long) channel->params.interval);
 }
 
 size_t
@@ -2398,10 +2398,10 @@ _dispatch_operation_debug_attr(dispatch_operation_t op, char* buf,
 			"write", op->fd_entry ? op->fd_entry->fd : -1, op->fd_entry,
 			op->channel, op->op_q, oqtarget && oqtarget->dq_label ?
 			oqtarget->dq_label : "", oqtarget, target && target->dq_label ?
-			target->dq_label : "", target, op->offset, op->length, op->total,
+			target->dq_label : "", target, (long long)op->offset, op->length, op->total,
 			op->undelivered + op->buf_len, op->flags, op->err, op->params.low,
 			op->params.high, op->params.interval_flags &
-			DISPATCH_IO_STRICT_INTERVAL ? "(strict)" : "", op->params.interval);
+			DISPATCH_IO_STRICT_INTERVAL ? "(strict)" : "", (unsigned long long)op->params.interval);
 }
 
 size_t

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -895,7 +895,7 @@ static bool _dispatch_futex_wait_slow(dispatch_futex_t dfx,
 		const struct timespec* timeout);
 
 DISPATCH_INLINE
-static int
+int
 _dispatch_futex_syscall(int *futex_addr, 
 		int op, int val, const struct timespec *timeout)
 {

--- a/tests/bsdtests.c
+++ b/tests/bsdtests.c
@@ -18,6 +18,10 @@
  * @APPLE_APACHE_LICENSE_HEADER_END@
  */
 
+#ifdef __linux__
+// for asprintf
+#define _GNU_SOURCE 1
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/dispatch_overcommit.c
+++ b/tests/dispatch_overcommit.c
@@ -18,6 +18,10 @@
  * @APPLE_APACHE_LICENSE_HEADER_END@
  */
 
+#ifdef __linux__
+// for asprintf
+#define _GNU_SOURCE 1
+#endif
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
 #include <stdio.h>

--- a/tests/dispatch_starfish.c
+++ b/tests/dispatch_starfish.c
@@ -70,7 +70,7 @@ collect(void *context __attribute__((unused)))
 
 	printf("lap: %ld\n", lap_count_down);
 	printf("count: %lu\n", COUNT);
-	printf("delta: %llu ns\n", delta);
+	printf("delta: %lu ns\n", delta);
 	printf("math: %Lf ns / lap\n", math);
 
 	for (i = 0; i < COUNT; i++) {

--- a/tests/dispatch_timer.c
+++ b/tests/dispatch_timer.c
@@ -63,7 +63,7 @@ test_timer(void)
 		dispatch_source_set_event_handler(s, ^{
 			if (!finalized) {
 				test_long_less_than("timer number", j, stop_at);
-				fprintf(stderr, "timer[%lld]\n", j);
+				fprintf(stderr, "timer[%lu]\n", j);
 			}
 			dispatch_release(s);
 		});


### PR DESCRIPTION
Resolve all compiler warnings when building libdispatch and
the test suite on linux.  It now compiles cleanly.

Many of the warnings were due to platform-specific sized integers
being used in printf-like contexts.  In libdispatch itself, I took
the approach of adding casts to the values to match the size/type
specified in the printf format string (under the assumption that
the expected output format should not be changed and needs to be
the same on all platforms).