### PR TITLE
fix issues preventing overlay from compiling due to SE-0025

### DIFF
--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -35,7 +35,7 @@ public struct DispatchData : RandomAccessCollection {
 		//        which is only made available on platforms with Objective-C.
 		case custom(DispatchQueue?, () -> Void)
 
-		private var _deallocator: (DispatchQueue?, @convention(block) () -> Void) {
+		fileprivate var _deallocator: (DispatchQueue?, @convention(block) () -> Void) {
 			switch self {
 			case .free: return (nil, _dispatch_data_destructor_free())
 			case .unmap: return (nil, _dispatch_data_destructor_munmap())

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -32,7 +32,7 @@ public struct DispatchQueueAttributes : OptionSet {
 	public static let serial = DispatchQueueAttributes(rawValue: 1<<0)
 	public static let concurrent = DispatchQueueAttributes(rawValue: 1<<1)
 
-	private var _translatedValue: DispatchQueue.Attributes {
+	fileprivate var _translatedValue: DispatchQueue.Attributes {
 		if self.contains(.concurrent) { return .concurrent }
 		return []
 	}
@@ -48,7 +48,7 @@ public extension DispatchQueue {
 		@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 		public static let initiallyInactive = Attributes(rawValue: 1<<2)
 
-		private func _attr() -> dispatch_queue_attr_t? {
+		fileprivate func _attr() -> dispatch_queue_attr_t? {
 			var attr: dispatch_queue_attr_t? = nil
 
 			if self.contains(.concurrent) {
@@ -95,7 +95,7 @@ public extension DispatchQueue {
 	public enum GlobalQueueDeprecatedPriority {
 		case qosBackground
 
-		private var _translatedValue: DispatchQoS.QoSClass {
+		fileprivate var _translatedValue: DispatchQoS.QoSClass {
 			switch self {
 			case .qosBackground: return .background
 			}

--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -26,7 +26,7 @@ public struct DispatchTime : Comparable {
 
 	public static let distantFuture = DispatchTime(rawValue: ~0)
 
-	private init(rawValue: dispatch_time_t) { 
+	fileprivate init(rawValue: dispatch_time_t) { 
 		self.rawValue = rawValue
 	}
 
@@ -64,7 +64,7 @@ public struct DispatchWallTime : Comparable {
 
 	public static let distantFuture = DispatchWallTime(rawValue: ~0)
 
-	private init(rawValue: dispatch_time_t) {
+	fileprivate init(rawValue: dispatch_time_t) {
 		self.rawValue = rawValue
 	}
 


### PR DESCRIPTION
Without this change, the overlay fails to compile when running Swift's `utils/build-script --libdispatch` as of apple/swift@805e06e, which landed earlier today.