### PR TITLE
fix timebase used in _dispatch_semaphore_wait_slow leading to infinit…

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -380,7 +380,7 @@ again:
 		}
 #elif USE_FUTEX_SEM
 		do {
-			uint64_t nsec = _dispatch_time_to_nanoseconds(timeout);
+			uint64_t nsec = _dispatch_timeout(timeout);
 			_timeout.tv_sec = (typeof(_timeout.tv_sec))(nsec / NSEC_PER_SEC);
 			_timeout.tv_nsec = (typeof(_timeout.tv_nsec))(nsec % NSEC_PER_SEC);
 			ret = slowpath(_dispatch_futex_wait(&dsema->dsema_futex, &_timeout));
@@ -645,10 +645,9 @@ again:
 		}
 #elif USE_FUTEX_SEM
 		do {
-			// HF: check whether we need same timer as POSIX_SEM
 			uint64_t nsec = _dispatch_timeout(timeout);
-			_timeout.tv_sec = nsec / NSEC_PER_SEC;
-			_timeout.tv_nsec = nsec % NSEC_PER_SEC;
+			_timeout.tv_sec = (typeof(_timeout.tv_sec))(nsec / NSEC_PER_SEC);
+			_timeout.tv_nsec = (typeof(_timeout.tv_nsec))(nsec % NSEC_PER_SEC);
 			ret = slowpath(_dispatch_futex_wait(&dsema->dsema_futex, &_timeout));
 		} while (ret == false && errno == EINTR);
 


### PR DESCRIPTION
…y wait

This fixes a bug where as the timebase for a timeout for futex was absolute time not relative time
as required by futex system call. 