### PR TITLE
[Swift 3.0] Disable drift, pingpong and io tests to clean up Swift CI

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -32,7 +32,10 @@ DISABLED_TESTS=					\
 	dispatch_priority			\
 	dispatch_priority2			\
 	dispatch_read				\
-	dispatch_read2
+	dispatch_read2				\
+	dispatch_pingpong			\
+	dispatch_drift				\
+	dispatch_io
 
 TESTS=							\
 	dispatch_apply				\
@@ -42,7 +45,6 @@ TESTS=							\
 	dispatch_queue_finalizer	\
 	dispatch_group				\
 	dispatch_overcommit			\
-	dispatch_pingpong			\
 	dispatch_plusplus			\
 	dispatch_context_for_key	\
 	dispatch_after				\
@@ -56,9 +58,7 @@ TESTS=							\
 	dispatch_timer_set_time		\
 	dispatch_starfish			\
 	dispatch_cascade			\
-	dispatch_drift				\
 	dispatch_data				\
-	dispatch_io					\
 	dispatch_io_net				\
 	dispatch_select
 


### PR DESCRIPTION
Pair PR for #158 