### PR TITLE
Remove ObjC support functions not needed on non-ObjC platforms

### DIFF
--- a/src/BlocksRuntime/runtime.c
+++ b/src/BlocksRuntime/runtime.c
@@ -12,8 +12,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#if HAVE_OBJC
 #define __USE_GNU
 #include <dlfcn.h>
+#endif
 #if __has_include(<os/assumes.h>)
 #include <os/assumes.h>
 #else
@@ -202,6 +204,7 @@ static void (*_Block_memmove)(void *dest, void *src, unsigned long size) = _Bloc
 static void (*_Block_destructInstance) (const void *aBlock) = _Block_destructInstance_default;
 
 
+#if HAVE_OBJC
 /**************************************************************************
 GC support SPI functions - called from ObjC runtime and CoreFoundation
 ***************************************************************************/
@@ -252,6 +255,7 @@ void _Block_use_RR( void (*retain)(const void *),
     _Block_release_object = release;
     _Block_destructInstance = dlsym(RTLD_DEFAULT, "objc_destructInstance");
 }
+#endif // HAVE_OBJC
 
 // Called from CF to indicate MRR. Newer version uses a versioned structure, so we can add more functions
 // without defining a new entry point.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,7 +88,9 @@ if BUILD_OWN_BLOCKS_RUNTIME
 libdispatch_la_SOURCES+= BlocksRuntime/data.c BlocksRuntime/runtime.c
 CBLOCKS_FLAGS+= -I$(top_srcdir)/src/BlocksRuntime
 CXXBLOCKS_FLAGS+= -I$(top_srcdir)/src/BlocksRuntime
+if USE_OBJC
 BLOCKS_RUNTIME_LIBS=-ldl
+endif
 endif
 
 libdispatch_la_LDFLAGS=-avoid-version


### PR DESCRIPTION
When compiling on non-Apple platforms, this removes ObjC support functions that are not needed which allows removal of ```libdl```.

Hopefully I have used the correct flags, ```HAVE_OBJC``` in the code and ```USE_OBJC``` in the makefile but if there are better flags to use please let me know.

I tested this by building the static library ```libdispatch.a``` and linking it into a statically built swift program which included ```import Dispatch``` and didnt see any missing references so the functions that have been excluded should be correct.