### PR TITLE
use uintptr_t instead of long

### DIFF
--- a/src/source.c
+++ b/src/source.c
@@ -328,7 +328,7 @@ _dispatch_source_set_handler_slow(void *context)
 
 DISPATCH_NOINLINE
 static void
-_dispatch_source_set_handler(dispatch_source_t ds, long kind,
+_dispatch_source_set_handler(dispatch_source_t ds, uintptr_t kind,
 		dispatch_continuation_t dc)
 {
 	dispatch_assert(dx_type(ds) == DISPATCH_SOURCE_KEVENT_TYPE);


### PR DESCRIPTION
The kind can sometimes hold a dispatch continuation, which is a pointer.
Ensure that the type of the parameter is able to hold a pointer
(consider LLP64 hosts which use 64-bit pointers, 32-bit longs and would
truncate).  This is an internal interface, and should be safe to change