### PR TITLE
build: attempt to add swift support to cmake

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,69 @@
+
+include(CMakeParseArguments)
+
+function(add_swift_library library)
+  set(options)
+  set(single_value_options MODULE_NAME;MODULE_LINK_NAME;MODULE_PATH;MODULE_CACHE_PATH;OUTPUT)
+  set(multiple_value_options SOURCES;SWIFT_FLAGS;CFLAGS)
+
+  cmake_parse_arguments(ASL "${options}" "${single_value_options}" "${multiple_value_options}" ${ARGN})
+
+  set(flags ${CMAKE_SWIFT_FLAGS})
+
+  list(APPEND flags -emit-library)
+
+  if(ASL_MODULE_NAME)
+    list(APPEND flags -module-name;${ASL_MODULE_NAME})
+  endif()
+  if(ASL_MODULE_LINK_NAME)
+    list(APPEND flags -module-link-name;${ASL_MODULE_LINK_NAME})
+  endif()
+  if(ASL_MODULE_PATH)
+    list(APPEND flags -emit-module-path;${ASL_MODULE_PATH})
+  endif()
+  if(ASL_MODULE_CACHE_PATH)
+    list(APPEND flags -module-cache-path;${ASL_MODULE_CACHE_PATH})
+  endif()
+  if(ASL_SWIFT_FLAGS)
+    foreach(flag ${ASL_SWIFT_FLAGS})
+      list(APPEND flags ${flag})
+    endforeach()
+  endif()
+  if(ASL_CFLAGS)
+    foreach(flag ${ASL_CFLAGS})
+      list(APPEND flags -Xcc;${flag})
+    endforeach()
+  endif()
+
+  # FIXME: We shouldn't /have/ to build things in a single process.
+  # <rdar://problem/15972329>
+  list(APPEND flags -force-single-frontend-invocation)
+
+  set(sources)
+  foreach(source ${ASL_SOURCES})
+    get_filename_component(location ${source} PATH)
+    if(IS_ABSOLUTE ${location})
+      list(APPEND sources ${source})
+    else()
+      list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/${source})
+    endif()
+  endforeach()
+
+  get_filename_component(module_directory ${ASL_MODULE_PATH} DIRECTORY)
+
+  add_custom_command(OUTPUT
+                       ${ASL_OUTPUT}
+                       ${ASL_MODULE_PATH}
+                       ${moodule_directory}/${ASL_MODULE_NAME}.swiftdoc
+                     DEPENDS
+                       ${ASL_SOURCES}
+                     COMMAND
+                       ${CMAKE_COMMAND} -E make_directory ${module_directory}
+                     COMMAND
+                       ${CMAKE_SWIFT_COMPILER} ${flags} -c ${sources} -o ${ASL_OUTPUT})
+  add_custom_target(${library}
+                    DEPENDS
+                       ${ASL_OUTPUT}
+                       ${ASL_MODULE_PATH}
+                       ${moodule_directory}/${ASL_MODULE_NAME}.swiftdoc)
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,43 @@
 
+include(SwiftSupport)
+
 set(dispatch_BLOCK_SOURCES block.cpp)
 if(HAVE_OBJC)
   list(APPEND dispatch_BLOCK_SOURCES data.m object.m)
+endif()
+set(dispatch_SWIFT_SOURCES)
+if(CMAKE_SWIFT_COMPILER)
+  set(swift_optimization_flags)
+  if(CMAKE_BUILD_TYPE MATCHES Release)
+    set(swift_optimization_flags -O)
+  endif()
+  add_swift_library(swiftDispatch
+                    MODULE_NAME
+                      Dispatch
+                    MODULE_LINK_NAME
+                      dispatch
+                    MODULE_PATH
+                      ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftmodule
+                    OUTPUT
+                      ${CMAKE_CURRENT_BINARY_DIR}/swiftDispatch.o
+                    SOURCES
+                      swift/Block.swift
+                      swift/Data.swift
+                      swift/Dispatch.swift
+                      swift/IO.swift
+                      swift/Private.swift
+                      swift/Queue.swift
+                      swift/Source.swift
+                      swift/Time.swift
+                      swift/Wrapper.swift
+                    CFLAGS
+                      -fblocks
+                      -fmodule-map-file=${CMAKE_SOURCE_DIR}/dispatch/module.modulemap
+                    SWIFT_FLAGS
+                      -I ${CMAKE_SOURCE_DIR}
+                      ${swift_optimization_flags})
+  list(APPEND dispatch_SWIFT_SOURCES
+       swift/DispatchStubs.cc;${CMAKE_CURRENT_BINARY_DIR}/swiftDispatch.o)
 endif()
 add_library(dispatch
               allocator.c
@@ -55,7 +91,8 @@ add_library(dispatch
               shims/time.h
               shims/tsd.h
               shims/yield.h
-              ${dispatch_BLOCK_SOURCES})
+              ${dispatch_BLOCK_SOURCES}
+              ${dispatch_SWIFT_SOURCES})
 target_include_directories(dispatch
                            PRIVATE
                              ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
Introduce support for building the swift SDK overlay into the CMake
based build system.  This was the one piece which was missing from the
original cmake port of the build system.