### PR TITLE
Disable dispatch_cascade due to hang in Swift CI

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ DISABLED_TESTS=					\
 	dispatch_read2				\
 	dispatch_pingpong			\
 	dispatch_drift				\
+	dispatch_cascade			\
 	dispatch_io
 
 TESTS=							\
@@ -57,7 +58,6 @@ TESTS=							\
 	dispatch_timer_bit63		\
 	dispatch_timer_set_time		\
 	dispatch_starfish			\
-	dispatch_cascade			\
 	dispatch_data				\
 	dispatch_io_net				\
 	dispatch_select


### PR DESCRIPTION
Temporarily disable the `dispatch_cascade` test as it hung in the Swift CI with the following log:
```
==================================================
[TEST] Dispatch Cascade
[PID] 19223
==================================================


[BEGIN] Process exited
    Actual: 1
    Expected: 0
[FAIL] Process exited (bsdtestharness.c:132)
    bsdtestharness.c:132
[PERF]  wall time: 0.034725
[PERF]  user time: 0.056000
[PERF]  system time: 0.008000
[PERF]  max resident set size: 17660
[PERF]  page faults: 0
[PERF]  swaps: 0
[PERF]  voluntary context switches: 43
[PERF]  involuntary context switches: 10
FAIL dispatch_cascade (exit status: 1)
``` 
Note that the process exited because the CI job killed it after 45 minutes.