### PR TITLE
[Data] Fixed crash when getting pointer to empty DispatchData

### DIFF
--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -187,7 +187,7 @@ public struct DispatchData : RandomAccessCollection {
 		return copyRange.count
 	}
 
-	/// Sets or returns the byte at the specified index.
+	/// Returns the byte at the specified index.
 	public subscript(index: Index) -> UInt8 {
 		var offset = 0
 		let subdata = CDispatch.dispatch_data_copy_region(__wrapped.__wrapped, index, &offset)

--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -74,12 +74,13 @@ public struct DispatchData : RandomAccessCollection {
 	}
 
 	public func withUnsafeBytes<Result, ContentType>(
-		body: (UnsafePointer<ContentType>) throws -> Result) rethrows -> Result
+		body: (UnsafePointer<ContentType>?) throws -> Result) rethrows -> Result
 	{
 		var ptr: UnsafeRawPointer? = nil
 		var size = 0
 		let data = CDispatch.dispatch_data_create_map(__wrapped.__wrapped, &ptr, &size)
-		let contentPtr = ptr!.bindMemory(
+		assert(ptr != nil || self.isEmpty)
+		let contentPtr = ptr?.bindMemory(
 			to: ContentType.self, capacity: size / MemoryLayout<ContentType>.stride)
 		defer { _fixLifetime(data) }
 		return try body(contentPtr)


### PR DESCRIPTION
- corrected comment for read-only subscript
