### PR TITLE
Another fix for libpwq configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,7 @@ AS_IF([test -f $srcdir/libpwq/configure.ac],
   [AC_DEFINE(BUILD_OWN_PTHREAD_WORKQUEUES, 1, [Define if building pthread work queues from source])
    ac_configure_args="--disable-libpwq-install $ac_configure_args"
    AC_CONFIG_SUBDIRS([libpwq])
-   build_own_pthread_workqueues=true,
+   build_own_pthread_workqueues=true
    AC_DEFINE(HAVE_PTHREAD_WORKQUEUES, 1, [Define if pthread work queues are present])
    have_pthread_workqueues=true],
   [build_own_pthread_workqueues=false


### PR DESCRIPTION
Setting a configure variable that is tested in
a later AM_CONDITIOANL to true, is not the same as
setting it to true