### PR TITLE
Adding documentation to clarify the result of DispatchTime(uptimeNanoseconds: 0) 

### DIFF
--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -37,6 +37,12 @@ public struct DispatchTime : Comparable {
 	///   - uptimeNanoseconds: The number of nanoseconds since boot, excluding
 	///                        time the system spent asleep
 	/// - Returns: A new `DispatchTime`
+	/// - Discussion: This clock is the same as the value returned by
+	///               `mach_absolute_time` when converted into nanoseconds.
+	///               Note that `DispatchTime(uptimeNanoseconds: 0)` is
+	///               equivalent to `DispatchTime.now()`, that is, its value
+	///               represents the number of nanoseconds since boot (excluding
+	///               system sleep time), not zero nanoseconds since boot.
 	public init(uptimeNanoseconds: UInt64) {
 		self.rawValue = dispatch_time_t(uptimeNanoseconds)
 	}


### PR DESCRIPTION
The documentation does not make it clear that DispatchTime(uptimeNanoseconds: 0) produces a value that represents the current nanoseconds since boot, not the time of boot. The fix adds a documentation comment to that effect.

(Radar 28814085)

Resolves [SR-2807](https://bugs.swift.org/browse/SR-2807).