### PR TITLE
Android support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,10 @@ if BUILD_OWN_KQUEUES
   MAYBE_KQUEUES = libkqueue
 endif
 
+if BUILD_TESTS
+  MAYBE_TESTS = tests
+endif
+
 SUBDIRS=						\
 	dispatch					\
 	$(MAYBE_PTHREAD_WORKQUEUES)	\
@@ -20,7 +24,7 @@ SUBDIRS=						\
 	os							\
 	private						\
 	src							\
-	tests
+	$(MAYBE_TESTS)
 
 EXTRA_DIST=					\
 	README.md				\

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,10 @@ AC_CONFIG_MACRO_DIR([m4])
 ac_clean_files=a.out.dSYM
 AM_MAINTAINER_MODE
 
+AC_CANONICAL_BUILD
+AC_CANONICAL_HOST
+AC_CANONICAL_TARGET
+
 #
 # Command line argument to specify build variant (default to release).
 # Impacts default value of CFLAGS et al. so must come before AC_PROG_CC
@@ -55,6 +59,53 @@ AC_PROG_CC([clang gcc cc])
 AC_PROG_CXX([clang++ g++ c++])
 AC_PROG_OBJC([clang gcc cc])
 AC_PROG_OBJCXX([clang++ g++ c++])
+
+#
+# Android cross-compilation support
+#
+AC_ARG_WITH([android-ndk],
+  [AS_HELP_STRING([--with-android-ndk],
+    [Android NDK location])], [
+  android_ndk=${withval}
+])
+AC_ARG_WITH([android-ndk-gcc-version],
+  [AS_HELP_STRING([--with-android-ndk-gcc-version],
+    [Android NDK GCC version [defaults=4.9]])],
+  [android_ndk_gcc_version=${withval}], [android_ndk_gcc_version=4.9])
+AC_ARG_WITH([android-api-level],
+  [AS_HELP_STRING([--with-android-api-level],
+    [Android API level to link with])], [
+  android_api_level=${withval}
+])
+AC_ARG_ENABLE([android],
+  [AS_HELP_STRING([--enable-android],
+    [Compile for Android])], [
+  android=true
+
+  # Override values until there's real support for multiple Android platforms
+  host=armv7-none-linux-androideabi
+  host_alias=arm-linux-androideabi
+  host_cpu=armv7
+  host_os=linux-androideabi
+  host_vendor=unknown
+  arch=arm
+
+  sysroot=${android_ndk}/platforms/android-${android_api_level}/arch-${arch}
+  toolchain=${android_ndk}/toolchains/${host_alias}-${android_ndk_gcc_version}/prebuilt/linux-${build_cpu}
+
+  CFLAGS="$CFLAGS -target ${host_alias} --sysroot=${sysroot} -B${toolchain}/${host_alias}/bin"
+  CXXFLAGS="$CXXFLAGS -target ${host_alias} --sysroot=${sysroot} -B${toolchain}/${host_alias}/bin"
+  SWIFTC_FLAGS="-target ${host} -sdk ${sysroot} -L${toolchain}/lib/gcc/${host_alias}/${android_ndk_gcc_version}.x"
+  LIBS="$LIBS -L${toolchain}/lib/gcc/${host_alias}/${android_ndk_gcc_version}.x"
+  LDFLAGS="$LDFLAGS -Wc,'-target','${host_alias}','-B${toolchain}/${host_alias}/bin'"
+
+  # FIXME: empty CFLAGS and CXXFLAGS are assumed for this to work.
+  # FIXME: there should be a more elegant way to do this
+  ac_configure_args=`echo $ac_configure_args | sed -e "s/ 'CFLAGS='//" -e "s/ 'CXXFLAGS='//"`
+  # CFLAGS, CXXFLAGS and LIBS needs to be passed to libkqueue and libpwq
+  ac_configure_args="$ac_configure_args --enable-bionic-libc 'CFLAGS=$CFLAGS' 'CXXFLAGS=$CXXFLAGS' 'LIBS=$LIBS'"
+], [android=false])
+AM_CONDITIONAL(ANDROID, $android)
 
 #
 # On Mac OS X, some required header files come from other source packages;
@@ -134,8 +185,6 @@ AS_IF([test "x$enable_apple_tsd_optimizations" = "xyes"],
     [Define to use non-portable pthread TSD optimizations for Mac OS X)])]
 )
 
-AC_CANONICAL_TARGET
-
 #
 # Enable building Swift overlay support into libdispatch
 #
@@ -164,6 +213,7 @@ AC_ARG_WITH([swift-toolchain],
 )
 AM_CONDITIONAL(HAVE_SWIFT, $have_swift)
 AC_SUBST([SWIFTC])
+AC_SUBST([SWIFTC_FLAGS])
 AC_SUBST([SWIFT_LIBDIR])
 
 #
@@ -472,6 +522,13 @@ AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM([void __attribute__((__noreturn__)) temp(void) { __builtin_trap(); }], [])],
   [AC_DEFINE(HAVE_NORETURN_BUILTIN_TRAP, 1, [Define if __builtin_trap marked noreturn])]
 )
+
+#
+# Add option to avoid building tests
+#
+AC_ARG_ENABLE([build-tests],
+  [AS_HELP_STRING([--disable-build-tests], [Disable tests compilation])])
+AM_CONDITIONAL(BUILD_TESTS, [test "x$enable_build_tests" != "xno"])
 
 #
 # Generate Makefiles.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,7 @@ libdispatch_la_SOURCES=		\
 	trace.h					\
 	voucher_internal.h		\
 	firehose/firehose_internal.h \
+	shims/android_stubs.h	\
 	shims/atomic.h			\
 	shims/atomic_sfb.h		\
 	shims/getprogname.h		\
@@ -148,7 +149,7 @@ SWIFT_SRC_FILES=\
 SWIFT_ABS_SRC_FILES = $(SWIFT_SRC_FILES:%=$(abs_srcdir)/%)
 SWIFT_OBJ_FILES = $(abs_builddir)/swift/swift_overlay.o
 
-SWIFTC_FLAGS = -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.modulemap -I$(abs_top_srcdir) -Xcc -fblocks
+SWIFTC_FLAGS+= -Xcc -fmodule-map-file=$(abs_top_srcdir)/dispatch/module.modulemap -I$(abs_top_srcdir) -Xcc -fblocks
 if DISPATCH_ENABLE_OPTIMIZATION
 SWIFTC_FLAGS+=-O
 endif
@@ -180,4 +181,3 @@ BUILT_SOURCES=$(MIG_SOURCES) $(DTRACE_SOURCES)
 nodist_libdispatch_la_SOURCES=$(BUILT_SOURCES)
 CLEANFILES=$(BUILT_SOURCES) $(SWIFT_GEN_FILES)
 DISTCLEANFILES=pthread_machdep.h pthread System mach objc
-

--- a/src/internal.h
+++ b/src/internal.h
@@ -155,6 +155,7 @@
 #endif
 
 /* private.h must be included last to avoid picking up installed headers. */
+#include <pthread.h>
 #include "os/object_private.h"
 #include "queue_private.h"
 #include "source_private.h"
@@ -245,7 +246,11 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 #include <sys/event.h>
 #include <sys/mount.h>
 #include <sys/queue.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/mman.h>

--- a/src/queue.c
+++ b/src/queue.c
@@ -976,6 +976,7 @@ _dispatch_get_mach_host_port(void)
 #include <unistd.h>
 #include <sys/syscall.h>
 
+#ifndef __ANDROID__
 #ifdef SYS_gettid
 DISPATCH_ALWAYS_INLINE
 static inline pid_t
@@ -985,7 +986,8 @@ gettid(void)
 }
 #else
 #error "SYS_gettid unavailable on this system"
-#endif
+#endif /* SYS_gettid */
+#endif /* ! __ANDROID__ */
 
 #define _tsd_call_cleanup(k, f)  do { \
 		if ((f) && tsd->k) ((void(*)(void*))(f))(tsd->k); \

--- a/src/shims.h
+++ b/src/shims.h
@@ -97,6 +97,10 @@ typedef unsigned long pthread_priority_t;
 #include "shims/linux_stubs.h"
 #endif
 
+#ifdef __ANDROID__
+#include "shims/android_stubs.h"
+#endif
+
 typedef uint32_t dispatch_priority_t;
 #define DISPATCH_SATURATED_OVERRIDE ((dispatch_priority_t)UINT32_MAX)
 

--- a/src/shims/android_stubs.h
+++ b/src/shims/android_stubs.h
@@ -1,0 +1,34 @@
+/*
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2015 Apple Inc. and the Swift project authors
+ *
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See http://swift.org/LICENSE.txt for license information
+ * See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ */
+
+// forward declarations for functions we are stubbing out
+// in the intial android port.
+
+#ifndef __DISPATCH__ANDROID__STUBS__INTERNAL
+#define __DISPATCH__ANDROID__STUBS__INTERNAL
+
+/*
+ * Missing sys/queue.h macro stubs
+ */
+
+#ifndef TAILQ_FOREACH_SAFE
+#	define TAILQ_FOREACH_SAFE(var, head, field, tvar)                      \
+    	    for ((var) = TAILQ_FIRST((head));                              \
+        	    (var) && ((tvar) = TAILQ_NEXT((var), field), 1);           \
+            	(var) = (tvar))
+#endif /* TAILQ_FOREACH_SAFE */
+
+#ifndef TRASHIT
+#	define TRASHIT(x)      do {(x) = (void *)-1;} while (0)
+#endif /* TRASHIT */
+
+#endif /* __DISPATCH__ANDROID__STUBS__INTERNAL */

--- a/src/shims/getprogname.h
+++ b/src/shims/getprogname.h
@@ -23,11 +23,18 @@
 #define __DISPATCH_SHIMS_GETPROGNAME__
 
 #if !HAVE_GETPROGNAME
+
+#ifdef __ANDROID__
+extern const char *__progname;
+#endif /* __ANDROID */)
+
 static inline char *
 getprogname(void)
 {
 # if HAVE_DECL_PROGRAM_INVOCATION_SHORT_NAME
 	return program_invocation_short_name;
+# elif defined(__ANDROID__)
+	return __progname;
 # else
 #   error getprogname(3) is not available on this platform
 # endif

--- a/src/shims/linux_stubs.c
+++ b/src/shims/linux_stubs.c
@@ -17,7 +17,11 @@
  */
 
 #include <stdint.h>
+#ifdef __ANDROID__
+#include <sys/syscall.h>
+#else
 #include <syscall.h>
+#endif /* __ANDROID__ */
 
 #if __has_include(<config/config_ac.h>)
 #include <config/config_ac.h>

--- a/src/shims/linux_stubs.h
+++ b/src/shims/linux_stubs.h
@@ -71,7 +71,9 @@ typedef void (*dispatch_mach_msg_destructor_t)(void*);
 #endif
 
 // SIZE_T_MAX should not be hardcoded like this here.
-#define SIZE_T_MAX (0x7fffffff)
+#ifndef SIZE_T_MAX
+#define SIZE_T_MAX (~(size_t)0)
+#endif
 
 // Define to 0 the NOTE_ values that are not present on Linux.
 // Revisit this...would it be better to ifdef out the uses instead??

--- a/src/shims/lock.c
+++ b/src/shims/lock.c
@@ -117,7 +117,11 @@ _dispatch_unfair_lock_wake(uint32_t *uaddr, uint32_t flags)
 #pragma mark - futex wrappers
 #if HAVE_FUTEX
 #include <sys/time.h>
+#ifdef __ANDROID__
+#include <sys/syscall.h>
+#else
 #include <syscall.h>
+#endif /* __ANDROID__ */
 
 DISPATCH_ALWAYS_INLINE
 static inline int

--- a/src/source.c
+++ b/src/source.c
@@ -2034,8 +2034,10 @@ _dispatch_kevent_qos_s _dispatch_kevent_timeout[] = {
 };
 #define DISPATCH_KEVENT_TIMEOUT_COUNT \
 		((sizeof(_dispatch_kevent_timeout) / sizeof(_dispatch_kevent_timeout[0])))
-static_assert(DISPATCH_KEVENT_TIMEOUT_COUNT == DISPATCH_TIMER_INDEX_COUNT - 1,
+#if __has_feature(c_static_assert)
+_Static_assert(DISPATCH_KEVENT_TIMEOUT_COUNT == DISPATCH_TIMER_INDEX_COUNT - 1,
 		"should have a kevent for everything but disarm (ddt assumes this)");
+#endif
 
 #define DISPATCH_KEVENT_COALESCING_WINDOW_INIT(qos, ms) \
 		[DISPATCH_TIMER_QOS_##qos] = 2ull * (ms) * NSEC_PER_MSEC

--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -112,7 +112,7 @@ public extension DispatchSource {
 	}
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 	public struct ProcessEvent : OptionSet, RawRepresentable {
 		public let rawValue: UInt
 		public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -170,7 +170,7 @@ public extension DispatchSource {
 	}
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 	public class func makeProcessSource(identifier: pid_t, eventMask: ProcessEvent, queue: DispatchQueue? = nil) -> DispatchSourceProcess {
 		let source = dispatch_source_create(_swift_dispatch_source_type_proc(), UInt(identifier), eventMask.rawValue, queue?.__wrapped)
 		return DispatchSource(source: source) as DispatchSourceProcess
@@ -202,7 +202,7 @@ public extension DispatchSource {
 		return DispatchSource(source: source) as DispatchSourceUserDataOr
 	}
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 	public class func makeFileSystemObjectSource(fileDescriptor: Int32, eventMask: FileSystemEvent, queue: DispatchQueue? = nil) -> DispatchSourceFileSystemObject {
 		let source = dispatch_source_create(_swift_dispatch_source_type_vnode(), UInt(fileDescriptor), eventMask.rawValue, queue?.__wrapped)
 		return DispatchSource(source: source) as DispatchSourceFileSystemObject
@@ -255,7 +255,7 @@ public extension DispatchSourceMemoryPressure {
 }
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 public extension DispatchSourceProcess {
 	public var handle: pid_t {
 		return pid_t(dispatch_source_get_handle(self as! DispatchSource))
@@ -299,7 +299,7 @@ public extension DispatchSourceTimer {
 	}
 }
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 public extension DispatchSourceFileSystemObject {
 	public var handle: Int32 {
 		return Int32(dispatch_source_get_handle((self as! DispatchSource).__wrapped))
@@ -368,7 +368,7 @@ internal func _swift_dispatch_source_type_mach_recv() -> dispatch_source_type_t
 internal func _swift_dispatch_source_type_memorypressure() -> dispatch_source_type_t
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 @_silgen_name("_swift_dispatch_source_type_PROC")
 internal func _swift_dispatch_source_type_proc() -> dispatch_source_type_t
 #endif
@@ -382,7 +382,7 @@ internal func _swift_dispatch_source_type_signal() -> dispatch_source_type_t
 @_silgen_name("_swift_dispatch_source_type_TIMER")
 internal func _swift_dispatch_source_type_timer() -> dispatch_source_type_t
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 @_silgen_name("_swift_dispatch_source_type_VNODE")
 internal func _swift_dispatch_source_type_vnode() -> dispatch_source_type_t
 #endif

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -180,7 +180,7 @@ extension DispatchSource : DispatchSourceMachSend,
 }
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 extension DispatchSource : DispatchSourceProcess,
 	DispatchSourceFileSystemObject {
 }
@@ -268,7 +268,7 @@ public protocol DispatchSourceMemoryPressure : DispatchSourceProtocol {
 }
 #endif
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 public protocol DispatchSourceProcess : DispatchSourceProtocol {
 	var handle: pid_t { get }
 
@@ -298,7 +298,7 @@ public protocol DispatchSourceTimer : DispatchSourceProtocol {
 	func scheduleRepeating(wallDeadline: DispatchWallTime, interval: Double, leeway: DispatchTimeInterval)
 }
 
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 public protocol DispatchSourceFileSystemObject : DispatchSourceProtocol {
 	var handle: Int32 { get }
 

--- a/tests/Foundation/bench.mm
+++ b/tests/Foundation/bench.mm
@@ -20,7 +20,11 @@
 
 #include <Foundation/Foundation.h>
 #include <libkern/OSAtomic.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #include <stdio.h>

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -27,7 +27,11 @@
 #include <libkern/OSAtomic.h>
 #endif
 #include <sys/types.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -24,7 +24,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -28,7 +28,11 @@
 #include <TargetConditionals.h>
 #endif
 #include <sys/types.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 
 #include <bsdtests.h>
 #include "dispatch_test.h"

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -22,7 +22,11 @@
 #include <dispatch/private.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 #include <assert.h>
 
 #include <bsdtests.h>

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -26,7 +26,11 @@
 #include <libkern/OSAtomic.h>
 #endif
 #include <assert.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 #include <stdarg.h>
 #include <time.h>
 


### PR DESCRIPTION
This changeset adds support for Android cross-compilation with the same restrictions applied to `swift` project.
## Options
- `--disable-build-tests`: tests are failing to be built due to the lack of `spawn`. Until this is fixed, the flag will be useful to complete compilation
- `--with-android-ndk`: Android NDK path to be used as a base for cross toolchain, SDK and support files.
- `--with-android-ndk-gcc-version`: NDK GCC version to be used (defaults to `4.9`)
- `--with-android-api-level`: API version to be used for compilation
- `--enable-android`: Enabled Android cross-compilation. In this implementation, as it is being done right now in `swift`, this is enforcing `arm-linux-androideabi` `armeabi-v7a`. 
## Issues

There are a few things in this changeset that I'd like to iterate, assuming there are better or more generic solution that can be applied:
- [x] `src/shims/android` includes: In this directory I created [`sys/sysctl.h`](https://github.com/gonzalolarralde/swift-corelibs-libdispatch/blob/android-support/src/shims/android/sys/sysctl.h) + [`syscall.h`](https://github.com/gonzalolarralde/swift-corelibs-libdispatch/blob/android-support/src/shims/android/syscall.h) to redirect headers to their locations in Android. -- _update: moved to compiler conditionals instead of include overlay. [commit](https://github.com/apple/swift-corelibs-libdispatch/pull/162/commits/e67e77f9eda8b87eca90795364e4bc4cd0839582)_
- [x] `src/shims/android` libraries: `libpthread.a` + `librt.a` are dummy libraries because of the [difference described here](https://gist.github.com/leto/663362#file-gistfile1-txt-L85). To avoid this both `libkqueue` and `libpwq` should be modified to avoid asking libtool to link against them.
- [x] [`configure.ac` and `src/Makefile.am`](https://github.com/gonzalolarralde/swift-corelibs-libdispatch/commit/2b2cb83a1810fe2f8dd37f5c64d0ce00fdcafeda): This the first time I deal with `autotools`, so I think there should be a better way to implement this. `(C|CXX|LD)FLAGS` params I think will be needed explicitly declared somewhere to enable cross compilation, but maybe in `AM_$0_FLAGS`? I think there are some overwrites in the `am` files that were causing troubles, but they can be fixed if this is the right direction. Removing flags from `ac_configure_args` like that with `sed` seems like a terrible idea, maybe both `libkqueue` and `libpwq` need to be extended somehow to support this in a better way?
- [x] and more…
## Build

This is an example call to compile `libdispatch` for Android. This is similarly formatted to the call that build script in `swift` does to compile `libdispatch`.

```
$ sh autogen.sh
$ export SWIFT_ANDROID=<...>
$ export NDK_PATH=<...>
$ env \
CC="$SWIFT_ANDROID/build/Ninja-ReleaseAssert/llvm-linux-x86_64/bin/clang" \
CXX="$SWIFT_ANDROID/build/Ninja-ReleaseAssert/llvm-linux-x86_64/bin/clang++" \
SWIFTC="$SWIFT_ANDROID/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc" \
$SWIFT_ANDROID/swift-corelibs-libdispatch/configure \
--with-swift-toolchain="$SWIFT_ANDROID/build/Ninja-ReleaseAssert/swift-linux-x86_64/" \
--with-build-variant=release \
--enable-android \
--host=arm-linux-androideabi \
--with-android-ndk=$NDK_PATH \
--with-android-api-level=21 \
--disable-build-tests
$ make
```

_Side note: `va_list` issue mentioned in #155 is affecting the build process. There's no patch for that issues here, to avoid mixing problems that may be addressed in different ways._
## Outcome

This compilation process creates the shared library with the following ELF header:

```
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Shared object file)
  Machine:                           ARM
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          52 (bytes into file)
  Start of section headers:          1060700 (bytes into file)
  Flags:                             0x5000200, Version5 EABI, soft-float ABI
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         9
  Size of section headers:           40 (bytes)
  Number of section headers:         50
  Section header string table index: 49
```

and dependencies

```
 0x00000001 (NEEDED)                     Shared library: [libstdc++.so]
 0x00000001 (NEEDED)                     Shared library: [libm.so]
 0x00000001 (NEEDED)                     Shared library: [libc.so]
 0x00000001 (NEEDED)                     Shared library: [libdl.so]
```
