### PR TITLE
Disable tests failing intermittently in Swift CI

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,18 +43,15 @@ TESTS=							\
 	dispatch_priority2			\
 	dispatch_context_for_key	\
 	dispatch_read				\
-	dispatch_read2				\
 	dispatch_after				\
 	dispatch_timer				\
 	dispatch_timer_timeout		\
 	dispatch_suspend_timer		\
 	dispatch_timer_bit31		\
 	dispatch_timer_bit63		\
-	dispatch_timer_set_time		\
 	dispatch_starfish			\
 	dispatch_cascade			\
 	dispatch_data				\
-	dispatch_io					\
 	dispatch_io_net				\
 	dispatch_select
 
@@ -67,6 +64,9 @@ FAILING_TESTS = 				\
 	dispatch_timer_short		\
 	dispatch_sema				\
 	dispatch_readsync			\
+	dispatch_read2				\
+	dispatch_io					\
+	dispatch_timer_set_time		\
 	dispatch_drift
 
 # List tests that are expected to fail here.


### PR DESCRIPTION
Disable another 3 tests with intermittent failures in the CI. These are:

- dispatch_read2: the problem is likely an overflow where the `usr/lib` directory is large. This is fixed in master already
- dispatch_io: the test triggers 7 events which have to execute within an arbitrary time limit of 3 seconds. This doesn't fail for me locally, but the events often take 2 seconds, so likely this time limit just needs to be extended.
- dispatch_read2: not sure why this is failing, but it seems to roughly 1 time in 20.

We'll need to fix up the tests properly in the future, or create new alternative tests, but at the moment this PR is to disable them so that we don't have build failures.