### PR TITLE
Removed uses of deprecated @warn_unused_result attr

### DIFF
--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -65,7 +65,6 @@ public var DISPATCH_QUEUE_PRIORITY_BACKGROUND: dispatch_queue_priority_t {
 
 /*
 FIXME: LINUX_PORT:  qos_class_t not being imported
-@warn_unused_result
 public func dispatch_get_global_queue(identifier: qos_class_t,
                                       _ flags: UInt) -> dispatch_queue_t {
   return dispatch_get_global_queue(Int(identifier.rawValue), flags)
@@ -76,7 +75,6 @@ public var DISPATCH_QUEUE_CONCURRENT: dispatch_queue_attr_t {
   return _swift_dispatch_queue_concurrent()
 }
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_queue_concurrent")
 internal func _swift_dispatch_queue_concurrent() -> dispatch_queue_attr_t
 
@@ -85,7 +83,6 @@ public var dispatch_data_empty: dispatch_data_t {
   return _swift_dispatch_data_empty()
 }
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_data_empty")
 internal func _swift_dispatch_data_empty() -> dispatch_data_t
 
@@ -131,35 +128,27 @@ public var DISPATCH_SOURCE_TYPE_WRITE: dispatch_source_type_t {
   return _swift_dispatch_source_type_write()
 }
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_DATA_ADD")
 internal func _swift_dispatch_source_type_data_add() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_DATA_OR")
 internal func _swift_dispatch_source_type_data_or() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_PROC")
 internal func _swift_dispatch_source_type_proc() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_READ")
 internal func _swift_dispatch_source_type_read() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_SIGNAL")
 internal func _swift_dispatch_source_type_signal() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_TIMER")
 internal func _swift_dispatch_source_type_timer() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_VNODE")
 internal func _swift_dispatch_source_type_vnode() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_WRITE")
 internal func _swift_dispatch_source_type_write() -> dispatch_source_type_t
 


### PR DESCRIPTION
The `@warn_unused_result` attribute is no longer needed as its behavior is now the default. A future change to the compiler (apple/swift#2760) will make its use an error. This PR removes the uses of this attribute.