### PR TITLE
inform libpwq thread manager before semaphore wait

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -383,6 +383,7 @@ again:
 			uint64_t nsec = _dispatch_timeout(timeout);
 			_timeout.tv_sec = (typeof(_timeout.tv_sec))(nsec / NSEC_PER_SEC);
 			_timeout.tv_nsec = (typeof(_timeout.tv_nsec))(nsec % NSEC_PER_SEC);
+			pthread_workqueue_signal_np();
 			ret = slowpath(_dispatch_futex_wait(&dsema->dsema_futex, &_timeout));
 		} while (ret == false && errno == EINTR);
 
@@ -430,6 +431,7 @@ again:
 		DISPATCH_SEMAPHORE_VERIFY_RET(ret);
 #elif USE_FUTEX_SEM
 		do {
+			pthread_workqueue_signal_np();
 			ret = _dispatch_futex_wait(&dsema->dsema_futex, NULL);
 		} while (ret == false && errno == EINTR);
 		DISPATCH_SEMAPHORE_VERIFY_RET(ret);
@@ -648,6 +650,7 @@ again:
 			uint64_t nsec = _dispatch_timeout(timeout);
 			_timeout.tv_sec = (typeof(_timeout.tv_sec))(nsec / NSEC_PER_SEC);
 			_timeout.tv_nsec = (typeof(_timeout.tv_nsec))(nsec % NSEC_PER_SEC);
+			pthread_workqueue_signal_np();
 			ret = slowpath(_dispatch_futex_wait(&dsema->dsema_futex, &_timeout));
 		} while (ret == false && errno == EINTR);
 
@@ -695,6 +698,7 @@ again:
 		DISPATCH_SEMAPHORE_VERIFY_RET(ret);
 #elif USE_FUTEX_SEM
 		do {
+			pthread_workqueue_signal_np();
 			ret = _dispatch_futex_wait(&dsema->dsema_futex, NULL);
 		} while (ret == false && errno == EINTR);
 		DISPATCH_SEMAPHORE_VERIFY_RET(ret);


### PR DESCRIPTION
Before waiting on a dispatch_semaphore (slow path), notify the thread pool manager
that this thread will go to block.

Depends on the small patch submitted to libpwq which has been integrated. 

This patch will wakeup the thread manager (instead of doing this once per second)
which then forces a new worker_thread to be started.

Lack of this patch will result in reduced concurrency at program startup time.
See https://bugs.swift.org/browse/SR-761 for some symptoms.

This patch is not a fix for all, for instance it does not catch sleep() calls, but according
to Swift Foundation implementers its a good intermediate solution before the  linux kernel solution
is considered which has a longer lead time and requires a kernel extension to be installed.
