### PR TITLE
don't hold references to unowned DispatchData objects (SR-3628)

### DIFF
--- a/src/swift/DispatchStubs.cc
+++ b/src/swift/DispatchStubs.cc
@@ -165,6 +165,12 @@ _swift_dispatch_release(dispatch_object_t obj) {
   dispatch_release(obj);
 }
 
+SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
+extern "C" void
+_swift_dispatch_retain(dispatch_object_t obj) {
+  dispatch_retain(obj);
+}
+
 // DISPATCH_RUNTIME_STDLIB_INTERFACE
 // extern "C" dispatch_queue_t
 // _swift_apply_current_root_queue() {

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -188,7 +188,6 @@ extension DispatchSource : DispatchSourceProcess,
 
 internal class __DispatchData : DispatchObject {
 	internal let __wrapped:dispatch_data_t
-	internal let __owned:Bool
 
 	final internal override func wrapped() -> dispatch_object_t {
 		return unsafeBitCast(__wrapped, to: dispatch_object_t.self)
@@ -196,13 +195,13 @@ internal class __DispatchData : DispatchObject {
 
 	internal init(data:dispatch_data_t, owned:Bool) {
 		__wrapped = data
-		__owned = owned
+		if !owned {
+			_swift_dispatch_retain(unsafeBitCast(data, to: dispatch_object_t.self))
+		}
 	}
 
 	deinit {
-		if __owned {
-			_swift_dispatch_release(wrapped())
-		}
+		_swift_dispatch_release(wrapped())
 	}
 }
 
@@ -335,3 +334,6 @@ internal enum _OSQoSClass : UInt32  {
 
 @_silgen_name("_swift_dispatch_release")
 internal func _swift_dispatch_release(_ obj: dispatch_object_t) -> Void
+
+@_silgen_name("_swift_dispatch_retain")
+internal func _swift_dispatch_retain(_ obj: dispatch_object_t) -> Void


### PR DESCRIPTION
In `DispatchIO.read`, the `dispatch_data_t` object received from `dispatch_io_read` will be released once the block passed to `dispatch_io_read` returns.

In the Swift overlay (`src/swift/IO.swift`) the code marks that data object correctly as "borrowedData"

	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
		dispatch_io_read(self.__wrapped, offset, length, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
			ioHandler(done, data.flatMap { DispatchData(borrowedData: $0) }, error)
		}
	}

that however leads to use-after-frees if the Swift `DispatchData` is kept around for longer.

The change I made will `retain` the underlying `dispatch_data_t` if it's "borrowed" which I believe is correct and fixes [SR-3628](https://bugs.swift.org/browse/SR-3628).
