### PR TITLE
Link to Swift libraries for CI tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -122,7 +122,8 @@ endif
 endif
 
 if HAVE_SWIFT
-  SWIFT_LIBS=-L$(SWIFT_LIBDIR) -lswiftCore
+  SWIFT_LIBS=-L$(SWIFT_LIBDIR) -lswiftCore -lswiftSwiftOnoneSupport
+  AM_LDFLAGS=-rpath $(SWIFT_LIBDIR)
 endif
 
 LDADD=libbsdtests.la $(top_builddir)/src/libdispatch.la $(KQUEUE_LIBS) $(PTHREAD_WORKQUEUE_LIBS) $(BSD_OVERLAY_LIBS) $(SWIFT_LIBS)


### PR DESCRIPTION
The libdispatch CI test failed for #100:
https://github.com/apple/swift-corelibs-libdispatch/pull/100

Due to the following linkage issues when building the tests:
```
../src/.libs/libdispatch.so: undefined reference to `_TTSgq5SiSis10ComparablesSis11_Strideables___TFVs14CountableRangeg8endIndexx'
../src/.libs/libdispatch.so: undefined reference to `_TTSgq5SiSis10ComparablesSis11_Strideables___TFVs14CountableRangeg10startIndexx'
../src/.libs/libdispatch.so: undefined reference to `_TTSgq5SiSis10ComparablesSis11_Strideables___TFVs14CountableRangeCfT15uncheckedBoundsT5lowerx5upperx__GS_x_'
```
Those symbols appear in libswiftSwiftOnoneSupport. Additionally after adding that library to the linkage flags, the tests fail to find the Swift libraries during test execution, which can be fixed by adding the Swift library directory to the RPATH.


