### PR TITLE
[libdispatch-fixits] Address stale or incorrect fixits

### DIFF
--- a/src/swift/Private.swift
+++ b/src/swift/Private.swift
@@ -14,13 +14,13 @@
 
 import CDispatch
 
-@available(*, unavailable, renamed:"DispatchQueue.init(label:attributes:target:)")
+@available(*, unavailable, renamed:"DispatchQueue.init(label:qos:attributes:autoreleaseFrequency:target:)")
 public func dispatch_queue_create(_ label: UnsafePointer<Int8>?, _ attr: dispatch_queue_attr_t?) -> DispatchQueue
 {
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueue.init(label:attributes:target:)")
+@available(*, unavailable, renamed:"DispatchQueue.init(label:qos:attributes:autoreleaseFrequency:target:)")
 public func dispatch_queue_create_with_target(_ label: UnsafePointer<Int8>?, _ attr: dispatch_queue_attr_t?, _ queue: DispatchQueue?) -> DispatchQueue
 {
 	fatalError()
@@ -158,25 +158,25 @@ public func dispatch_get_global_queue(_ identifier: Int, _ flags: UInt) -> Dispa
 	fatalError()
 }
 
-@available(*, unavailable, renamed: "DispatchQueue.main")
+@available(*, unavailable, renamed: "getter:DispatchQueue.main()")
 public func dispatch_get_main_queue() -> DispatchQueue 
 {
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueueAttributes.initiallyInactive")
+@available(*, unavailable, renamed:"DispatchQueue.Attributes.initiallyInactive")
 public func dispatch_queue_attr_make_initially_inactive(_ attr: dispatch_queue_attr_t?) -> dispatch_queue_attr_t
 {
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueueAttributes.autoreleaseWorkItem")
+@available(*, unavailable, renamed:"DispatchQueue.AutoreleaseFrequency.workItem")
 public func dispatch_queue_attr_make_with_autorelease_frequency(_ attr: dispatch_queue_attr_t?, _ frequency: dispatch_autorelease_frequency_t) -> dispatch_queue_attr_t
 {
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueueAttributes.qosUserInitiated")
+@available(*, unavailable, renamed:"DispatchQoS")
 public func dispatch_queue_attr_make_with_qos_class(_ attr: dispatch_queue_attr_t?, _ qos_class: dispatch_qos_class_t, _ relative_priority: Int32) -> dispatch_queue_attr_t
 {
 	fatalError()
@@ -194,19 +194,19 @@ public func dispatch_queue_get_qos_class(_ queue: DispatchQueue, _ relative_prio
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueue.after(self:when:execute:)")
+@available(*, unavailable, renamed:"DispatchQueue.asyncAfter(self:deadline:qos:flags:execute:)")
 public func dispatch_after(_ when: dispatch_time_t, _ queue: DispatchQueue, _ block: @escaping () -> Void)
 {
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueue.asynchronously(self:group:qos:flags:execute:)")
+@available(*, unavailable, renamed:"DispatchQueue.async(self:group:qos:flags:execute:)")
 public func dispatch_barrier_async(_ queue: DispatchQueue, _ block: @escaping () -> Void)
 {
 	fatalError()
 }
 
-@available(*, unavailable, renamed:"DispatchQueue.synchronously(self:flags:execute:)")
+@available(*, unavailable, renamed:"DispatchQueue.sync(self:flags:execute:)")
 public func dispatch_barrier_sync(_ queue: DispatchQueue, _ block: () -> Void)
 {
 	fatalError()
@@ -338,22 +338,22 @@ public func dispatch_walltime(_ when: UnsafePointer<timespec>?, _ delta: Int64) 
 	fatalError()
 }
 
-@available(*, unavailable, renamed: "DispatchQueue.GlobalAttributes.qosUserInitiated")
+@available(*, unavailable, renamed: "DispatchQueue.GlobalQueuePriority.high")
 public var DISPATCH_QUEUE_PRIORITY_HIGH: Int {
   fatalError()
 }
 
-@available(*, unavailable, renamed: "DispatchQueue.GlobalAttributes.qosDefault")
+@available(*, unavailable, renamed: "DispatchQueue.GlobalQueuePriority.default")
 public var DISPATCH_QUEUE_PRIORITY_DEFAULT: Int {
   fatalError()
 }
 
-@available(*, unavailable, renamed: "DispatchQueue.GlobalAttributes.qosUtility")
+@available(*, unavailable, renamed: "DispatchQueue.GlobalQueuePriority.low")
 public var DISPATCH_QUEUE_PRIORITY_LOW: Int {
   fatalError()
 }
 
-@available(*, unavailable, renamed: "DispatchQueue.GlobalAttributes.qosBackground")
+@available(*, unavailable, renamed: "DispatchQueue.GlobalQueuePriority.background")
 public var DISPATCH_QUEUE_PRIORITY_BACKGROUND: Int {
   fatalError()
 }


### PR DESCRIPTION
Apply changes from 25f7cda01c324f13995ae2d1c54c8d2b0615ea36
to the copy of Private.swift used by the wrapping overlay.
This reduces divergence from Darwin overlay.