### PR TITLE
SR-4201: DispatchSourceSignal not working on Linux

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -72,6 +72,29 @@ dispatch_atfork_child(void)
 	_dispatch_unsafe_fork = 0;
 }
 
+int
+_dispatch_sigmask(void)
+{
+	sigset_t mask;
+	int r = 0;
+
+	/* Workaround: 6269619 Not all signals can be delivered on any thread */
+	r |= sigfillset(&mask);
+	r |= sigdelset(&mask, SIGILL);
+	r |= sigdelset(&mask, SIGTRAP);
+#if HAVE_DECL_SIGEMT
+	r |= sigdelset(&mask, SIGEMT);
+#endif
+	r |= sigdelset(&mask, SIGFPE);
+	r |= sigdelset(&mask, SIGBUS);
+	r |= sigdelset(&mask, SIGSEGV);
+	r |= sigdelset(&mask, SIGSYS);
+	r |= sigdelset(&mask, SIGPIPE);
+	r |= sigdelset(&mask, SIGPROF);
+	r |= pthread_sigmask(SIG_BLOCK, &mask, NULL);
+	(void)dispatch_assume_zero(r);
+}
+
 #pragma mark -
 #pragma mark dispatch_globals
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -990,6 +990,8 @@ extern int _dispatch_evfilt_machport_direct_enabled;
 #endif // DISPATCH_USE_EVFILT_MACHPORT_DIRECT
 
 
+int _dispatch_sigmask(void);
+
 /* #includes dependent on internal.h */
 #include "object_internal.h"
 #include "semaphore_internal.h"


### PR DESCRIPTION
The observed bug is that signals sent to the main thread
after it called dispatch_main were not triggering the
event handler of a DispatchSourceSignal that had been
previously created and activated to handle that signal.

If plausible signals are added to the sigsuspend mask,
then they are properly routed to the signalfd and the
DispatchSourceSignal event handler runs as expected.

This commit also changes event_epoll to use pthread_sigmask
to block the signal when creating a signalfd because
the Linux man page for sigprocmask states that sigprocmask's
behavior is undefined for multi-threaded programs and
pthread_sigmask should be used instead.