### PR TITLE
leverage of new kevent timer granularity functionality

### DIFF
--- a/src/shims/linux_stubs.h
+++ b/src/shims/linux_stubs.h
@@ -82,10 +82,13 @@ typedef void (*dispatch_mach_msg_destructor_t)(void*);
 
 #define IGNORE_KEVENT64_EXT   /* will force the kevent64_s.ext[] to not be used -> leeway ignored */
 
+#ifndef NOTE_SECONDS
 #define NOTE_SECONDS	0x01
 #define NOTE_USECONDS	0x02
 #define NOTE_NSECONDS	0x04
 #define NOTE_ABSOLUTE	0x08
+#define KEVENT_NSEC_NOT_SUPPORTED
+#endif
 #define NOTE_CRITICAL	0x10
 #define NOTE_BACKGROUND	0x20
 #define NOTE_LEEWAY	0x40

--- a/src/source.c
+++ b/src/source.c
@@ -2341,11 +2341,15 @@ _dispatch_kevent_timer_set_delay(_dispatch_kevent_qos_s *ke, uint64_t delay,
 {
 	// call to update nows[]
 	_dispatch_source_timer_now(nows, DISPATCH_TIMER_KIND_WALL);
+#if KEVENT_NSEC_NOT_SUPPORTED
 	// adjust nsec based delay to msec based and ignore leeway
 	delay /= 1000000L;
 	if ((int64_t)(delay) <= 0) {
 		delay = 1; // if value <= 0 the dispatch will stop
 	}
+#else
+	ke->fflags |= NOTE_NSECONDS;
+#endif
 	ke->data = (int64_t)delay;
 }
 


### PR DESCRIPTION
This modification takes advantage of the kevent timer granularity extension 
https://github.com/mheily/libkqueue/pull/14 , that was already merged.
This fixes some of the timer resolution and performance issues.