### PR TITLE
change prototype of functions returning nil to use ImplictlyUnwrapped…

### DIFF
--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -41,13 +41,13 @@ public var DISPATCH_IO_STRICT_INTERVAL: dispatch_io_interval_flags_t {
   return 1
 }
 
-public var DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t {
+public var DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t! {
   return nil
 }
-public var DISPATCH_CURRENT_QUEUE_LABEL: dispatch_queue_t {
+public var DISPATCH_CURRENT_QUEUE_LABEL: dispatch_queue_t! {
   return nil
 }
-public var DISPATCH_TARGET_QUEUE_DEFAULT: dispatch_queue_t {
+public var DISPATCH_TARGET_QUEUE_DEFAULT: dispatch_queue_t! {
   return nil
 }
 public var DISPATCH_QUEUE_PRIORITY_HIGH: dispatch_queue_priority_t {


### PR DESCRIPTION
…Optional

Fixes build break with 20160412a development drop by restoring !
annotation on the return types of methods that return nil.
Picked ! (not ?) to match swift/public/SDK/Dispatch/Dispatch.swift.