### PR TITLE
handle EWOULDBLOCK error in _dispatch_operation_perform

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2288,10 +2288,10 @@ syscall:
 		return DISPATCH_OP_DELIVER;
 	}
 error:
-	if (err == EAGAIN) {
+	if (err == EAGAIN || err == EWOULDBLOCK) {
 		// For disk based files with blocking I/O we should never get EAGAIN
 		dispatch_assert(!op->fd_entry->disk);
-		_dispatch_op_debug("performed: EAGAIN", op);
+		_dispatch_op_debug("performed: EAGAIN/EWOULDBLOCK", op);
 		if (op->direction == DOP_DIR_READ && op->total &&
 				op->channel == op->fd_entry->convenience_channel) {
 			// Convenience read with available data completes on EAGAIN


### PR DESCRIPTION
POSIX.1-2001 allows either EAGAIN or EWOULDBLOCK to be returned when a
write to a nonblocking socket would block. For example IBM z/OS returns
EWOULDBLOCK for this case.