### PR TITLE
Use shims for all calls to Dispatch APIs that take blocks

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -47,7 +47,7 @@ public class DispatchWorkItem {
 	}
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(flags.rawValue),
+		_block = _swift_dispatch_block_create_with_qos_class(dispatch_block_flags_t(flags.rawValue),
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
 
@@ -106,6 +106,9 @@ public class DispatchWorkItem {
 /// on the referential identity of a block. Particularly, dispatch_block_create.
 internal typealias _DispatchBlock = @convention(block) () -> Void
 internal typealias dispatch_block_t = @convention(block) () -> Void
+
+@_silgen_name("_swift_dispatch_block_create_with_qos_class")
+internal func _swift_dispatch_block_create_with_qos_class(_ flags: dispatch_block_flags_t, _ qos: dispatch_qos_class_t, _ relativePriority: Int32, _ block: () -> Void) -> _DispatchBlock
 
 @_silgen_name("_swift_dispatch_block_create_noescape")
 internal func _swift_dispatch_block_create_noescape(_ flags: dispatch_block_flags_t, _ block: @noescape () -> ()) -> _DispatchBlock

--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -137,15 +137,15 @@ public extension DispatchGroup {
 	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> ()) {
 		if #available(OSX 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
-			dispatch_group_notify(self.__wrapped, queue.__wrapped, item._block)
+			_swift_dispatch_group_notify(self.__wrapped, queue.__wrapped, item._block)
 		} else {
-			dispatch_group_notify(self.__wrapped, queue.__wrapped, work)
+			_swift_dispatch_group_notify(self.__wrapped, queue.__wrapped, work)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func notify(queue: DispatchQueue, work: DispatchWorkItem) {
-		dispatch_group_notify(self.__wrapped, queue.__wrapped, work._block)
+		_swift_dispatch_group_notify(self.__wrapped, queue.__wrapped, work._block)
 	}
 
 	public func wait() {
@@ -181,3 +181,6 @@ public extension DispatchSemaphore {
 		return dispatch_semaphore_wait(self.__wrapped, wallTimeout.rawValue) == 0 ? .success : .timedOut
 	}
 }
+
+@_silgen_name("_swift_dispatch_group_notify")
+internal func _swift_dispatch_group_notify(_ group: dispatch_group_t, _ queue: dispatch_queue_t, _ block: @convention(block) () -> Void)

--- a/src/swift/DispatchStubs.cc
+++ b/src/swift/DispatchStubs.cc
@@ -155,8 +155,20 @@ _swift_dispatch_async(dispatch_queue_t queue, dispatch_block_t block) {
 
 SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
 extern "C" void
+_swift_dispatch_barrier_async(dispatch_queue_t queue, dispatch_block_t block) {
+  dispatch_barrier_async(queue, block);
+}
+
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
 _swift_dispatch_group_async(dispatch_group_t group, dispatch_queue_t queue, dispatch_block_t block) {
   dispatch_group_async(group, queue, block);
+}
+
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
+_swift_dispatch_group_notify(dispatch_group_t group, dispatch_queue_t queue, dispatch_block_t block) {
+  dispatch_group_notify(group, queue, block);
 }
 
 SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
@@ -167,8 +179,32 @@ _swift_dispatch_sync(dispatch_queue_t queue, dispatch_block_t block) {
 
 SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
 extern "C" void
+_swift_dispatch_after(dispatch_time_t when, dispatch_queue_t queue, dispatch_block_t block) {
+  dispatch_after(when, queue, block);
+}
+
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
 _swift_dispatch_release(dispatch_object_t obj) {
   dispatch_release(obj);
+}
+
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
+_swift_dispatch_source_set_event_handler(dispatch_source_t source, dispatch_block_t block) {
+  dispatch_source_set_event_handler(source, block);
+}
+
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
+_swift_dispatch_source_set_cancel_handler(dispatch_source_t source, dispatch_block_t block) {
+  dispatch_source_set_cancel_handler(source, block);
+}
+
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
+_swift_dispatch_source_set_registration_handler(dispatch_source_t source, dispatch_block_t block) {
+  dispatch_source_set_registration_handler(source, block);
 }
 
 // DISPATCH_RUNTIME_STDLIB_INTERFACE

--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -17,43 +17,43 @@ public extension DispatchSourceProtocol {
 	public func setEventHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
 		if #available(OSX 10.10, iOS 8.0, *), let h = handler, qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: h)
-			CDispatch.dispatch_source_set_event_handler((self as! DispatchSource).__wrapped, item._block)
+			_swift_dispatch_source_set_event_handler((self as! DispatchSource).__wrapped, item._block)
 		} else {
-			CDispatch.dispatch_source_set_event_handler((self as! DispatchSource).__wrapped, handler)
+			_swift_dispatch_source_set_event_handler((self as! DispatchSource).__wrapped, handler)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func setEventHandler(handler: DispatchWorkItem) {
-		CDispatch.dispatch_source_set_event_handler((self as! DispatchSource).__wrapped, handler._block)
+		_swift_dispatch_source_set_event_handler((self as! DispatchSource).__wrapped, handler._block)
 	}
 
 	public func setCancelHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
 		if #available(OSX 10.10, iOS 8.0, *), let h = handler, qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: h)
-			CDispatch.dispatch_source_set_cancel_handler((self as! DispatchSource).__wrapped, item._block)
+			_swift_dispatch_source_set_cancel_handler((self as! DispatchSource).__wrapped, item._block)
 		} else {
-			CDispatch.dispatch_source_set_cancel_handler((self as! DispatchSource).__wrapped, handler)
+			_swift_dispatch_source_set_cancel_handler((self as! DispatchSource).__wrapped, handler)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func setCancelHandler(handler: DispatchWorkItem) {
-		CDispatch.dispatch_source_set_cancel_handler((self as! DispatchSource).__wrapped, handler._block)
+		_swift_dispatch_source_set_cancel_handler((self as! DispatchSource).__wrapped, handler._block)
 	}
 
 	public func setRegistrationHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
 		if #available(OSX 10.10, iOS 8.0, *), let h = handler, qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: h)
-			CDispatch.dispatch_source_set_registration_handler((self as! DispatchSource).__wrapped, item._block)
+			_swift_dispatch_source_set_registration_handler((self as! DispatchSource).__wrapped, item._block)
 		} else {
-			CDispatch.dispatch_source_set_registration_handler((self as! DispatchSource).__wrapped, handler)
+			_swift_dispatch_source_set_registration_handler((self as! DispatchSource).__wrapped, handler)
 		}
 	}
 
 	@available(OSX 10.10, iOS 8.0, *)
 	public func setRegistrationHandler(handler: DispatchWorkItem) {
-		CDispatch.dispatch_source_set_registration_handler((self as! DispatchSource).__wrapped, handler._block)
+		_swift_dispatch_source_set_registration_handler((self as! DispatchSource).__wrapped, handler._block)
 	}
 
 	@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
@@ -350,6 +350,15 @@ public extension DispatchSourceUserDataOr {
 		dispatch_source_merge_data((self as! DispatchSource).__wrapped, data)
 	}
 }
+
+@_silgen_name("_swift_dispatch_source_set_event_handler")
+internal func _swift_dispatch_source_set_event_handler(_ source: dispatch_source_t, _ block: (@convention(block) () -> Void)?)
+
+@_silgen_name("_swift_dispatch_source_set_cancel_handler")
+internal func _swift_dispatch_source_set_cancel_handler(_ source: dispatch_source_t, _ block: (@convention(block) () -> Void)?)
+
+@_silgen_name("_swift_dispatch_source_set_registration_handler")
+internal func _swift_dispatch_source_set_registration_handler(_ source: dispatch_source_t, _ block: (@convention(block) () -> Void)?)
 
 @_silgen_name("_swift_dispatch_source_type_DATA_ADD")
 internal func _swift_dispatch_source_type_data_add() -> dispatch_source_type_t


### PR DESCRIPTION
This preserves referential integrity for blocks that were created via
the `dispatch_block_create*` functions which, among other things,
ensures barrier blocks work correctly.

Also add a fast path for barrier blocks to async.

This is a port of apple/swift#3923, though the shims are done a bit differently. I also don't know how to confirm that it actually works, since I don't know how to go about testing swift-corelibs-libdispatch (I just barely figured out how to compile it on my Linode), but I did confirm that it at least compiles.