### PR TITLE
add dispatchMain to wrapping overlay

### DIFF
--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -15,6 +15,10 @@ import CDispatch
 // This file contains declarations that are provided by the
 // importer via Dispatch.apinote when the platform has Objective-C support
 
+@noreturn public func dispatchMain() {
+	CDispatch.dispatch_main()
+}
+
 public class DispatchObject {
 
 	internal func wrapped() -> dispatch_object_t {


### PR DESCRIPTION
dispatch_main is meant to be made available via
the global function dispatchMain().