### PR TITLE
adjust dispatch_timer_short to control testing time

### DIFF
--- a/tests/dispatch_timer_short.c
+++ b/tests/dispatch_timer_short.c
@@ -36,7 +36,7 @@
 #define delay (1ull * NSEC_PER_SEC)
 #define interval (5ull * NSEC_PER_USEC)
 
-#define N 100000
+#define N 25000
 
 static dispatch_source_t t[N];
 static dispatch_queue_t q;


### PR DESCRIPTION
Reduce N (number of suspended timers) from 100000 to 25000
to make it suitable for running in CI environment.
Test case execution time on Linux appears to be roughly quadratic
in N.  Setting N to 25000 yields a test that runs in about 30
seconds; at 100000 the test takes around 15 minutes to run.

Profiling says that 99% of test execution is spent in
_dispatch_timers_update.