### PR TITLE
Create a DISPATCH_PTR_SIZE macro and use it

### DIFF
--- a/src/event/event_kevent.c
+++ b/src/event/event_kevent.c
@@ -1557,7 +1557,7 @@ _dispatch_mach_notify_port_init(void *context DISPATCH_UNUSED)
 	kern_return_t kr;
 #if HAVE_MACH_PORT_CONSTRUCT
 	mach_port_options_t opts = { .flags = MPO_CONTEXT_AS_GUARD | MPO_STRICT };
-#ifdef __LP64__
+#if DISPATCH_SIZEOF_PTR == 8
 	const mach_port_context_t guard = 0xfeed09071f1ca7edull;
 #else
 	const mach_port_context_t guard = 0xff1ca7edull;

--- a/src/object_internal.h
+++ b/src/object_internal.h
@@ -225,7 +225,7 @@
 	.do_xref_cnt = DISPATCH_OBJECT_GLOBAL_REFCNT
 #endif
 
-#ifdef __LP64__
+#if DISPATCH_SIZEOF_PTR == 8
 // the bottom nibble must not be zero, the rest of the bits should be random
 // we sign extend the 64-bit version so that a better instruction encoding is
 // generated on Intel

--- a/src/queue_internal.h
+++ b/src/queue_internal.h
@@ -748,7 +748,6 @@ dispatch_queue_attr_t _dispatch_get_default_queue_attr(void);
 	void *dc_ctxt; \
 	void *dc_data; \
 	void *dc_other
-#define _DISPATCH_SIZEOF_PTR 8
 #elif OS_OBJECT_HAVE_OBJC1
 #define DISPATCH_CONTINUATION_HEADER(x) \
 	dispatch_function_t dc_func; \
@@ -766,7 +765,6 @@ dispatch_queue_attr_t _dispatch_get_default_queue_attr(void);
 	void *dc_ctxt; \
 	void *dc_data; \
 	void *dc_other
-#define _DISPATCH_SIZEOF_PTR 4
 #else
 #define DISPATCH_CONTINUATION_HEADER(x) \
 	union { \
@@ -784,17 +782,16 @@ dispatch_queue_attr_t _dispatch_get_default_queue_attr(void);
 	void *dc_ctxt; \
 	void *dc_data; \
 	void *dc_other
-#define _DISPATCH_SIZEOF_PTR 4
 #endif
 #define _DISPATCH_CONTINUATION_PTRS 8
 #if DISPATCH_HW_CONFIG_UP
 // UP devices don't contend on continuations so we don't need to force them to
 // occupy a whole cacheline (which is intended to avoid contention)
 #define DISPATCH_CONTINUATION_SIZE \
-		(_DISPATCH_CONTINUATION_PTRS * _DISPATCH_SIZEOF_PTR)
+		(_DISPATCH_CONTINUATION_PTRS * DISPATCH_SIZEOF_PTR)
 #else
 #define DISPATCH_CONTINUATION_SIZE  ROUND_UP_TO_CACHELINE_SIZE( \
-		(_DISPATCH_CONTINUATION_PTRS * _DISPATCH_SIZEOF_PTR))
+		(_DISPATCH_CONTINUATION_PTRS * DISPATCH_SIZEOF_PTR))
 #endif
 #define ROUND_UP_TO_CONTINUATION_SIZE(x) \
 		(((x) + (DISPATCH_CONTINUATION_SIZE - 1u)) & \

--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -27,6 +27,22 @@
 #ifndef __DISPATCH_SHIMS_HW_CONFIG__
 #define __DISPATCH_SHIMS_HW_CONFIG__
 
+#ifdef __SIZEOF_POINTER__
+#define DISPATCH_SIZEOF_PTR __SIZEOF_POINTER__
+#elif defined(_WIN64)
+#define DISPATCH_SIZEOF_PTR 8
+#elif defined(_WIN32)
+#define DISPATCH_SIZEOF_PTR 4
+#elif defined(_MSC_VER)
+#error "could not determine pointer size as a constant int for MSVC"
+#elif defined(__LP64__) || defined(__LLP64__)
+#define DISPATCH_SIZEOF_PTR 8
+#elif defined(__ILP32__)
+#define DISPATCH_SIZEOF_PTR 4
+#else
+#error "could not determine pointer size as a constant int"
+#endif // __SIZEOF_POINTER__
+
 #if !TARGET_OS_WIN32
 
 typedef enum {

--- a/tests/dispatch_queue_finalizer.c
+++ b/tests/dispatch_queue_finalizer.c
@@ -50,7 +50,7 @@ main(void)
 {
 	dispatch_test_start("Dispatch Queue Finalizer");
 
-#ifdef __LP64__
+#if DISPATCH_SIZEOF_PTR == 8
 	ctxt_magic = (void*)((uintptr_t)arc4random() << 32 | arc4random());
 #else
 	ctxt_magic = (void*)arc4random();


### PR DESCRIPTION
This introduces a new macro, `DISPATCH_PTR_SIZE` which is defined much
like `LLVM_PTR_SIZE`.  We can gracefully fallback to alternate means of
checking the width of the pointer and use this rather than `__LP64__` to
determine if we are on a 64-bit host.