### PR TITLE
[SE-0103][noescape by default] Migration to @noescape by default feature.

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -41,12 +41,12 @@ public class DispatchWorkItem {
 
 	// Temporary for swift-corelibs-foundation
 	@available(*, deprecated, renamed: "DispatchWorkItem(qos:flags:block:)")
-	public convenience init(group: DispatchGroup, qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @convention(block) () -> ()) {
+	public convenience init(group: DispatchGroup, qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
 		self.init(qos: qos, flags: flags, block: block)
 
 	}
 
-	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @convention(block) () -> ()) {
+	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
 		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(flags.rawValue),
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
@@ -77,7 +77,7 @@ public class DispatchWorkItem {
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
 		queue: DispatchQueue, 
-		execute: @convention(block) () -> Void) 
+		execute: @escaping @convention(block) () -> ()) 
 	{
 		if qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: execute)

--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -134,7 +134,7 @@ public enum DispatchTimeoutResult {
 /// dispatch_group
 
 public extension DispatchGroup {
-	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @convention(block) () -> ()) {
+	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> ()) {
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
 			dispatch_group_notify(self.__wrapped, queue.__wrapped, item._block)

--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -50,7 +50,7 @@ public extension DispatchIO {
 		type: StreamType,
 		fileDescriptor: Int32,
 		queue: DispatchQueue,
-		cleanupHandler: (_ error: Int32) -> Void)
+		cleanupHandler: @escaping (_ error: Int32) -> Void)
 	{
 		self.init(__type: type.rawValue, fd: fileDescriptor, queue: queue, handler: cleanupHandler)
 	}
@@ -61,7 +61,7 @@ public extension DispatchIO {
 		oflag: Int32,
 		mode: mode_t,
 		queue: DispatchQueue,
-		cleanupHandler: (_ error: Int32) -> Void)
+		cleanupHandler: @escaping (_ error: Int32) -> Void)
 	{
 		self.init(__type: type.rawValue, path: path, oflag: oflag, mode: mode, queue: queue, handler: cleanupHandler)
 	}
@@ -70,7 +70,7 @@ public extension DispatchIO {
 		type: StreamType,
 		io: DispatchIO,
 		queue: DispatchQueue,
-		cleanupHandler: (_ error: Int32) -> Void)
+		cleanupHandler: @escaping (_ error: Int32) -> Void)
 	{
 		self.init(__type: type.rawValue, io: io, queue: queue, handler: cleanupHandler)
 	}

--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -34,13 +34,13 @@ public extension DispatchIO {
 		public static let strictInterval = IntervalFlags(rawValue: 1)
 	}
 
-	public class func read(fromFileDescriptor: Int32, maxLength: Int, runningHandlerOn queue: DispatchQueue, handler: (_ data: DispatchData, _ error: Int32) -> Void) {
+	public class func read(fromFileDescriptor: Int32, maxLength: Int, runningHandlerOn queue: DispatchQueue, handler: @escaping (_ data: DispatchData, _ error: Int32) -> Void) {
 		dispatch_read(fromFileDescriptor, maxLength, queue.__wrapped) { (data: dispatch_data_t, error: Int32) in
 			handler(DispatchData(data: data), error)
 		}
 	}
 
-	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: (_ data: DispatchData?, _ error: Int32) -> Void) {
+	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: @escaping (_ data: DispatchData?, _ error: Int32) -> Void) {
 		dispatch_write(toFileDescriptor, data.__wrapped.__wrapped, queue.__wrapped) { (data: dispatch_data_t?, error: Int32) in
 			handler(data.flatMap { DispatchData(data: $0) }, error)
 		}
@@ -75,13 +75,13 @@ public extension DispatchIO {
 		self.init(__type: type.rawValue, io: io, queue: queue, handler: cleanupHandler)
 	}
 
-	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
+	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
 		dispatch_io_read(self.__wrapped, offset, length, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
 			ioHandler(done, data.flatMap { DispatchData(data: $0) }, error)
 		}
 	}
 
-	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
+	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
 		dispatch_io_write(self.__wrapped, offset, data.__wrapped.__wrapped, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
 			ioHandler(done, data.flatMap { DispatchData(data: $0) }, error)
 		}

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -221,7 +221,7 @@ public extension DispatchQueue {
 		group: DispatchGroup? = nil, 
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
-		execute work: @convention(block) () -> Void) 
+		execute work: @escaping @convention(block) () -> Void) 
 	{
 		if group == nil && qos == .unspecified && flags.isEmpty {
 			// Fast-path route for the most common API usage
@@ -229,7 +229,7 @@ public extension DispatchQueue {
 			return
 		}
 
-		var block: @convention(block) () -> Void = work
+		var block: @escaping @convention(block) () -> Void = work
 		if #available(OSX 10.10, iOS 8.0, *), (qos != .unspecified || !flags.isEmpty) {
 			let workItem = DispatchWorkItem(qos: qos, flags: flags, block: work)
 			block = workItem._block
@@ -309,7 +309,7 @@ public extension DispatchQueue {
 		deadline: DispatchTime, 
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
-		execute work: @convention(block) () -> Void) 
+		execute work: @escaping @convention(block) () -> Void) 
 	{
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
@@ -323,7 +323,7 @@ public extension DispatchQueue {
 		wallDeadline: DispatchWallTime,
 		qos: DispatchQoS = .unspecified, 
 		flags: DispatchWorkItemFlags = [], 
-		execute work: @convention(block) () -> Void) 
+		execute work: @escaping @convention(block) () -> Void) 
 	{
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -91,17 +91,17 @@ public class DispatchIO : DispatchObject {
 	}
 
 	internal init(__type: UInt, fd: Int32, queue: DispatchQueue,
-				  handler: (_ error: Int32) -> Void) {
+				  handler: @escaping (_ error: Int32) -> Void) {
 		__wrapped = dispatch_io_create(__type, fd, queue.__wrapped, handler)
 	}
 
 	internal init(__type: UInt, path: UnsafePointer<Int8>, oflag: Int32,
-				  mode: mode_t, queue: DispatchQueue, handler: (_ error: Int32) -> Void) {
+				  mode: mode_t, queue: DispatchQueue, handler: @escaping (_ error: Int32) -> Void) {
 		__wrapped = dispatch_io_create_with_path(__type, path, oflag, mode, queue.__wrapped, handler)
 	}
 
 	internal init(__type: UInt, io: DispatchIO,
-				  queue: DispatchQueue, handler: (_ error: Int32) -> Void) {
+				  queue: DispatchQueue, handler: @escaping (_ error: Int32) -> Void) {
 		__wrapped = dispatch_io_create_with_io(__type, io.__wrapped, queue.__wrapped, handler)
 	}
 
@@ -113,7 +113,7 @@ public class DispatchIO : DispatchObject {
 		_swift_dispatch_release(wrapped())
 	}
 
-	public func barrier(execute: () -> ()) {
+	public func barrier(execute: @escaping () -> ()) {
 		dispatch_io_barrier(self.__wrapped, execute)
 	}
 


### PR DESCRIPTION
[SE-0103][1] makes `@noescape` the default annotation for blocks, adding the `@escaping` annotation in return to specify the opposite behaviour.

This changeset adds the annotation as it was required by the compiler.

[1]: https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md