### PR TITLE
SR-1101 : clang 3.9 doesn't allow typeof on bit-field

### DIFF
--- a/src/inline_internal.h
+++ b/src/inline_internal.h
@@ -497,7 +497,7 @@ static inline void
 _dispatch_queue_set_bound_thread(dispatch_queue_t dq)
 {
 	//Tag thread-bound queues with the owning thread
-	dispatch_assert(dq->dq_is_thread_bound);
+	dispatch_assert(dq->dq_is_thread_bound != 0);
 	dq->dq_thread = _dispatch_thread_port();
 }
 
@@ -505,7 +505,7 @@ DISPATCH_ALWAYS_INLINE
 static inline void
 _dispatch_queue_clear_bound_thread(dispatch_queue_t dq)
 {
-	dispatch_assert(dq->dq_is_thread_bound);
+	dispatch_assert(dq->dq_is_thread_bound != 0);
 	dq->dq_thread = MACH_PORT_NULL;
 }
 
@@ -513,7 +513,7 @@ DISPATCH_ALWAYS_INLINE
 static inline mach_port_t
 _dispatch_queue_get_bound_thread(dispatch_queue_t dq)
 {
-	dispatch_assert(dq->dq_is_thread_bound);
+	dispatch_assert(dq->dq_is_thread_bound != 0);
 	return dq->dq_thread;
 }
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -2839,7 +2839,7 @@ _dispatch_barrier_sync_f_slow_invoke(void *ctxt)
 
 	dispatch_assert(dq == _dispatch_queue_get_current());
 #if DISPATCH_COCOA_COMPAT
-	if (slowpath(dq->dq_is_thread_bound)) {
+	if (slowpath(dq->dq_is_thread_bound != 0)) {
 		// The queue is bound to a non-dispatch thread (e.g. main thread)
 		_dispatch_continuation_voucher_adopt(dc);
 		_dispatch_client_callout(dc->dc_ctxt, dc->dc_func);
@@ -2879,7 +2879,7 @@ _dispatch_barrier_sync_f_slow(dispatch_queue_t dq, void *ctxt,
 	// It's preferred to execute synchronous blocks on the current thread
 	// due to thread-local side effects, garbage collection, etc. However,
 	// blocks submitted to the main thread MUST be run on the main thread
-	if (slowpath(dq->dq_is_thread_bound)) {
+	if (slowpath(dq->dq_is_thread_bound != 0)) {
 		_dispatch_continuation_voucher_set(&dc, 0);
 	}
 #endif
@@ -3074,7 +3074,7 @@ _dispatch_barrier_sync_slow(dispatch_queue_t dq, void (^work)(void))
 void
 dispatch_barrier_sync(dispatch_queue_t dq, void (^work)(void))
 {
-	if (slowpath(dq->dq_is_thread_bound) ||
+	if (slowpath(dq->dq_is_thread_bound != 0) ||
 			slowpath(_dispatch_block_has_private_data(work))) {
 		return _dispatch_barrier_sync_slow(dq, work);
 	}
@@ -3279,7 +3279,7 @@ dispatch_sync(dispatch_queue_t dq, void (^work)(void))
 	if (fastpath(dq->dq_width == 1)) {
 		return dispatch_barrier_sync(dq, work);
 	}
-	if (slowpath(dq->dq_is_thread_bound) ||
+	if (slowpath(dq->dq_is_thread_bound != 0) ||
 			slowpath(_dispatch_block_has_private_data(work)) ) {
 		return _dispatch_sync_slow(dq, work);
 	}

--- a/src/source.c
+++ b/src/source.c
@@ -621,7 +621,7 @@ _dispatch_source_kevent_resume(dispatch_source_t ds, uint32_t new_flags)
 static void
 _dispatch_source_kevent_register(dispatch_source_t ds)
 {
-	dispatch_assert_zero(ds->ds_is_installed);
+	dispatch_assert(ds->ds_is_installed == 0);
 	switch (ds->ds_dkev->dk_kevent.filter) {
 	case DISPATCH_EVFILT_TIMER:
 		_dispatch_timers_update(ds);


### PR DESCRIPTION
Avoid using an expression whose type is a bitfield in
macros like slowpath or dispatch_assert that internally
use typeof on their argument expression.