### PR TITLE
Correct signedness handling of DispatchTimeInterval

### DIFF
--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -88,7 +88,7 @@ public extension DispatchIO {
 	}
 
 	public func setInterval(interval: DispatchTimeInterval, flags: IntervalFlags = []) {
-		dispatch_io_set_interval(self.__wrapped, interval.rawValue, flags.rawValue)
+		dispatch_io_set_interval(self.__wrapped, UInt64(interval.rawValue), flags.rawValue)
 	}
 
 	public func close(flags: CloseFlags = []) {

--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -283,7 +283,7 @@ public extension DispatchSourceTimer {
 	}
 
 	public func scheduleRepeating(deadline: DispatchTime, interval: DispatchTimeInterval, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		dispatch_source_set_timer((self as! DispatchSource).__wrapped, deadline.rawValue, interval.rawValue, UInt64(leeway.rawValue))
+		dispatch_source_set_timer((self as! DispatchSource).__wrapped, deadline.rawValue, UInt64(interval.rawValue), UInt64(leeway.rawValue))
 	}
 
 	public func scheduleRepeating(deadline: DispatchTime, interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {
@@ -291,7 +291,7 @@ public extension DispatchSourceTimer {
 	}
 
 	public func scheduleRepeating(wallDeadline: DispatchWallTime, interval: DispatchTimeInterval, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		dispatch_source_set_timer((self as! DispatchSource).__wrapped, wallDeadline.rawValue, interval.rawValue, UInt64(leeway.rawValue))
+		dispatch_source_set_timer((self as! DispatchSource).__wrapped, wallDeadline.rawValue, UInt64(interval.rawValue), UInt64(leeway.rawValue))
 	}
 
 	public func scheduleRepeating(wallDeadline: DispatchWallTime, interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {

--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -89,23 +89,23 @@ public enum DispatchTimeInterval {
 	case microseconds(Int)
 	case nanoseconds(Int)
 
-	internal var rawValue: UInt64 {
+	internal var rawValue: Int64 {
 		switch self {
-		case .seconds(let s): return UInt64(s) * NSEC_PER_SEC
-		case .milliseconds(let ms): return UInt64(ms) * NSEC_PER_MSEC
-		case .microseconds(let us): return UInt64(us) * NSEC_PER_USEC
-		case .nanoseconds(let ns): return UInt64(ns)
+		case .seconds(let s): return Int64(s) * Int64(NSEC_PER_SEC)
+		case .milliseconds(let ms): return Int64(ms) * Int64(NSEC_PER_MSEC)
+		case .microseconds(let us): return Int64(us) * Int64(NSEC_PER_USEC)
+		case .nanoseconds(let ns): return Int64(ns)
 		}
 	}
 }
 
 public func +(time: DispatchTime, interval: DispatchTimeInterval) -> DispatchTime {
-	let t = CDispatch.dispatch_time(time.rawValue, Int64(interval.rawValue))
+	let t = CDispatch.dispatch_time(time.rawValue, interval.rawValue)
 	return DispatchTime(rawValue: t)
 }
 
 public func -(time: DispatchTime, interval: DispatchTimeInterval) -> DispatchTime {
-	let t = CDispatch.dispatch_time(time.rawValue, -Int64(interval.rawValue))
+	let t = CDispatch.dispatch_time(time.rawValue, -interval.rawValue)
 	return DispatchTime(rawValue: t)
 }
 
@@ -120,12 +120,12 @@ public func -(time: DispatchTime, seconds: Double) -> DispatchTime {
 }
 
 public func +(time: DispatchWallTime, interval: DispatchTimeInterval) -> DispatchWallTime {
-	let t = CDispatch.dispatch_time(time.rawValue, Int64(interval.rawValue))
+	let t = CDispatch.dispatch_time(time.rawValue, interval.rawValue)
 	return DispatchWallTime(rawValue: t)
 }
 
 public func -(time: DispatchWallTime, interval: DispatchTimeInterval) -> DispatchWallTime {
-	let t = CDispatch.dispatch_time(time.rawValue, -Int64(interval.rawValue))
+	let t = CDispatch.dispatch_time(time.rawValue, -interval.rawValue)
 	return DispatchWallTime(rawValue: t)
 }
 


### PR DESCRIPTION
Replicate e32016ffd765020c696bc5d1e42606074305f2db
from the Darwin overlay to the wrapping overlay.