### PR TITLE
Set CMake defaults to match autoconf Linux behavior.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ set(USE_LIBDISPATCH_INIT_CONSTRUCTOR ${ENABLE_DISPATCH_INIT_CONSTRUCTOR})
 
 # TODO(compnerd) swift options
 
+option(BUILD_SHARED_LIBS "build shared libraries" ON)
+
+option(ENABLE_TESTING "build libdispatch tests" ON)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
    CMAKE_SYSTEM_NAME STREQUAL Android)
   set(USE_GOLD_LINKER_DEFAULT ON)


### PR DESCRIPTION
There may be a more elegant way to do this, but we really want
to build shared libraries by default on Linux and we want to
build the test cases and be able to run them.