### PR TITLE
os_string fixes for cross-compilation and Android when Swift is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,7 @@ AM_CONDITIONAL(HAVE_SWIFT, $have_swift)
 AC_SUBST([SWIFTC])
 AC_SUBST([SWIFTC_FLAGS])
 AC_SUBST([SWIFT_LIBDIR])
+AC_SUBST([OS_STRING], ["$os_string"])
 
 #
 # Enable use of gold linker when building the Swift overlay

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,9 @@ AC_ARG_WITH([swift-toolchain],
    AC_DEFINE(HAVE_SWIFT, 1, [Define if building for Swift])
    SWIFTC="$swift_toolchain_path/bin/swiftc"
    case $target_os in
+      *android*)
+	    os_string="android"
+	    ;;
       linux*)
 	    os_string="linux"
 	    case $target_cpu in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@
 #
 
 if HAVE_SWIFT
-swiftlibdir=${prefix}/lib/swift/linux
+swiftlibdir=${prefix}/lib/swift/${OS_STRING}
 swiftlib_LTLIBRARIES=libdispatch.la
 else
 lib_LTLIBRARIES=libdispatch.la
@@ -171,7 +171,7 @@ SWIFT_GEN_FILES=	\
 	$(abs_builddir)/swift/Dispatch.swiftdoc \
 	$(SWIFT_OBJ_FILES)
 
-swiftmoddir=${prefix}/lib/swift/linux/${build_cpu}
+swiftmoddir=${prefix}/lib/swift/${OS_STRING}/${host_cpu}
 swiftmod_HEADERS=\
 	$(abs_builddir)/swift/Dispatch.swiftmodule \
 	$(abs_builddir)/swift/Dispatch.swiftdoc


### PR DESCRIPTION
Two different issues were affecting the use and generation of output directories for libraries.

* os_string wasn't resolving `android` for the `linux-androideabi` target OS
* Installation directory for cross-compiled target is malformed.

To fix the latter, I'm now passing `OS_STRING` and using `host_cpu` instead of `build_cpu`.