### PR TITLE
tests: fix test build

### DIFF
--- a/tests/dispatch_queue_finalizer.c
+++ b/tests/dispatch_queue_finalizer.c
@@ -50,7 +50,7 @@ main(void)
 {
 	dispatch_test_start("Dispatch Queue Finalizer");
 
-#if DISPATCH_SIZEOF_PTR == 8
+#if defined(__LP64__) || defined(_WIN64)
 	ctxt_magic = (void*)((uintptr_t)arc4random() << 32 | arc4random());
 #else
 	ctxt_magic = (void*)arc4random();


### PR DESCRIPTION
The DISPATCH_SIZEOF_PTR caused a test to go down the wrong path.  This
fixes the test and accounts for the Windows 64 bit case as well (which
is not a LP64 environment).