### PR TITLE
deallocation support for DispatchData on Linux

### DIFF
--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -41,7 +41,7 @@ public extension DispatchIO {
 	}
 
 	public class func write(fromFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: (data: DispatchData?, error: Int32) -> Void) {
-		dispatch_write(fromFileDescriptor, data.__wrapped, queue.__wrapped) { (data: dispatch_data_t?, error: Int32) in
+		dispatch_write(fromFileDescriptor, data.__wrapped.__wrapped, queue.__wrapped) { (data: dispatch_data_t?, error: Int32) in
 			handler(data: data.flatMap { DispatchData(data: $0) }, error: error)
 		}
 	}
@@ -82,7 +82,7 @@ public extension DispatchIO {
 	}
 
 	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: (done: Bool, data: DispatchData?, error: Int32) -> Void) {
-		dispatch_io_write(self.__wrapped, offset, data.__wrapped, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
+		dispatch_io_write(self.__wrapped, offset, data.__wrapped.__wrapped, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
 			ioHandler(done: done, data: data.flatMap { DispatchData(data: $0) }, error: error)
 		}
 	}

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -186,6 +186,22 @@ extension DispatchSource : DispatchSourceProcess,
 }
 #endif
 
+internal class __DispatchData : DispatchObject {
+	internal let __wrapped:dispatch_data_t
+
+	final internal override func wrapped() -> dispatch_object_t {
+		return unsafeBitCast(__wrapped, to: dispatch_object_t.self)
+	}
+
+	internal init(data:dispatch_data_t) {
+		__wrapped = data
+	}
+
+	deinit {
+		_swift_dispatch_release(wrapped())
+	}
+}
+
 public typealias DispatchSourceHandler = @convention(block) () -> Void
 
 public protocol DispatchSourceType {
@@ -307,9 +323,9 @@ internal enum _OSQoSClass : UInt32  {
 		case 0x21: self = .QOS_CLASS_USER_INTERACTIVE
 		case 0x19: self = .QOS_CLASS_USER_INITIATED
 		case 0x15: self = .QOS_CLASS_DEFAULT
-		case 0x11: self = QOS_CLASS_UTILITY
-		case 0x09: self = QOS_CLASS_BACKGROUND
-		case 0x00: self = QOS_CLASS_UNSPECIFIED
+		case 0x11: self = .QOS_CLASS_UTILITY
+		case 0x09: self = .QOS_CLASS_BACKGROUND
+		case 0x00: self = .QOS_CLASS_UNSPECIFIED
 		default: return nil
 		}
 	}


### PR DESCRIPTION
Deallocation / reference counting support for DispatchData
in the wrapping overlay consisting of two main pieces.

First, since DispatchData is a struct and dispatch_data_t is
a COpaquePointer, we need an intermediate class __DispatchData
on which to perform the reference counting operations to enable
the backing _dispatch_data_t to be deallocated when they are no
longer reachable.  I overlooked the mapping of _dispatch_data_t
to OS_dispatch_data in Dispatch.apinotes in my initial pull request
for the wrapping overlay and as a result all the dispatch_data_t
instances were not being reference counted.

Second, enable the DispatchData.Deallocator portion of the API.
After some experimentation, found a way to have the desired API
without getting a reference to _TMBO in the generated code.
Left a FIXME because the current approach is sub-optimal in where
it converts from Swift blocks to @convention(block) blocks.