### PR TITLE
libdispatch: Avoid submodules for headers that should not be included

### DIFF
--- a/dispatch/darwin/module.modulemap
+++ b/dispatch/darwin/module.modulemap
@@ -1,6 +1,5 @@
 module Dispatch [system] [extern_c] {
 	umbrella header "dispatch.h"
-	module * { export * }
 	export *
 }
 

--- a/dispatch/generic/module.modulemap
+++ b/dispatch/generic/module.modulemap
@@ -11,7 +11,6 @@ module DispatchIntrospection [system] [extern_c] {
 
 module CDispatch [system] [extern_c] {
 	umbrella header "dispatch.h"
-	module * { export * }
 	export *
 	requires blocks
 	link "dispatch"

--- a/private/darwin/module.modulemap
+++ b/private/darwin/module.modulemap
@@ -1,7 +1,6 @@
 module DispatchPrivate [system] [extern_c] {
 	umbrella header "private.h"
 	exclude header "mach_private.h"
-	module * { export * }
 	export *
 }
 

--- a/private/generic/module.modulemap
+++ b/private/generic/module.modulemap
@@ -1,7 +1,6 @@
 module DispatchPrivate [system] [extern_c] {
 	umbrella header "private.h"
 	exclude header "mach_private.h"
-	module * { export * }
 	export *
 }
 


### PR DESCRIPTION
libdispatch has an umbrella header, dispatch.h, that should be used for
including all of the other headers.  This is enforced via
__DISPATCH_INDIRECT__.

Since it isn't legal to include one of the other headers on their own,
it isn't logical to have submodules for them.  Moreover, submodules
*should* have local visibility (be unaware of the context they're
included from); meaning that __DISPATCH_INDIRECT__ will never be
defined.

Logically, all of the headers are part of a single module/interface.

Patch by me & Duncan P. Exon Smith