### PR TITLE
More changes for SE-0103 (@noescape by default).

### DIFF
--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -235,7 +235,7 @@ public extension DispatchQueue {
 		fn: (DispatchWorkItem) -> (), 
 		flags: DispatchWorkItemFlags,
 		execute work: () throws -> T,
-		rescue: @escaping ((Swift.Error) throws -> (T))) rethrows -> T
+		rescue: ((Swift.Error) throws -> (T))) rethrows -> T
 	{
 		var result: T?
 		var error: Swift.Error?


### PR DESCRIPTION
The following declarations that were `@escaping` (default, actually) before `SE-0103` and that I think they should remain `@escaping`.
- [`dispatch_data_create(…, destructor)`](https://github.com/apple/swift-corelibs-libdispatch/blob/95875d7bed3f66ed8186f9f77bad8ad23f80d152/src/swift/Private.swift#L72) along with [`DispatchData.Deallocator.custom`](https://github.com/apple/swift-corelibs-libdispatch/blob/master/src/swift/Data.swift#L36-L38)
- [`dispatch_queue_set_specific(…, destructor)`](https://github.com/apple/swift-corelibs-libdispatch/blob/master/src/swift/Private.swift#L216) (there's no associated typealias / parameter for this one, it's just being called with [`Queue._destructDispatchSpecificValue`](https://github.com/apple/swift-corelibs-libdispatch/blob/1a7ff3f3e1073eb3352a56ab121ccfa712c42cef/src/swift/Queue.swift#L368-L372) as parameter)

And finally,
- [`dispatch_source_set_event_handler(…, handler)`](https://github.com/apple/swift-corelibs-libdispatch/blob/master/src/swift/Private.swift#L270)
- [`dispatch_source_set_cancel_handler(…, handler)`](https://github.com/apple/swift-corelibs-libdispatch/blob/master/src/swift/Private.swift#L276)
- [`dispatch_source_set_registration_handler(…, handler)`](https://github.com/apple/swift-corelibs-libdispatch/blob/master/src/swift/Private.swift#L324)

along with
- [`DispatchSourceHandler`](https://github.com/apple/swift-corelibs-libdispatch/blob/55261225184e49c6a42c38bbedb144c2610def4a/src/swift/Wrapper.swift#L209)
- [`_DispatchBlock`](https://github.com/apple/swift-corelibs-libdispatch/blob/1a7ff3f3e1073eb3352a56ab121ccfa712c42cef/src/swift/Block.swift#L103)

Finally, the `rescue` parameter in `DispatchQueue._syncHelper` was marked as `@escaping` due to a manual migration, but there's nothing keeping a reference to it.

Please let me know if this patch works for you, or if there's anything that needs to be changed. /cc @slavapestov @dgrove-oss 

Thanks.
