### PR TITLE
Swift 3.1: remove unused dependency on linux/membarrier.h for intel to fix CI build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -152,7 +152,7 @@ on Ubuntu; currently supported versions are 14.04, 15.10 and 16.04.
 
 1. The first thing to do is install required packages:
 
-    `sudo apt-get install autoconf libtool pkg-config clang systemtap-sdt-dev libbsd-dev`
+    `sudo apt-get install autoconf libtool pkg-config clang systemtap-sdt-dev libbsd-dev linux-libc-dev`
 
     Note: compiling libdispatch requires clang 3.8 or better and
 the gold linker. If the default clang on your Ubuntu version is

--- a/src/shims/lock.h
+++ b/src/shims/lock.h
@@ -89,7 +89,9 @@ _dispatch_lock_has_failed_trylock(dispatch_lock lock_value)
 
 #elif defined(__linux__)
 #include <linux/futex.h>
+#if !defined(__x86_64__) && !defined(__i386__)
 #include <linux/membarrier.h>
+#endif
 #include <unistd.h>
 #include <sys/syscall.h>   /* For SYS_xxx definitions */
 


### PR DESCRIPTION
add dependency on linux-libc-dev to INSTALL.md for other architectures

backport of #221 for swift 3.1