### PR TITLE
fix compilation error when building against old libkqueue

### DIFF
--- a/src/source.c
+++ b/src/source.c
@@ -2341,7 +2341,7 @@ _dispatch_kevent_timer_set_delay(_dispatch_kevent_qos_s *ke, uint64_t delay,
 {
 	// call to update nows[]
 	_dispatch_source_timer_now(nows, DISPATCH_TIMER_KIND_WALL);
-#if KEVENT_NSEC_NOT_SUPPORTED
+#ifdef KEVENT_NSEC_NOT_SUPPORTED
 	// adjust nsec based delay to msec based and ignore leeway
 	delay /= 1000000L;
 	if ((int64_t)(delay) <= 0) {


### PR DESCRIPTION
Should have used an ifdef instead of an if to guard this block
of code.  Fixes compilation on linux when using an older version
of libkqueue that doesn't include the nsec kevent support.