### PR TITLE
SR-3002: DispatchData.enumerateBytes on Linux leaks the block

### DIFF
--- a/src/swift/DispatchStubs.cc
+++ b/src/swift/DispatchStubs.cc
@@ -142,12 +142,6 @@ _swift_dispatch_block_testcancel(dispatch_block_t block) {
 }
 
 SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
-extern "C" bool
-_swift_dispatch_data_apply(dispatch_data_t data, bool (^applier)(dispatch_data_t, size_t, const void *, size_t)) {
-  return dispatch_data_apply(data, applier);
-}
-
-SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
 extern "C" void
 _swift_dispatch_async(dispatch_queue_t queue, dispatch_block_t block) {
   dispatch_async(queue, block);


### PR DESCRIPTION
To avoid leaking the block parameter of enumerateBytes,
we need to directly call CDispatch.dispatch_data_apply
(not _swift_dispatch_data_apply). However, we need to tell
the compiler that the internal closure that translates between
the C and Swift layers will not cause the captured block
parameter to escape.  If SR-2313 were implemented, we could use
withoutActuallyEscaping.  Since withoutActuallyEscaping is not available,
we instead use unsafeBitCast to bypass the compiler's analysis.
