### PR TITLE
Add fast path for queue.async(flags: .barrier)

### DIFF
--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -181,10 +181,15 @@ public extension DispatchQueue {
 		flags: DispatchWorkItemFlags = [], 
 		execute work: @escaping @convention(block) () -> Void) 
 	{
-		if group == nil && qos == .unspecified && flags.isEmpty {
+		if group == nil && qos == .unspecified {
 			// Fast-path route for the most common API usage
-			CDispatch.dispatch_async(self.__wrapped, work)
-			return
+			if flags.isEmpty {
+				CDispatch.dispatch_async(self.__wrapped, work)
+				return
+			} else if flags == .barrier {
+				CDispatch.dispatch_barrier_async(self.__wrapped, work)
+				return
+			}
 		}
 
 		var block: @convention(block) () -> Void = work


### PR DESCRIPTION
Replicate 6fe9b13f12fc34d80c8c63cce84fa3667424baaf which fixes
SR-2248 from the Darwin overlay to the wrapping overlay.