### PR TITLE
Fix building on armv7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,12 @@ AC_ARG_WITH([swift-toolchain],
    case $target_os in
       linux*)
 	    os_string="linux"
+	    case $target_cpu in
+		    armv7l*)
+			target_cpu="armv7"
+			;;
+			*)
+            esac
 	    ;;
 	  *)
         os_string=$target_os

--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -49,7 +49,9 @@
 
 #if defined(__linux__) && defined(__has_feature)
 #if __has_feature(modules)
+#if !defined(__arm__)
 #include <stdio.h> // for off_t (to match Glibc.modulemap)
+#endif
 #endif
 #endif
 

--- a/src/io.c
+++ b/src/io.c
@@ -24,6 +24,10 @@
 #define DISPATCH_IO_DEBUG DISPATCH_DEBUG
 #endif
 
+#ifndef PAGE_SIZE
+#define PAGE_SIZE getpagesize()
+#endif
+
 #if DISPATCH_DATA_IS_BRIDGED_TO_NSDATA
 #define _dispatch_io_data_retain(x) _dispatch_objc_retain(x)
 #define _dispatch_io_data_release(x) _dispatch_objc_release(x)


### PR DESCRIPTION
This patch enables compilation from build-script on armv7.  I don't expect this patch to be without controversy; rather I'd like this to be the opening point for some discussion about the specific implementation.

In particular, I'd like to draw attention to this PR at foundation: https://github.com/apple/swift-corelibs-foundation/pull/399/files which addresses val_list in the same way as presented here.

Furthermore, PAGE_SIZE is, for some reason, undefined on ARM.  The definition provided here is an assumption, and kind of a hack.  I'd happy to receive some guidance whether there is a better way to move forward.

Thanks!