### PR TITLE
Build fix for Linux overlay with 03242016 compiler.

### DIFF
--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -32,6 +32,10 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <fcntl.h>
+#ifndef __APPLE__
+#include <stdio.h>
+#include <sys/types.h>
+#endif
 
 #ifndef __OSX_AVAILABLE_STARTING
 #define __OSX_AVAILABLE_STARTING(x, y)


### PR DESCRIPTION
With the 03242016 development drop, building the
Dispatch overlay on Linux fails because mode_t and
off_t are not defined.  This is a minimal fix to
include the needed header files and get the build
working again.