### PR TITLE
Remove unused include of sys/user.h

### DIFF
--- a/os/linux_base.h
+++ b/os/linux_base.h
@@ -13,7 +13,6 @@
 #ifndef __OS_LINUX_BASE__
 #define __OS_LINUX_BASE__
 
-#include <sys/user.h>
 #include <sys/param.h>
 
 #if __GNUC__


### PR DESCRIPTION
The include of sys/user.h is not needed; it
is a leftover from the initial linux port.
Eliminating it avoids a build problem for
the Swift dispatch overlay on ubuntu 14.04
powerpc64le because the content of sys/user.h
confuses the clang module importer when it
attempts to import CDispatch.