### PR TITLE
Move dispatch_concur and dispatch_readsync to the XFAIL list

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,7 +38,6 @@ TESTS=							\
 	dispatch_plusplus			\
 	dispatch_priority			\
 	dispatch_priority2			\
-	dispatch_concur				\
 	dispatch_context_for_key	\
 	dispatch_read				\
 	dispatch_read2				\
@@ -54,7 +53,6 @@ TESTS=							\
 	dispatch_starfish			\
 	dispatch_cascade			\
 	dispatch_drift				\
-	dispatch_readsync			\
 	dispatch_data				\
 	dispatch_io					\
 	dispatch_io_net				\
@@ -62,7 +60,9 @@ TESTS=							\
 
 # List tests that are expected to fail here.
 # Currently dispatch_concur fails occasionally, but passes more often than fails. 
-XFAIL_TESTS =
+XFAIL_TESTS =					\
+	dispatch_concur				\
+	dispatch_readsync
 
 ORIGINAL_LIST_OF_TESTS=			\
 	dispatch_apply				\


### PR DESCRIPTION
Move the following tests to the XFAIL list as they fail in the Swift CI environment:
- `dispatch_concur`: fails every time
- `dispatch_readsync`: fails around 50% of the time

The failures can be recreated on a sufficiently large (24 CPU+) machine locally, so we can debug offline and re-enable the tests once we've either fixed the test or an underlying issue in dispatch/kqueue/pwq

Disabling the tests should allows us to get the CI environment running clean, and moving towards enabling higher level testing by integrating into Foundation.

Note that `dispatch_concur` still fails for me locally with PR #117 applied, although that patch certainly causes many less components of the test to fail.