### PR TITLE
Thread detach hook for Java JNI on Android

### DIFF
--- a/private/queue_private.h
+++ b/private/queue_private.h
@@ -322,6 +322,20 @@ void
 dispatch_async_enforce_qos_class_f(dispatch_queue_t queue,
 	void *_Nullable context, dispatch_function_t work);
 
+#ifdef __ANDROID__
+/*!
+ * @function _dispatch_install_thread_detach_callback
+ *
+ * @param callback
+ * Function to be called before each worker thread exits to detach JVM.
+ *
+ * Hook to be able to detach threads from the Java JVM before they exit.
+ * If JNI has been used on a thread on Android it needs to have been
+ * "detached" before the thread exits or the application will crash.
+ */
+DISPATCH_EXPORT
+void _dispatch_install_thread_detach_callback(dispatch_function_t cb);
+#endif
 
 __END_DECLS
 

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -330,6 +330,15 @@ public extension DispatchQueue {
 		let p = Unmanaged.passRetained(v).toOpaque()
 		dispatch_queue_set_specific(self.__wrapped, k, p, _destructDispatchSpecificValue)
 	}
+
+	#if os(Android)
+	@_silgen_name("_dispatch_install_thread_detach_callback")
+	private static func _dispatch_install_thread_detach_callback(_ cb: @escaping @convention(c) () -> Void)
+
+	public static func setThreadDetachCallback(_ cb: @escaping @convention(c) () -> Void) {
+		_dispatch_install_thread_detach_callback(cb)
+	}
+	#endif
 }
 
 private func _destructDispatchSpecificValue(ptr: UnsafeMutableRawPointer?) {


### PR DESCRIPTION
This is a callback hook required when mixing multi threaded Swift and Java on Android. When Java JNI has been used on a thread the thread needs to be detached from JNI before the thread exits to free local variables or the application will crash e.g. https://github.com/SwiftJava/java_swift/blob/master/Sources/JavaJNI.swift#L20.
Introducing this hook gives any future Java integration code a chance to do this.