### PR TITLE
remove unused/incorrect internal init from DispatchIO

### DIFF
--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -105,10 +105,6 @@ public class DispatchIO : DispatchObject {
 		__wrapped = dispatch_io_create_with_io(__type, io.__wrapped, queue.__wrapped, handler)
 	}
 
-	internal init(queue:dispatch_queue_t) {
-		__wrapped = queue
-	}
-
 	deinit {
 		_swift_dispatch_release(wrapped())
 	}


### PR DESCRIPTION
DispatchIO should not have an internal init(dispatch_queue_t)
that stores a dispatch_queue_t into a field of type dispatch_io_t.
Bug is only in the wrapping (Linux) overlay; not in Dispatch.apinotes.