### PR TITLE
[Swift3] SR-2356 : Remove temporary APIs from Linux overlay

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -39,13 +39,6 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 	internal var _group: DispatchGroup?
 
-	// Temporary for swift-corelibs-foundation
-	@available(*, deprecated, renamed: "DispatchWorkItem(qos:flags:block:)")
-	public convenience init(group: DispatchGroup, qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-		self.init(qos: qos, flags: flags, block: block)
-
-	}
-
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
 		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(flags.rawValue),
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -23,21 +23,6 @@ internal class _DispatchSpecificValue<T> {
 	internal init(value: T) { self.value = value }
 }
 
-// Temporary for swift-corelibs-foundation
-@available(*, deprecated, renamed: "DispatchQueue.Attributes")
-public struct DispatchQueueAttributes : OptionSet {
-	public let rawValue: UInt64
-	public init(rawValue: UInt64) { self.rawValue = rawValue }
-
-	public static let serial = DispatchQueueAttributes(rawValue: 1<<0)
-	public static let concurrent = DispatchQueueAttributes(rawValue: 1<<1)
-
-	fileprivate var _translatedValue: DispatchQueue.Attributes {
-		if self.contains(.concurrent) { return .concurrent }
-		return []
-	}
-}
-
 public extension DispatchQueue {
 	public struct Attributes : OptionSet {
 		public let rawValue: UInt64
@@ -90,18 +75,6 @@ public extension DispatchQueue {
 		}
 	}
 
-	// Temporary for swift-corelibs-foundation
-	@available(*, deprecated, renamed: "DispatchQoS")
-	public enum GlobalQueueDeprecatedPriority {
-		case qosBackground
-
-		fileprivate var _translatedValue: DispatchQoS.QoSClass {
-			switch self {
-			case .qosBackground: return .background
-			}
-		}
-	}
-
 	public enum AutoreleaseFrequency {
 		case inherit
 
@@ -144,12 +117,6 @@ public extension DispatchQueue {
 		return DispatchQueue(queue: CDispatch.dispatch_get_global_queue(priority._translatedValue, 0))
 	}
 
-	// Temporary for swift-corelibs-foundation
-	@available(*, deprecated, renamed: "DispatchQueue.global(qos:)")
-	public class func global(attributes: GlobalQueueDeprecatedPriority) -> DispatchQueue {
-		return global(qos: attributes._translatedValue)
-	}
-
 	@available(OSX 10.10, iOS 8.0, *)
 	public class func global(qos: DispatchQoS.QoSClass = .default) -> DispatchQueue {
 		return DispatchQueue(queue: CDispatch.dispatch_get_global_queue(Int(qos.rawValue.rawValue), 0))
@@ -164,15 +131,6 @@ public extension DispatchQueue {
 			return v.value
 		}
 		return nil
-	}
-
-	// Temporary for swift-corelibs-foundation
-	@available(*, deprecated, renamed: "DispatchQueue(label:attributes:)")
-	public convenience init(
-		label: String,
-		attributes: DispatchQueueAttributes)
-	{
-		self.init(label: label, attributes: attributes._translatedValue)
 	}
 
 	public convenience init(


### PR DESCRIPTION
Remove temporary APIs from Linux Dispatch overlay;
swift-corelibs-foundation builds without them and
they are not present in the Darwin Dispatch overlay.