### PR TITLE
fixes for swiftc compiler warnings

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -53,7 +53,7 @@ public class DispatchWorkItem {
 
 	// Used by DispatchQueue.synchronously<T> to provide a @noescape path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
-	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: @noescape () -> ()) {
+	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
 		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(flags.rawValue), noescapeBlock)
 	}
 
@@ -108,4 +108,4 @@ internal typealias _DispatchBlock = @convention(block) () -> Void
 internal typealias dispatch_block_t = @convention(block) () -> Void
 
 @_silgen_name("_swift_dispatch_block_create_noescape")
-internal func _swift_dispatch_block_create_noescape(_ flags: dispatch_block_flags_t, _ block: @noescape () -> ()) -> _DispatchBlock
+internal func _swift_dispatch_block_create_noescape(_ flags: dispatch_block_flags_t, _ block: () -> ()) -> _DispatchBlock

--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -74,7 +74,7 @@ public struct DispatchData : RandomAccessCollection {
 	}
 
 	public func withUnsafeBytes<Result, ContentType>(
-		body: @noescape (UnsafePointer<ContentType>) throws -> Result) rethrows -> Result
+		body: (UnsafePointer<ContentType>) throws -> Result) rethrows -> Result
 	{
 		var ptr: UnsafeRawPointer? = nil
 		var size = 0
@@ -86,7 +86,7 @@ public struct DispatchData : RandomAccessCollection {
 	}
 
 	public func enumerateBytes(
-		block: @noescape (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Int, _ stop: inout Bool) -> Void) 
+		block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Int, _ stop: inout Bool) -> Void)
 	{
 		_swift_dispatch_data_apply(__wrapped.__wrapped) { (data: dispatch_data_t, offset: Int, ptr: UnsafeRawPointer, size: Int) in
 			let bytePtr = ptr.bindMemory(to: UInt8.self, capacity: size)

--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -96,7 +96,6 @@ public struct DispatchQoS : Equatable {
 			case .QOS_CLASS_USER_INITIATED: self = .userInitiated
 			case .QOS_CLASS_USER_INTERACTIVE: self = .userInteractive
 			case .QOS_CLASS_UNSPECIFIED: self = .unspecified
-			default: return nil
 			}
 		}
 

--- a/src/swift/Private.swift
+++ b/src/swift/Private.swift
@@ -141,7 +141,7 @@ public func dispatch_io_set_interval(_ channel: DispatchIO, _ interval: UInt64, 
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.apply(attributes:iterations:execute:)")
-public func dispatch_apply(_ iterations: Int, _ queue: DispatchQueue, _ block: @noescape (Int) -> Void) 
+public func dispatch_apply(_ iterations: Int, _ queue: DispatchQueue, _ block: (Int) -> Void)
 {
 	fatalError()
 }
@@ -207,7 +207,7 @@ public func dispatch_barrier_async(_ queue: DispatchQueue, _ block: () -> Void)
 }
 
 @available(*, unavailable, renamed:"DispatchQueue.synchronously(self:flags:execute:)")
-public func dispatch_barrier_sync(_ queue: DispatchQueue, _ block: @noescape () -> Void)
+public func dispatch_barrier_sync(_ queue: DispatchQueue, _ block: () -> Void)
 {
 	fatalError()
 }

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -130,7 +130,7 @@ public extension DispatchQueue {
 		}
 	}
 
-	public class func concurrentPerform(iterations: Int, execute work: @noescape (Int) -> Void) {
+	public class func concurrentPerform(iterations: Int, execute work: (Int) -> Void) {
 		_swift_dispatch_apply_current(iterations, work)
 	}
 
@@ -242,13 +242,13 @@ public extension DispatchQueue {
 		}
 	}
 
-	private func _syncBarrier(block: @noescape () -> ()) {
+	private func _syncBarrier(block: () -> ()) {
 		CDispatch.dispatch_barrier_sync(self.__wrapped, block)
 	}
 
 	private func _syncHelper<T>(
-		fn: (@noescape () -> ()) -> (), 
-		execute work: @noescape () throws -> T, 
+		fn: (() -> ()) -> (), 
+		execute work: () throws -> T, 
 		rescue: ((Swift.Error) throws -> (T))) rethrows -> T
 	{
 		var result: T?
@@ -271,7 +271,7 @@ public extension DispatchQueue {
 	private func _syncHelper<T>(
 		fn: (DispatchWorkItem) -> (), 
 		flags: DispatchWorkItemFlags,
-		execute work: @noescape () throws -> T,
+		execute work: () throws -> T,
 		rescue: ((Swift.Error) throws -> (T))) rethrows -> T
 	{
 		var result: T?
@@ -291,11 +291,11 @@ public extension DispatchQueue {
 		}
 	}
 
-	public func sync<T>(execute work: @noescape () throws -> T) rethrows -> T {
+	public func sync<T>(execute work: () throws -> T) rethrows -> T {
 		return try self._syncHelper(fn: sync, execute: work, rescue: { throw $0 })
 	}
 
-	public func sync<T>(flags: DispatchWorkItemFlags, execute work: @noescape () throws -> T) rethrows -> T {
+	public func sync<T>(flags: DispatchWorkItemFlags, execute work: () throws -> T) rethrows -> T {
 		if flags == .barrier {
 			return try self._syncHelper(fn: _syncBarrier, execute: work, rescue: { throw $0 })
 		} else if #available(OSX 10.10, iOS 8.0, *), !flags.isEmpty {
@@ -385,4 +385,4 @@ internal func _swift_dispatch_get_main_queue() -> dispatch_queue_t
 internal func _swift_dispatch_apply_current_root_queue() -> dispatch_queue_t
 
 @_silgen_name("_swift_dispatch_apply_current")
-internal func _swift_dispatch_apply_current(_ iterations: Int, _ block: @convention(block) @noescape (Int) -> Void)
+internal func _swift_dispatch_apply_current(_ iterations: Int, _ block: @convention(block) (Int) -> Void)

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -153,7 +153,7 @@ public class DispatchQueue : DispatchObject {
 		_swift_dispatch_release(wrapped())
 	}
 
-	public func sync(execute workItem: @noescape ()->()) {
+	public func sync(execute workItem: ()->()) {
 		dispatch_sync(self.__wrapped, workItem)
 	}
 }


### PR DESCRIPTION
1. @noescape is now the default for blocks (and is deprecated)
2. unreachable default in switch statement