### PR TITLE
build: fix typo in build system

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -54,7 +54,7 @@ function(add_swift_library library)
   add_custom_command(OUTPUT
                        ${ASL_OUTPUT}
                        ${ASL_MODULE_PATH}
-                       ${moodule_directory}/${ASL_MODULE_NAME}.swiftdoc
+                       ${module_directory}/${ASL_MODULE_NAME}.swiftdoc
                      DEPENDS
                        ${ASL_SOURCES}
                      COMMAND
@@ -65,5 +65,5 @@ function(add_swift_library library)
                     DEPENDS
                        ${ASL_OUTPUT}
                        ${ASL_MODULE_PATH}
-                       ${moodule_directory}/${ASL_MODULE_NAME}.swiftdoc)
+                       ${module_directory}/${ASL_MODULE_NAME}.swiftdoc)
 endfunction()


### PR DESCRIPTION
This fixes a typo in the build system which is important because it
fixes the dependency tracking and the output location for the swift doc
that is generated for the swift SDK overlay.