### PR TITLE
[SE-0101] Migration

### DIFF
--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -118,7 +118,7 @@ public struct DispatchData : RandomAccessCollection {
 	///
 	/// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
 	public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-		self.append(UnsafePointer(buffer.baseAddress!), count: buffer.count * MemoryLayout<SourceType>.size)
+		self.append(UnsafePointer(buffer.baseAddress!), count: buffer.count * MemoryLayout<SourceType>.stride)
 	}
 
 	private func _copyBytesHelper(to pointer: UnsafeMutablePointer<UInt8>, from range: CountableRange<Index>) {
@@ -169,9 +169,9 @@ public struct DispatchData : RandomAccessCollection {
 			precondition(r.endIndex >= 0)
 			precondition(r.endIndex <= cnt, "The range is outside the bounds of the data")
 			
-			copyRange = r.startIndex..<(r.startIndex + Swift.min(buffer.count * MemoryLayout<DestinationType>.size, r.count))
+			copyRange = r.startIndex..<(r.startIndex + Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, r.count))
 		} else {
-			copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.size, cnt)
+			copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.stride, cnt)
 		}
 		
 		guard !copyRange.isEmpty else { return 0 }

--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -80,7 +80,7 @@ public struct DispatchData : RandomAccessCollection {
 		var size = 0
 		let data = CDispatch.dispatch_data_create_map(__wrapped.__wrapped, &ptr, &size)
 		let contentPtr = ptr!.bindMemory(
-			to: ContentType.self, capacity: size / strideof(ContentType.self))
+			to: ContentType.self, capacity: size / MemoryLayout<ContentType>.stride)
 		defer { _fixLifetime(data) }
 		return try body(contentPtr)
 	}
@@ -118,7 +118,7 @@ public struct DispatchData : RandomAccessCollection {
 	///
 	/// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
 	public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-		self.append(UnsafePointer(buffer.baseAddress!), count: buffer.count * sizeof(SourceType.self))
+		self.append(UnsafePointer(buffer.baseAddress!), count: buffer.count * MemoryLayout<SourceType>.size)
 	}
 
 	private func _copyBytesHelper(to pointer: UnsafeMutablePointer<UInt8>, from range: CountableRange<Index>) {
@@ -151,7 +151,7 @@ public struct DispatchData : RandomAccessCollection {
 	
 	/// Copy the contents of the data into a buffer.
 	///
-	/// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `sizeof(DestinationType) * buffer.count` then the first N bytes will be copied into the buffer.
+	/// This function copies the bytes in `range` from the data into the buffer. If the count of the `range` is greater than `MemoryLayout<DestinationType>.size * buffer.count` then the first N bytes will be copied into the buffer.
 	/// - precondition: The range must be within the bounds of the data. Otherwise `fatalError` is called.
 	/// - parameter buffer: A buffer to copy the data into.
 	/// - parameter range: A range in the data to copy into the buffer. If the range is empty, this function will return 0 without copying anything. If the range is nil, as much data as will fit into `buffer` is copied.
@@ -169,9 +169,9 @@ public struct DispatchData : RandomAccessCollection {
 			precondition(r.endIndex >= 0)
 			precondition(r.endIndex <= cnt, "The range is outside the bounds of the data")
 			
-			copyRange = r.startIndex..<(r.startIndex + Swift.min(buffer.count * sizeof(DestinationType.self), r.count))
+			copyRange = r.startIndex..<(r.startIndex + Swift.min(buffer.count * MemoryLayout<DestinationType>.size, r.count))
 		} else {
-			copyRange = 0..<Swift.min(buffer.count * sizeof(DestinationType.self), cnt)
+			copyRange = 0..<Swift.min(buffer.count * MemoryLayout<DestinationType>.size, cnt)
 		}
 		
 		guard !copyRange.isEmpty else { return 0 }


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/3854

[SE-0101](https://github.com/apple/swift-evolution/blob/master/proposals/0101-standardizing-sizeof-naming.md) removes `sizeof`, `sizeofValue` and related functions from the stdlib.
This PR is migrating them to newly introduced `MemoryLayout<T>` values.