### PR TITLE
bugfix in Linux wrapper: DispatchGroup.leave should call leave, not e…

### DIFF
--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -63,7 +63,7 @@ public class DispatchGroup : DispatchObject {
 	}
 
 	public func leave() {
-		dispatch_group_enter(__wrapped)
+		dispatch_group_leave(__wrapped)
 	}
 }
 


### PR DESCRIPTION
…nter!