### PR TITLE
Revert "Use sizeof more pervasively"

### DIFF
--- a/src/allocator.c
+++ b/src/allocator.c
@@ -601,7 +601,10 @@ _dispatch_alloc_init(void)
 	// Double-check our math. These are all compile time checks and don't
 	// generate code.
 
+	dispatch_assert(sizeof(bitmap_t) == BYTES_PER_BITMAP);
 	dispatch_assert(sizeof(bitmap_t) == BYTES_PER_SUPERMAP);
+	dispatch_assert(sizeof(struct dispatch_magazine_header_s) ==
+			SIZEOF_HEADER);
 
 	dispatch_assert(sizeof(struct dispatch_continuation_s) <=
 			DISPATCH_CONTINUATION_SIZE);
@@ -611,6 +614,8 @@ _dispatch_alloc_init(void)
 	dispatch_assert(sizeof(struct dispatch_magazine_s) == BYTES_PER_MAGAZINE);
 
 	// The header and maps sizes should match what we computed.
+	dispatch_assert(SIZEOF_HEADER ==
+			sizeof(((struct dispatch_magazine_s *)0x0)->header));
 	dispatch_assert(SIZEOF_MAPS ==
 			sizeof(((struct dispatch_magazine_s *)0x0)->maps));
 

--- a/src/allocator_internal.h
+++ b/src/allocator_internal.h
@@ -97,21 +97,25 @@
 // Use the largest type your platform is comfortable doing atomic ops with.
 // TODO: rdar://11477843
 typedef unsigned long bitmap_t;
-#define BYTES_PER_BITMAP sizeof(bitmap_t)
+#if defined(__LP64__)
+#define BYTES_PER_BITMAP 8
+#else
+#define BYTES_PER_BITMAP 4
+#endif
 
 #define BITMAP_C(v) ((bitmap_t)(v))
 #define BITMAP_ALL_ONES (~BITMAP_C(0))
 
 // Stop configuring.
 
-#define CONTINUATIONS_PER_BITMAP (BYTES_PER_BITMAP * CHAR_BIT)
-#define BITMAPS_PER_SUPERMAP (BYTES_PER_SUPERMAP * CHAR_BIT)
+#define CONTINUATIONS_PER_BITMAP (BYTES_PER_BITMAP * 8)
+#define BITMAPS_PER_SUPERMAP (BYTES_PER_SUPERMAP * 8)
 
 #define BYTES_PER_MAGAZINE (PAGES_PER_MAGAZINE * DISPATCH_ALLOCATOR_PAGE_SIZE)
 #define CONSUMED_BYTES_PER_BITMAP (BYTES_PER_BITMAP + \
 		(DISPATCH_CONTINUATION_SIZE * CONTINUATIONS_PER_BITMAP))
 
-#define BYTES_PER_SUPERMAP sizeof(bitmap_t)
+#define BYTES_PER_SUPERMAP BYTES_PER_BITMAP
 #define CONSUMED_BYTES_PER_SUPERMAP (BYTES_PER_SUPERMAP + \
 		(BITMAPS_PER_SUPERMAP * CONSUMED_BYTES_PER_BITMAP))
 
@@ -143,7 +147,11 @@ typedef unsigned long bitmap_t;
 
 #define PADDING_TO_CONTINUATION_SIZE(x) (ROUND_UP_TO_CONTINUATION_SIZE(x) - (x))
 
-#define SIZEOF_HEADER (sizeof(struct dispatch_magazine_header_s))
+#if defined(__LP64__)
+#define SIZEOF_HEADER 16
+#else
+#define SIZEOF_HEADER 8
+#endif
 
 #define SIZEOF_SUPERMAPS (BYTES_PER_SUPERMAP * SUPERMAPS_PER_MAGAZINE)
 #define SIZEOF_MAPS (BYTES_PER_BITMAP * BITMAPS_PER_SUPERMAP * \


### PR DESCRIPTION
Reverts apple/swift-corelibs-libdispatch#242

breaks the build on Darwin with

```
In file included from libdispatch/src/allocator.c:22:
libdispatch/src/allocator_internal.h:240:5: error: function-like macro 'sizeof' is not defined
#if SUPERMAPS_TO_MAPS_PADDING > 0
    ^
libdispatch/src/allocator_internal.h:168:3: note: expanded from macro 'SUPERMAPS_TO_MAPS_PADDING'
                SIZEOF_SUPERMAPS + HEADER_TO_SUPERMAPS_PADDING + SIZEOF_HEADER))
                ^
libdispatch/src/allocator_internal.h:159:27: note: expanded from macro 'SIZEOF_SUPERMAPS'
#define SIZEOF_SUPERMAPS (BYTES_PER_SUPERMAP * SUPERMAPS_PER_MAGAZINE)
                          ^
libdispatch/src/allocator_internal.h:125:28: note: expanded from macro 'BYTES_PER_SUPERMAP'
#define BYTES_PER_SUPERMAP sizeof(bitmap_t)
                           ^
libdispatch/src/allocator_internal.h:248:5: error: function-like macro 'sizeof' is not defined
#if MAPS_TO_FPMAPS_PADDING > 0
    ^
libdispatch/src/allocator_internal.h:170:62: note: expanded from macro 'MAPS_TO_FPMAPS_PADDING'
#define MAPS_TO_FPMAPS_PADDING (PADDING_TO_CONTINUATION_SIZE(SIZEOF_MAPS))
                                                             ^
libdispatch/src/allocator_internal.h:160:22: note: expanded from macro 'SIZEOF_MAPS'
#define SIZEOF_MAPS (BYTES_PER_BITMAP * BITMAPS_PER_SUPERMAP * \
                     ^
libdispatch/src/allocator_internal.h:111:26: note: expanded from macro 'BYTES_PER_BITMAP'
#define BYTES_PER_BITMAP sizeof(bitmap_t)
                         ^
libdispatch/src/allocator_internal.h:258:5: error: function-like macro 'sizeof' is not defined
#if FPMAPS_TO_FPCONTS_PADDING > 0
    ^
libdispatch/src/allocator_internal.h:193:3: note: expanded from macro 'FPMAPS_TO_FPCONTS_PADDING'
                BYTES_PER_BITMAP * BITMAPS_IN_FIRST_PAGE))
                ^
libdispatch/src/allocator_internal.h:111:26: note: expanded from macro 'BYTES_PER_BITMAP'
#define BYTES_PER_BITMAP sizeof(bitmap_t)
                         ^
libdispatch/src/allocator_internal.h:278:5: error: function-like macro 'sizeof' is not defined
#if AFTER_CONTS_PADDING > 0
    ^
libdispatch/src/allocator_internal.h:202:33: note: expanded from macro 'AFTER_CONTS_PADDING'
                (DISPATCH_CONTINUATION_SIZE * CONTINUATIONS_PER_MAGAZINE)))
                                              ^
libdispatch/src/allocator_internal.h:140:4: note: expanded from macro 'CONTINUATIONS_PER_MAGAZINE'
                (BITMAPS_PER_MAGAZINE * CONTINUATIONS_PER_BITMAP)
                 ^
libdispatch/src/allocator_internal.h:138:31: note: expanded from macro 'BITMAPS_PER_MAGAZINE'
#define BITMAPS_PER_MAGAZINE (SUPERMAPS_PER_MAGAZINE * BITMAPS_PER_SUPERMAP)
                              ^
libdispatch/src/allocator_internal.h:137:3: note: expanded from macro 'SUPERMAPS_PER_MAGAZINE'
                CONSUMED_BYTES_PER_SUPERMAP)
                ^
libdispatch/src/allocator_internal.h:126:38: note: expanded from macro 'CONSUMED_BYTES_PER_SUPERMAP'
#define CONSUMED_BYTES_PER_SUPERMAP (BYTES_PER_SUPERMAP + \
                                     ^
libdispatch/src/allocator_internal.h:125:28: note: expanded from macro 'BYTES_PER_SUPERMAP'
#define BYTES_PER_SUPERMAP sizeof(bitmap_t)
                           ^
```