### PR TITLE
Swift3: Fix libdispatch's copy of objc_retainAutoreleasedReturnValue.

### DIFF
--- a/src/swift/DispatchStubs.cc
+++ b/src/swift/DispatchStubs.cc
@@ -197,10 +197,10 @@ SOURCE(VNODE)
 SOURCE(WRITE)
 
 // See comment in CFFuntime.c explaining why objc_retainAutoreleasedReturnValue is needed.
-extern "C" void swift_release(void *);
+extern "C" void swift_retain(void *);
 extern "C" void * objc_retainAutoreleasedReturnValue(void *obj) {
     if (obj) {
-        swift_release(obj);
+        swift_retain(obj);
         return obj;
     }
     else return NULL;


### PR DESCRIPTION
Swift3 branch of #193 as requested by @gparker42 