### PR TITLE
[DO NOT MERGE YET] Cherry-picks aed3841 for swift-3.0-branch Foundation integration

### DIFF
--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -238,7 +238,7 @@ test_io_stop(void) // rdar://problem/8250057
 static void
 test_io_read_write(void)
 {
-	const char *path_in = "/usr/share/dict/words";
+	const char *path_in = "/usr/bin/vi";
 	char path_out[] = "/tmp/dispatchtest_io.XXXXXX";
 
 	int in = open(path_in, O_RDONLY);

--- a/tests/dispatch_io_net.c
+++ b/tests/dispatch_io_net.c
@@ -62,7 +62,7 @@ main(int argc, char** argv)
 	socklen_t addr1len;
 	pid_t clientid;
 
-	const char *path = "/usr/share/dict/words";
+	const char *path = "/usr/bin/vi";
 	int read_fd, fd;
 
 	if (argc == 2) {

--- a/tests/dispatch_read.c
+++ b/tests/dispatch_read.c
@@ -45,7 +45,7 @@ test_fin(void *cxt)
 int
 main(void)
 {
-	const char *path = "/usr/share/dict/words";
+	const char *path = "/usr/bin/vi";
 	struct stat sb;
 
 	dispatch_test_start("Dispatch Source Read");

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -118,7 +118,7 @@ dispatch_read2(dispatch_fd_t fd,
 static void
 test_read(void)
 {
-	const char *path = "/usr/share/dict/words";
+	const char *path = "/usr/bin/vi";
 	int fd = open(path, O_RDONLY);
 	if (fd == -1) {
 		test_errno("open", errno, 0);

--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -84,7 +84,7 @@ stage1(int stage)
 void
 stage2(void)
 {
-	const char *path = "/usr/share/dict/words";
+	const char *path = "/usr/bin/vi";
 	struct stat sb;
 
 	int fd = open(path, O_RDONLY);


### PR DESCRIPTION
Pulls #151 "use /usr/bin/vi instead of /usr/share/dict/words as test input" into the Swift 3 branch. Although this change is not strictly required for branching swift-corelibs-foundation for Swift 3, this keeps all tests passing, which will help smooth out the integration.

Not to be merged until similar changes are ready to land for [swift #4528](https://github.com/apple/swift/pull/4528), [swiftpm #617](https://github.com/apple/swift-package-manager/pull/617), and [swift-corelibs-xctest #170](https://github.com/apple/swift-corelibs-xctest/pull/170).