### PR TITLE
Build fix for Linux overlay with 03242016 compiler.

### DIFF
--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -26,6 +26,7 @@
 #include <TargetConditionals.h>
 #endif
 #include <sys/cdefs.h>
+#include <sys/types.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/dispatch/io.h
+++ b/dispatch/io.h
@@ -26,6 +26,10 @@
 #include <dispatch/base.h> // for HeaderDoc
 #endif
 
+#ifdef __DISPATCH_BUILDING_SWIFT_MODULE__
+#include <stdio.h>
+#endif
+
 __BEGIN_DECLS
 
 /*! @header

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,7 +122,7 @@ SWIFT_OBJECTS=	\
 	$(abs_builddir)/Dispatch.swiftdoc \
 	$(abs_builddir)/Dispatch.o
 
-SWIFTC_FLAGS = -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.map -I$(abs_top_srcdir) -parse-as-library -Xcc -fblocks
+SWIFTC_FLAGS = -Xcc -D__DISPATCH_BUILDING_SWIFT_MODULE__=1 -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.map -I$(abs_top_srcdir) -parse-as-library -Xcc -fblocks
 
 $(abs_builddir)/Dispatch.o: $(abs_srcdir)/swift/Dispatch.swift
 	$(SWIFTC) $(SWIFTC_FLAGS) -c -o $@ $<


### PR DESCRIPTION
With the 03242016 development drop, building the
Dispatch overlay on Linux fails because mode_t and
off_t are not defined.  This is a minimal fix to
include the needed header files and get the build
working again.