### PR TITLE
Fix some small divergences from Darwin overlay

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -37,14 +37,13 @@ public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 @available(OSX 10.10, iOS 8.0, *)
 public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
-	internal var _group: DispatchGroup?
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
 		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(flags.rawValue),
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
 
-	// Used by DispatchQueue.synchronously<T> to provide a @noescape path through
+	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
 		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(flags.rawValue), noescapeBlock)

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -153,7 +153,7 @@ public class DispatchQueue : DispatchObject {
 		_swift_dispatch_release(wrapped())
 	}
 
-	public func sync(execute workItem: @noescape ()->()) {
+	public func sync(execute workItem: ()->()) {
 		dispatch_sync(self.__wrapped, workItem)
 	}
 }


### PR DESCRIPTION
A collection of small fixes to eliminate needless
differences (as reported by diff -r -b) between
swift/stdlib/public/SDK/Dispatch and
swift-corelibs-libdispatch/src/swift.