### PR TITLE
Fix warnings in DispatchQueue.sync() implementation when using a comp…

### DIFF
--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -216,11 +216,13 @@ public extension DispatchQueue {
 	{
 		var result: T?
 		var error: Swift.Error?
-		fn {
-			do {
-				result = try work()
-			} catch let e {
-				error = e
+		withoutActuallyEscaping(work) { _work in
+			fn {
+				do {
+					result = try _work()
+				} catch let e {
+					error = e
+				}
 			}
 		}
 		if let e = error {


### PR DESCRIPTION
…iler with SE-0176 support. 

* Explanation: This change fixes a warning in the Swift overlay for dispatch that was introduced by the compiler changes for SE-0176. It’s needed in Tioga so that the warning can be promoted to an error.
* Scope of Issue: The change is internal to the dispatch overlay and will have no effect on developers or library users.
* Risk: Since the effect is only to remove a compiler warning and the change is covered by the test suite, this is low risk.
* Reviewed By: Daniel Steffen (das@apple.com)
* Testing: There are tests in the Dispatch test suite that cover this code change.
* Directions for QA: N/A
* Radar: rdar://problem/33141836.

