### PR TITLE
Add rpath for libswiftCore when building with the Swift overlay

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -140,6 +140,10 @@ bsdtestsummarize_LDADD=-lm $(BSD_OVERLAY_LIBS)
 dispatch_timer_short_LDADD=-lm $(LDADD)
 dispatch_group_LDADD=-lm $(LDADD)
 
+if HAVE_SWIFT
+AM_LDFLAGS=-rpath $(SWIFT_RUNTIME_LIBS)
+endif
+
 if HAVE_LEAKS
 AM_TESTS_ENVIRONMENT=
 else


### PR DESCRIPTION
Running the dispatch tests with the Swift overlay complied in fails because the tests can't link to libswiftCore.so at runtime.

The quick fix for this is to add an `rpath` to the `SWIFT_RUNTIME_LIBS` directory which contains the libswiftCore.so from the version of Swift used to compile the overlay.