### PR TITLE
Fix building on RasPi

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -624,10 +624,6 @@ _dispatch_fork_becomes_unsafe(void)
 #define DISPATCH_PERF_MON 0
 #endif
 
-/* #includes dependent on internal.h */
-#include "shims.h"
-#include "event/event_internal.h"
-
 // Older Mac OS X and iOS Simulator fallbacks
 
 #if HAVE_PTHREAD_WORKQUEUES
@@ -938,6 +934,10 @@ _dispatch_ktrace_impl(uint32_t code, uint64_t a, uint64_t b,
 		_dispatch_assert_crash(_msg); \
 		free(_msg); \
 	} while (0)
+
+/* #includes dependent on internal.h */
+#include "shims.h"
+#include "event/event_internal.h"
 
 #define DISPATCH_NO_VOUCHER ((voucher_t)(void*)~0ul)
 #define DISPATCH_NO_PRIORITY ((pthread_priority_t)~0ul)


### PR DESCRIPTION
`shims.h` includes`shims/lock.h` which calls `DISPATCH_INTERNAL_CRASH`. However this is defined below the include of `shims.h` in `internal.h` and hence fails the build on the RasPi.
Moving the includes below the define of `DISPATCH_INTERNAL_CRASH` fixes the issue.

I don't know why this works on regular x86/x64 builds, though.