### PR TITLE
SR-3237: Document libdispatch testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ We are currently early in the development of this project. We began with a mirro
 ## Build and Install
 
 For detailed instructions on building and installing libdispatch, see [INSTALL.md](INSTALL.md)
+
+## Testing
+
+For detailed instructions on testing libdispatch, see [TESTING.md](TESTING.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,27 @@
+## Testing libdispatch
+
+### Running tests
+
+A C-based test suite can be found in the tests subdirectory.
+It uses the automake testing harness to execute the tests.
+
+A default set of tests that are always expected to pass can
+be executed by doing
+
+   ```
+   make check
+   ```
+
+An extended test suite that includes some tests that may fail
+occasionally can be enabled at configure time:
+
+   ```
+   ./configure --enable-extended-test-suite
+   make check
+   ```
+
+### Additional prerequisites
+
+A few test cases require additional packages to be installed.
+In particular, several IO tests assume /usr/bin/vi is available
+as an input file and will fail if it is not present.


### PR DESCRIPTION
Add brief documentation on how to run tests
and note assumption that /usr/bin/vi is present
to use as input for IO test cases.