### PR TITLE
Fix Swift dispatch time comparisons

### DIFF
--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -47,7 +47,6 @@ public struct DispatchTime : Comparable {
 }
 
 public func <(a: DispatchTime, b: DispatchTime) -> Bool {
-	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
 	return a.rawValue < b.rawValue
 }
 
@@ -75,7 +74,11 @@ public struct DispatchWallTime : Comparable {
 }
 
 public func <(a: DispatchWallTime, b: DispatchWallTime) -> Bool {
-	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
+	if b.rawValue == ~0 {
+		return a.rawValue != ~0
+	} else if a.rawValue == ~0 {
+		return false
+	}
 	return -Int64(bitPattern: a.rawValue) < -Int64(bitPattern: b.rawValue)
 }
 

--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -76,7 +76,7 @@ public struct DispatchWallTime : Comparable {
 
 public func <(a: DispatchWallTime, b: DispatchWallTime) -> Bool {
 	if a.rawValue == ~0 || b.rawValue == ~0 { return false }
-	return -Int64(a.rawValue) < -Int64(b.rawValue)
+	return -Int64(bitPattern: a.rawValue) < -Int64(bitPattern: b.rawValue)
 }
 
 public func ==(a: DispatchWallTime, b: DispatchWallTime) -> Bool {


### PR DESCRIPTION
This PR does two things:
1. It makes `<` comparisons on `DispatchWallTime` not crash.
2. It makes `<` comparisons against `DispatchTime.distantFuture` and `DispatchWallTime.distantFuture` behave as expected.

This is a port of apple/swift#5078, but without the tests because I don't see any Swift tests in this repo.
