### PR TITLE
Update for SE-0107: Migrate Void->Raw.

### DIFF
--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -76,7 +76,7 @@ public struct DispatchData : RandomAccessCollection {
 	public func withUnsafeBytes<Result, ContentType>(
 		body: @noescape (UnsafePointer<ContentType>) throws -> Result) rethrows -> Result
 	{
-		var ptr: UnsafePointer<Void>? = nil
+		var ptr: UnsafeRawPointer? = nil
 		var size = 0;
 		let data = CDispatch.dispatch_data_create_map(__wrapped.__wrapped, &ptr, &size)
 		defer { _fixLifetime(data) }
@@ -86,7 +86,7 @@ public struct DispatchData : RandomAccessCollection {
 	public func enumerateBytes(
 		block: @noescape (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Int, stop: inout Bool) -> Void) 
 	{
-		_swift_dispatch_data_apply(__wrapped.__wrapped) { (data: dispatch_data_t, offset: Int, ptr: UnsafePointer<Void>, size: Int) in
+		_swift_dispatch_data_apply(__wrapped.__wrapped) { (data: dispatch_data_t, offset: Int, ptr: UnsafeRawPointer, size: Int) in
 			let bp = UnsafeBufferPointer(start: UnsafePointer<UInt8>(ptr), count: size)
 			var stop = false
 			block(buffer: bp, byteIndex: offset, stop: &stop)
@@ -120,7 +120,7 @@ public struct DispatchData : RandomAccessCollection {
 
 	private func _copyBytesHelper(to pointer: UnsafeMutablePointer<UInt8>, from range: CountableRange<Index>) {
 		var copiedCount = 0
-		_ = CDispatch.dispatch_data_apply(__wrapped.__wrapped) { (data: dispatch_data_t, offset: Int, ptr: UnsafePointer<Void>, size: Int) in
+		_ = CDispatch.dispatch_data_apply(__wrapped.__wrapped) { (data: dispatch_data_t, offset: Int, ptr: UnsafeRawPointer, size: Int) in
 			let limit = Swift.min((range.endIndex - range.startIndex) - copiedCount, size)
 			memcpy(pointer + copiedCount, ptr, limit)
 			copiedCount += limit
@@ -183,7 +183,7 @@ public struct DispatchData : RandomAccessCollection {
 		var offset = 0
 		let subdata = CDispatch.dispatch_data_copy_region(__wrapped.__wrapped, index, &offset)
 
-		var ptr: UnsafePointer<Void>? = nil
+		var ptr: UnsafeRawPointer? = nil
 		var size = 0
 		let map = CDispatch.dispatch_data_create_map(subdata, &ptr, &size)
 		defer { _fixLifetime(map) }
@@ -239,7 +239,7 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 
 	/// Create an iterator over the given DisaptchData
 	public init(_data: DispatchData) {
-		var ptr: UnsafePointer<Void>?
+		var ptr: UnsafeRawPointer?
 		self._count = 0
 		self._data = __DispatchData(data: CDispatch.dispatch_data_create_map(_data.__wrapped.__wrapped, &ptr, &self._count))
 		self._ptr = UnsafePointer(ptr)
@@ -264,7 +264,7 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 	internal var _position: DispatchData.Index
 }
 
-typealias _swift_data_applier = @convention(block) @noescape (dispatch_data_t, Int, UnsafePointer<Void>, Int) -> Bool
+typealias _swift_data_applier = @convention(block) @noescape (dispatch_data_t, Int, UnsafeRawPointer, Int) -> Bool
 
 @_silgen_name("_swift_dispatch_data_apply")
 internal func _swift_dispatch_data_apply(_ data: dispatch_data_t, _ block: _swift_data_applier)

--- a/src/swift/Private.swift
+++ b/src/swift/Private.swift
@@ -69,7 +69,7 @@ func dispatch_write(_ fd: Int32, _ data: dispatch_data_t, _ queue: DispatchQueue
 }
 
 @available(*, unavailable, renamed:"DispatchData.init(bytes:)")
-public func dispatch_data_create(_ buffer: UnsafePointer<Void>, _ size: Int, _ queue: DispatchQueue?, _ destructor: (() -> Void)?) -> dispatch_data_t
+public func dispatch_data_create(_ buffer: UnsafeRawPointer, _ size: Int, _ queue: DispatchQueue?, _ destructor: (() -> Void)?) -> dispatch_data_t
 {
 	fatalError()
 }
@@ -81,7 +81,7 @@ public func dispatch_data_get_size(_ data: dispatch_data_t) -> Int
 }
 
 @available(*, unavailable, renamed:"DispatchData.withUnsafeBytes(self:body:)")
-public func dispatch_data_create_map(_ data: dispatch_data_t, _ buffer_ptr: UnsafeMutablePointer<UnsafePointer<Void>?>?, _ size_ptr: UnsafeMutablePointer<Int>?) -> dispatch_data_t
+public func dispatch_data_create_map(_ data: dispatch_data_t, _ buffer_ptr: UnsafeMutablePointer<UnsafeRawPointer?>?, _ size_ptr: UnsafeMutablePointer<Int>?) -> dispatch_data_t
 {
 	fatalError()
 }
@@ -99,7 +99,7 @@ public func dispatch_data_create_subrange(_ data: dispatch_data_t, _ offset: Int
 }
 
 @available(*, unavailable, renamed:"DispatchData.enumerateBytes(self:block:)")
-public func dispatch_data_apply(_ data: dispatch_data_t, _ applier: (dispatch_data_t, Int, UnsafePointer<Void>, Int) -> Bool) -> Bool
+public func dispatch_data_apply(_ data: dispatch_data_t, _ applier: (dispatch_data_t, Int, UnsafeRawPointer, Int) -> Bool) -> Bool
 {
 	fatalError()
 }
@@ -213,19 +213,19 @@ public func dispatch_barrier_sync(_ queue: DispatchQueue, _ block: @noescape () 
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.setSpecific(self:key:value:)")
-public func dispatch_queue_set_specific(_ queue: DispatchQueue, _ key: UnsafePointer<Void>, _ context: UnsafeMutablePointer<Void>?, _ destructor: (@convention(c) (UnsafeMutablePointer<Void>?) -> Void)?)
+public func dispatch_queue_set_specific(_ queue: DispatchQueue, _ key: UnsafeRawPointer, _ context: UnsafeMutableRawPointer?, _ destructor: (@convention(c) (UnsafeMutableRawPointer?) -> Void)?)
 {
 	fatalError()
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.getSpecific(self:key:)")
-public func dispatch_queue_get_specific(_ queue: DispatchQueue, _ key: UnsafePointer<Void>) -> UnsafeMutablePointer<Void>?
+public func dispatch_queue_get_specific(_ queue: DispatchQueue, _ key: UnsafeRawPointer) -> UnsafeMutableRawPointer?
 {
 	fatalError()
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.getSpecific(key:)")
-public func dispatch_get_specific(_ key: UnsafePointer<Void>) -> UnsafeMutablePointer<Void>?
+public func dispatch_get_specific(_ key: UnsafeRawPointer) -> UnsafeMutableRawPointer?
 {
 	fatalError()
 }

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -402,7 +402,7 @@ extension DispatchQueue {
 	}
 }
 
-private func _destructDispatchSpecificValue(ptr: UnsafeMutablePointer<Void>?) {
+private func _destructDispatchSpecificValue(ptr: UnsafeMutableRawPointer?) {
 	if let p = ptr {
 		Unmanaged<AnyObject>.fromOpaque(p).release()
 	}


### PR DESCRIPTION
Unsafe[Mutable]Pointer<Void> is replaced by Unsafe[Mutable]RawPointer.

Migrating often means simply removing casts to/from UnsafePointer<UInt8>
and working directly with UnsafeRawPointer instead.

Unfortunately some API's, like NSData still want UnsafePointer<UInt8>,
which requires "binding" memory to UInt8 before passing it to the API.