### PR TITLE
Disable drift, pingpong and io tests to clean up Swift CI

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -32,7 +32,10 @@ DISABLED_TESTS=					\
 	dispatch_priority			\
 	dispatch_priority2			\
 	dispatch_read				\
-	dispatch_read2
+	dispatch_read2				\
+	dispatch_pingpong			\
+	dispatch_drift				\
+	dispatch_io
 
 TESTS=							\
 	dispatch_apply				\
@@ -42,7 +45,6 @@ TESTS=							\
 	dispatch_queue_finalizer	\
 	dispatch_group				\
 	dispatch_overcommit			\
-	dispatch_pingpong			\
 	dispatch_plusplus			\
 	dispatch_context_for_key	\
 	dispatch_after				\
@@ -56,9 +58,7 @@ TESTS=							\
 	dispatch_timer_set_time		\
 	dispatch_starfish			\
 	dispatch_cascade			\
-	dispatch_drift				\
 	dispatch_data				\
-	dispatch_io					\
 	dispatch_io_net				\
 	dispatch_select
 


### PR DESCRIPTION
We're still getting some intermitted failures in the Swift CI which we've not been able to recreate locally (on a 38-way machine).

These are in:
* `dispatch_pingpong` - this results in a hang
* `dispatch_drift` - this fails because we exceed the drift threshold

Additionally, `dispatch_io` always fails in the CI builds on Ubuntu 14.04 where it runs out of file descriptors. I've run the tests on Ubuntu 14.04 and and 15.10 locally, and can't find any evidence that we're leaking file descriptors - it looks like the Swift CI's hard limit for NOFILES is too low.

In order to clean up the CI quickly, I'm proposing that we disable all three tests. We can then fix the CIs configuration and debug the tests once we've got Swift 3.0 done. 