### PR TITLE
Use SWIFT_SDK_OVERLAY_DISPATCH_EPOCH to detect that an overlay is bei…

### DIFF
--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -44,8 +44,8 @@
 #endif
 
 #ifdef __linux__
-#ifdef __DISPATCH_BUILDING_SWIFT_MODULE__
-#include <stdio.h> // for off_t
+#if __has_feature(modules)
+#include <stdio.h> // for off_t (to match Glibc.modulemap)
 #endif
 #define DISPATCH_LINUX_UNAVAILABLE() \
 		__DISPATCH_UNAVAILABLE("This interface is unavailable on linux systems")

--- a/dispatch/object.h
+++ b/dispatch/object.h
@@ -108,7 +108,7 @@ typedef union {
 #define DISPATCH_RETURNS_RETAINED
 #endif
 
-#if OS_OBJECT_SWIFT3
+#if OS_OBJECT_SWIFT3 && OS_OBJECT_USE_OBJC
 #define DISPATCH_SOURCE_TYPE_DECL(name) \
 		DISPATCH_EXPORT struct dispatch_source_type_s \
 				_dispatch_source_type_##name; \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -149,7 +149,7 @@ SWIFT_GEN_FILES=	\
 	$(SWIFT_OBJ_FILES:%=%.~partial.swiftdoc) \
 	$(SWIFT_OBJ_FILES:%=%.~partial.swiftdeps)
 
-SWIFTC_FLAGS = -Xcc -D__DISPATCH_BUILDING_SWIFT_MODULE__=1 -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.modulemap -I$(abs_top_srcdir) -Xcc -fblocks
+SWIFTC_FLAGS = -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.modulemap -I$(abs_top_srcdir) -Xcc -fblocks
 
 $(abs_builddir)/swift/%.o:	$(abs_srcdir)/swift/%.swift
 	$(SWIFTC) -frontend -c $(SWIFT_ABS_SRC_FILES) -primary-file $< \


### PR DESCRIPTION
…ng built

Instead of defining the special macro __DISPATCH_BUILDING_SWIFT_MODULE__
to detect that dispatch headers are being processed by the clang importer,
check to see if SWIFT_SDK_OVERLAY_DISPATCH_EPOCH is defined.

The prime motivation for doing this is to avoid needing to define __DISPATCH_BUILDING_SWIFT_MODULE__ when compiling a Swift program that imports Dispatch.  A secondary benefit is that it makes additional functions unavailable for Swift3 (eg dispatch_once).  

This depends on a pull request (https://github.com/apple/swift/pull/3346) to Swift to change the importer to define SWIFT_SDK_OVERLAY_DISPATCH_EPOCH on non-Darwin platforms.