### PR TITLE
Avoid overwriting config.h with generated header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ(2.69)
 AC_INIT([libdispatch], [1.3], [libdispatch@macosforge.org], [libdispatch], [http://libdispatch.macosforge.org])
 AC_REVISION([$$])
 AC_CONFIG_AUX_DIR(config)
-AC_CONFIG_HEADER([config/config.h])
+AC_CONFIG_HEADER([config/config_ac.h])
 AC_CONFIG_MACRO_DIR([m4])
 ac_clean_files=a.out.dSYM
 AM_MAINTAINER_MODE

--- a/src/internal.h
+++ b/src/internal.h
@@ -27,7 +27,11 @@
 #ifndef __DISPATCH_INTERNAL__
 #define __DISPATCH_INTERNAL__
 
+#if __has_include(<config/config_ac.h>)
+#include <config/config_ac.h>
+#else
 #include <config/config.h>
+#endif
 
 #define __DISPATCH_BUILDING_DISPATCH__
 #define __DISPATCH_INDIRECT__

--- a/src/shims/linux_stubs.c
+++ b/src/shims/linux_stubs.c
@@ -18,7 +18,12 @@
 
 #include <stdint.h>
 #include <syscall.h>
+
+#if __has_include(<config/config_ac.h>)
+#include <config/config_ac.h>
+#else
 #include <config/config.h>
+#endif
 
 #include "pthread.h"
 #include "os/linux_base.h"


### PR DESCRIPTION
config.h is generated by the autotools build process.
Having it stored in git causes useless diffs and the
need for git checkout operations when rebasing because
the generated version differs from the version in git.