### PR TITLE
provide fallback definitions for all API_* macros

### DIFF
--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -24,14 +24,20 @@
 #ifdef __APPLE__
 #include <Availability.h>
 #include <TargetConditionals.h>
-#endif
-
+#else
 #ifndef API_AVAILABLE
 #define API_AVAILABLE(...)
+#endif
+#ifndef API_DEPRECATED
 #define API_DEPRECATED(...)
+#endif
+#ifndef API_UNAVAILABLE
 #define API_UNAVAILABLE(...)
+#endif
+#ifndef API_DEPRECATED_WITH_REPLACEMENT
 #define API_DEPRECATED_WITH_REPLACEMENT(...)
-#endif // !API_AVAILABLE
+#endif
+#endif // __APPLE__
 
 #include <sys/cdefs.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fixes CI CF build failure (presumably because it has its own fallback definition of API_AVAILABLE but not API_DEPRECATED_WITH_REPLACEMENT)