### PR TITLE
fixes for compiler warnings

### DIFF
--- a/src/BlocksRuntime/data.c
+++ b/src/BlocksRuntime/data.c
@@ -14,7 +14,7 @@ We allocate space and export a symbol to be used as the Class for the on-stack a
 
 We keep these in a separate file so that we can include the runtime code in test subprojects but not include the data so that compiled code that sees the data in libSystem doesn't get confused by a second copy.  Somehow these don't get unified in a common block.
 **********************/
-#define BLOCK_EXPORT extern __attribute__((visibility("default")))
+#define BLOCK_EXPORT __attribute__((visibility("default")))
 
 BLOCK_EXPORT void * _NSConcreteStackBlock[32] = { 0 };
 BLOCK_EXPORT void * _NSConcreteMallocBlock[32] = { 0 };

--- a/src/BlocksRuntime/runtime.c
+++ b/src/BlocksRuntime/runtime.c
@@ -53,9 +53,11 @@ static __inline bool OSAtomicCompareAndSwapInt(int oldi, int newi, int volatile 
 Globals
 ************************/
 
+#if HAVE_OBJC
 static void *_Block_copy_class = _NSConcreteMallocBlock;
 static void *_Block_copy_finalizing_class = _NSConcreteMallocBlock;
 static int _Block_copy_flag = BLOCK_NEEDS_FREE;
+#endif
 static int _Byref_flag_initial_value = BLOCK_BYREF_NEEDS_FREE | 4;  // logical 2
 
 static bool isGC = false;
@@ -156,7 +158,9 @@ static void _Block_assign_default(void *value, void **destptr) {
 static void _Block_setHasRefcount_default(const void *ptr, const bool hasRefcount) {
 }
 
+#if HAVE_OBJC
 static void _Block_do_nothing(const void *aBlock) { }
+#endif
 
 static void _Block_retain_object_default(const void *ptr) {
 }
@@ -176,6 +180,7 @@ static void _Block_memmove_default(void *dst, void *src, unsigned long size) {
     memmove(dst, src, (size_t)size);
 }
 
+#if HAVE_OBJC
 static void _Block_memmove_gc_broken(void *dest, void *src, unsigned long size) {
     void **destp = (void **)dest;
     void **srcp = (void **)src;
@@ -186,6 +191,7 @@ static void _Block_memmove_gc_broken(void *dest, void *src, unsigned long size) 
         size -= sizeof(void *);
     }
 }
+#endif
 
 static void _Block_destructInstance_default(const void *aBlock) {}
 

--- a/src/source.c
+++ b/src/source.c
@@ -2515,7 +2515,7 @@ _dispatch_source_debug_attr(dispatch_source_t ds, char* buf, size_t bufsiz)
 			"mask = 0x%x, pending_data = 0x%llx, registered = %d, "
 			"armed = %d, deleted = %d%s, canceled = %d, ",
 			target && target->dq_label ? target->dq_label : "", target,
-			dr->du_ident, dr->du_fflags, ds->ds_pending_data,
+			dr->du_ident, dr->du_fflags, (unsigned long long)ds->ds_pending_data,
 			ds->ds_is_installed, (bool)(ds->dq_atomic_flags & DSF_ARMED),
 			(bool)(ds->dq_atomic_flags & DSF_DELETED),
 			(ds->dq_atomic_flags & DSF_DEFERRED_DELETE) ? " (pending)" : "",

--- a/tests/dispatch_data.c
+++ b/tests/dispatch_data.c
@@ -79,13 +79,14 @@ test_concat(void)
 static void
 test_cleanup(void) // <rdar://problem/9843440>
 {
+	static char buffer4[16];
 	dispatch_group_enter(g);
 	dispatch_async(dispatch_get_main_queue(), ^{
 		void *buffer3 = malloc(1024);
 		dispatch_data_t data3 = dispatch_data_create(buffer3, 0,
 				dispatch_get_main_queue(), DISPATCH_DATA_DESTRUCTOR_FREE);
 		__block bool buffer4_destroyed = false;
-		dispatch_data_t data4 = dispatch_data_create(NULL, 1024,
+		dispatch_data_t data4 = dispatch_data_create(buffer4, 16,
 				dispatch_get_main_queue(), ^{
 			buffer4_destroyed = true;
 		});


### PR DESCRIPTION
Collection of small fixes to eliminate compiler
warnings when building libdispatch and its tests.