### PR TITLE
CMake compatibility with Swift build assumptions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,15 @@ if(USE_GOLD_LINKER)
                  -fuse-ld=gold)
 endif()
 
+# Temporary staging; the various swift projects that depend on libdispatch
+# all expect libdispatch.so to be in src/.libs/libdispatch.so
+# So for now, make a copy so we don't have to do a coordinated commit across
+# all the swift projects to change this assumption.
+add_custom_command(TARGET dispatch POST_BUILD
+                   COMMAND cmake -E make_directory .libs
+                   COMMAND cmake -E copy $<TARGET_FILE:dispatch> .libs
+                   COMMENT "Copying libdispatch to .libs")
+
 install(TARGETS
           dispatch
         DESTINATION


### PR DESCRIPTION
All of the swift projects that depend on finding libdispatch.so
during their builds (swift, foundation, swiftpm) all expect it
to be in src/.libs/libdispatch.so (libtool convention). Temporarily
add a rule to copy the built library to where libtool would have
placed it to decouple using CMake for libdispatch from updating
all of the other dependent projects' build expectations.