### PR TITLE
Enable dispatch_block_create for Linux

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,7 +62,7 @@ DISPATCH_CFLAGS=-Wall $(VISIBILITY_FLAGS) $(OMIT_LEAF_FP_FLAGS) \
 	$(MARCH_FLAGS) $(KQUEUE_CFLAGS) $(BSD_OVERLAY_CFLAGS)
 AM_CFLAGS= $(PTHREAD_WORKQUEUE_CFLAGS) $(DISPATCH_CFLAGS) $(CBLOCKS_FLAGS)
 AM_OBJCFLAGS=$(DISPATCH_CFLAGS) $(CBLOCKS_FLAGS)
-AM_CXXFLAGS=$(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
+AM_CXXFLAGS=$(PTHREAD_WORKQUEUE_CFLAGS) $(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
 AM_OBJCXXFLAGS=$(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
 
 if BUILD_OWN_PTHREAD_WORKQUEUES
@@ -91,6 +91,9 @@ libdispatch_la_LDFLAGS+=-Wl,-upward-lobjc -Wl,-upward-lauto \
 	-Wl,-order_file,$(top_srcdir)/xcodeconfig/libdispatch.order \
 	-Wl,-alias_list,$(top_srcdir)/xcodeconfig/libdispatch_objc.aliases \
 	-Wl,-unexported_symbols_list,$(top_srcdir)/xcodeconfig/libdispatch.unexport
+else
+libdispatch_la_SOURCES+=block.cpp
+libdispatch_la_CXXFLAGS=$(AM_CXXFLAGS) -std=gnu++11 -fno-exceptions
 endif
 
 if USE_MIG

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -103,7 +103,11 @@ extern "C" {
 // The compiler hides the name of the function it generates, and changes it if
 // we try to reference it directly, but the linker still sees it.
 extern void DISPATCH_BLOCK_SPECIAL_INVOKE(void *)
+#ifdef __linux__
+		asm("___dispatch_block_create_block_invoke");
+#else
 		asm("____dispatch_block_create_block_invoke");
+#endif
 void (*_dispatch_block_special_invoke)(void*) = DISPATCH_BLOCK_SPECIAL_INVOKE;
 }
 

--- a/src/shims/linux_stubs.c
+++ b/src/shims/linux_stubs.c
@@ -35,12 +35,6 @@
 #undef LINUX_PORT_ERROR
 #define LINUX_PORT_ERROR()  do { printf("LINUX_PORT_ERROR_CALLED %s:%d: %s\n",__FILE__,__LINE__,__FUNCTION__); abort(); } while (0)
 
-dispatch_block_t _dispatch_block_create(dispatch_block_flags_t flags,
-					voucher_t voucher, pthread_priority_t priority,
-					dispatch_block_t block) {
-  LINUX_PORT_ERROR();
-}
-
 unsigned long _dispatch_runloop_queue_probe(dispatch_queue_t dq) {
   LINUX_PORT_ERROR();
 }


### PR DESCRIPTION
Add block.cpp to libdispatch_la_SOURCES when !USE_OBJC
Tweak linker hack for DISPATCH_BLOCK_SPECIAL_INVOKE to work on linux
Remove stub implementation of dispatch_create_block (porting remnant).