### PR TITLE
build: add option to use the gold linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,13 @@ set(USE_LIBDISPATCH_INIT_CONSTRUCTOR ${ENABLE_DISPATCH_INIT_CONSTRUCTOR})
 
 # TODO(compnerd) swift options
 
-# TODO(compnerd) consider adding a flag for USE_GOLD_LINKER.  Currently, we
-# expect the user to specify `-fuse-ld=gold`
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
+   CMAKE_SYSTEM_NAME STREQUAL Android)
+  set(USE_GOLD_LINKER_DEFAULT ON)
+else()
+  set(USE_GOLD_LINKER_DEFAULT OFF)
+endif()
+option(USE_GOLD_LINKER "use the gold linker" ${USE_GOLD_LINKER_DEFAULT})
 
 option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via __thread" ON)
 set(DISPATCH_USE_THREAD_LOCAL_STORAGE ${ENABLE_THREAD_LOCAL_STORAGE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,6 +179,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
                  "-Xlinker -dead_strip"
                  "-Xlinker -alias_list -Xlinker ${CMAKE_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
 endif()
+if(USE_GOLD_LINKER)
+  set_property(TARGET dispatch
+               APPEND_STRING
+               PROPERTY LINK_FLAGS
+                 -fuse-ld=gold)
+endif()
 
 install(TARGETS
           dispatch


### PR DESCRIPTION
This used to be an option in the autotools build.  Address the TODO item
and add an option to control that.