### PR TITLE
Windows cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,10 @@ check_include_files("unistd.h" HAVE_UNISTD_H)
 check_include_files("objc/objc-internal.h" HAVE_OBJC)
 
 check_library_exists(pthread sem_init "" USE_POSIX_SEM)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  add_definitions(-DTARGET_OS_WIN32)
+  add_definitions(-DUSE_WIN32_SEM)
+endif()
 
 check_symbol_exists(CLOCK_UPTIME "time.h" HAVE_DECL_CLOCK_UPTIME)
 check_symbol_exists(CLOCK_UPTIME_FAST "time.h" HAVE_DECL_CLOCK_UPTIME_FAST)

--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -39,13 +39,17 @@
 #endif
 #endif // __APPLE__
 
+#if HAVE_SYS_CDEFS_H
 #include <sys/cdefs.h>
+#endif
 #include <sys/types.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#if HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 
 #if defined(__linux__) && defined(__has_feature)

--- a/os/object.h
+++ b/os/object.h
@@ -26,10 +26,10 @@
 #include <TargetConditionals.h>
 #include <os/availability.h>
 #endif
-#ifndef __linux__
-#include <os/base.h>
-#else
+#ifdef __linux__
 #include <os/linux_base.h>
+#else
+#include <os/base.h>
 #endif
 
 /*!

--- a/os/object_private.h
+++ b/os/object_private.h
@@ -27,7 +27,9 @@
 #ifndef __OS_OBJECT_PRIVATE__
 #define __OS_OBJECT_PRIVATE__
 
+#if HAVE_SYS_CDEFS_H
 #include <sys/cdefs.h>
+#endif
 #include <stddef.h>
 #include <os/object.h>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,24 +72,47 @@ if(WITH_BLOCKS_RUNTIME)
                              SYSTEM BEFORE PRIVATE
                                "${WITH_BLOCKS_RUNTIME}")
 endif()
-# TODO(compnerd) make this portable
-target_compile_options(dispatch PRIVATE -fno-exceptions)
+if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+  target_compile_options(dispatch PRIVATE /EHsc-)
+else()
+  target_compile_options(dispatch PRIVATE -fno-exceptions)
+endif()
 if(DISPATCH_ENABLE_ASSERTS)
   target_compile_definitions(dispatch
                              PRIVATE
                                -DDISPATCH_DEBUG=1)
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_compile_definitions(dispatch
+                             PRIVATE
+                               -D_CRT_SECURE_NO_WARNINGS)
 endif()
 if(BSD_OVERLAY_FOUND)
   target_compile_options(dispatch
                          PRIVATE
                            ${BSD_OVERLAY_CFLAGS})
 endif()
-# FIXME(compnerd) add check for -momit-leaf-frame-pointer?
-target_compile_options(dispatch
-                       PRIVATE
-                         -Wall
-                         -fblocks
-                         -momit-leaf-frame-pointer)
+if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+  target_compile_options(dispatch
+                         PRIVATE
+                           /W3)
+else()
+  target_compile_options(dispatch
+                         PRIVATE
+                           -Wall)
+endif()
+# FIXME(compnerd) add check for -fblocks?
+if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+  target_compile_options(dispatch
+                         PRIVATE
+                           -Xclang -fblocks)
+else()
+  # FIXME(compnerd) add check for -momit-leaf-frame-pointer?
+  target_compile_options(dispatch
+                         PRIVATE
+                           -fblocks
+                           -momit-leaf-frame-pointer)
+endif()
 if(BSD_OVERLAY_FOUND)
   target_link_libraries(dispatch PRIVATE ${BSD_OVERLAY_LDFLAGS})
 endif()


### PR DESCRIPTION
Add some cl flags handling to the build system.  Improve macros for Windows builds to detect the target correctly.  This is not enough to perform a full Windows build yet but addresses some of the low hanging fruit.