### PR TITLE
autoconf support for selecting build variant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,46 @@ AC_CONFIG_MACRO_DIR([m4])
 ac_clean_files=a.out.dSYM
 AM_MAINTAINER_MODE
 
+#
+# Command line argument to specify build variant (default to release).
+# Impacts default value of CFLAGS et al. so must come before AC_PROG_CC
+#
+AC_ARG_WITH([build-variant],
+  [AS_HELP_STRING([--with-build-variant=release|debug|releaseassert|releasedebuginfo], [Specify build variant [default=release]])],
+  [dispatch_build_variant=${withval}],
+  [dispatch_build_variant=release]
+)
+AS_CASE([$dispatch_build_variant],
+  [debug], [
+    default_compiler_flags="-g -O0"
+    dispatch_enable_asserts=true
+    dispatch_enable_optimization=false
+  ],
+  [release], [
+    default_compiler_flags="-O2"
+    dispatch_enable_asserts=false
+    dispatch_enable_optimization=true
+  ],
+  [releaseassert], [
+    default_compiler_flags="-O2"
+    dispatch_enable_asserts=true
+    dispatch_enable_optimization=true
+  ],
+  [releasedebuginfo], [
+    default_compiler_flags="-g -O2"
+    dispatch_enable_asserts=false
+    dispatch_enable_optimization=true
+  ],
+  [AC_MSG_ERROR("invalid build-variant $dispatch_build_variant")]
+)
+AM_CONDITIONAL(DISPATCH_ENABLE_ASSERTS, $dispatch_enable_asserts)
+AM_CONDITIONAL(DISPATCH_ENABLE_OPTIMIZATION, $dispatch_enable_optimization)
+
+: ${CFLAGS=$default_compiler_flags}
+: ${CXXFLAGS=$default_compiler_flags}
+: ${OBJCFLAGS=$default_compiler_flags}
+: ${OBJCXXFLAGS=$default_compiler_flags}
+
 AC_PROG_CC([clang gcc cc])
 AC_PROG_CXX([clang++ g++ c++])
 AC_PROG_OBJC([clang gcc cc])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,6 +61,9 @@ AM_CPPFLAGS=-I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/private
 
 DISPATCH_CFLAGS=-Wall $(VISIBILITY_FLAGS) $(OMIT_LEAF_FP_FLAGS) \
 	$(MARCH_FLAGS) $(KQUEUE_CFLAGS) $(BSD_OVERLAY_CFLAGS)
+if DISPATCH_ENABLE_ASSERTS
+DISPATCH_CFLAGS+=-DDISPATCH_DEBUG=1
+endif
 AM_CFLAGS= $(PTHREAD_WORKQUEUE_CFLAGS) $(DISPATCH_CFLAGS) $(CBLOCKS_FLAGS)
 AM_OBJCFLAGS=$(DISPATCH_CFLAGS) $(CBLOCKS_FLAGS)
 AM_CXXFLAGS=$(PTHREAD_WORKQUEUE_CFLAGS) $(DISPATCH_CFLAGS) $(CXXBLOCKS_FLAGS)
@@ -150,6 +153,9 @@ SWIFT_GEN_FILES=	\
 	$(SWIFT_OBJ_FILES:%=%.~partial.swiftdeps)
 
 SWIFTC_FLAGS = -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.modulemap -I$(abs_top_srcdir) -Xcc -fblocks
+if DISPATCH_ENABLE_OPTIMIZATION
+SWIFTC_FLAGS+=-O
+endif
 
 $(abs_builddir)/swift/%.o:	$(abs_srcdir)/swift/%.swift
 	$(SWIFTC) -frontend -c $(SWIFT_ABS_SRC_FILES) -primary-file $< \

--- a/src/internal.h
+++ b/src/internal.h
@@ -353,8 +353,12 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 
 #if DISPATCH_DEBUG
 // sys/queue.h debugging
+#if defined(__linux__)
+#define QUEUE_MACRO_DEBUG 1
+#else
 #undef TRASHIT
 #define TRASHIT(x) do {(x) = (void *)-1;} while (0)
+#endif
 #endif // DISPATCH_DEBUG
 #define _TAILQ_TRASH_ENTRY(elm, field) do { \
 			TRASHIT((elm)->field.tqe_next); \

--- a/src/source.c
+++ b/src/source.c
@@ -6585,7 +6585,7 @@ dispatch_kevent_debug(const char *verb, const _dispatch_kevent_qos_s *kev,
 #else
 			0ull, 0ull,
 #endif
-			str, function, line);
+			function, line);
 #endif
 }
 


### PR DESCRIPTION
Add a command line option to allow selecting a build variant
(debug, release, releaseassert, releasedebuginfo). If no variant
is selected, default to release.

Also two small fixes to compilation errors in code guarded by
DISPATCH_DEBUG to allow the debug and releaseassert variants
to build successfully.