### PR TITLE
fixes to src to prep for enabling additional compiler warnings

### DIFF
--- a/src/BlocksRuntime/runtime.c
+++ b/src/BlocksRuntime/runtime.c
@@ -148,6 +148,8 @@ GC support stub routines
 
 
 static void *_Block_alloc_default(const unsigned long size, const bool initialCountIsOne, const bool isObject) {
+	(void)initialCountIsOne;
+	(void)isObject;
     return malloc(size);
 }
 
@@ -156,6 +158,8 @@ static void _Block_assign_default(void *value, void **destptr) {
 }
 
 static void _Block_setHasRefcount_default(const void *ptr, const bool hasRefcount) {
+	(void)ptr;
+	(void)hasRefcount;
 }
 
 #if HAVE_OBJC
@@ -163,9 +167,11 @@ static void _Block_do_nothing(const void *aBlock) { }
 #endif
 
 static void _Block_retain_object_default(const void *ptr) {
+	(void)ptr;
 }
 
 static void _Block_release_object_default(const void *ptr) {
+	(void)ptr;
 }
 
 static void _Block_assign_weak_default(const void *ptr, void *dest) {
@@ -193,7 +199,9 @@ static void _Block_memmove_gc_broken(void *dest, void *src, unsigned long size) 
 }
 #endif
 
-static void _Block_destructInstance_default(const void *aBlock) {}
+static void _Block_destructInstance_default(const void *aBlock) {
+	(void)aBlock;
+}
 
 /**************************************************************************
 GC support callout functions - initially set to stub routines

--- a/src/data.c
+++ b/src/data.c
@@ -138,6 +138,8 @@ _dispatch_data_destroy_buffer(const void* buffer, size_t size,
 		mach_vm_size_t vm_size = size;
 		mach_vm_address_t vm_addr = (uintptr_t)buffer;
 		mach_vm_deallocate(mach_task_self(), vm_addr, vm_size);
+#else
+		(void)size;
 #endif
 	} else {
 		if (!queue) {

--- a/src/internal.h
+++ b/src/internal.h
@@ -394,9 +394,9 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 DISPATCH_EXPORT DISPATCH_NOINLINE
 void _dispatch_bug(size_t line, long val);
 
-#if HAVE_MACH
 DISPATCH_NOINLINE
 void _dispatch_bug_client(const char* msg);
+#if HAVE_MACH
 DISPATCH_NOINLINE
 void _dispatch_bug_mach_client(const char *msg, mach_msg_return_t kr);
 #endif // HAVE_MACH
@@ -466,7 +466,9 @@ void _dispatch_log(const char *msg, ...);
 		} \
 	} while (0)
 #else
-static inline void _dispatch_assert(long e, long line) {
+static inline void
+_dispatch_assert(long e, size_t line)
+{
 	if (DISPATCH_DEBUG && !e) _dispatch_abort(line, e);
 }
 #define dispatch_assert(e) _dispatch_assert((long)(e), __LINE__)
@@ -488,7 +490,9 @@ static inline void _dispatch_assert(long e, long line) {
 		} \
 	} while (0)
 #else
-static inline void _dispatch_assert_zero(long e, long line) {
+static inline void
+_dispatch_assert_zero(long e, size_t line)
+{
 	if (DISPATCH_DEBUG && e) _dispatch_abort(line, e);
 }
 #define dispatch_assert_zero(e) _dispatch_assert_zero((long)(e), __LINE__)
@@ -512,7 +516,9 @@ static inline void _dispatch_assert_zero(long e, long line) {
 		_e; \
 	})
 #else
-static inline long _dispatch_assume(long e, long line) {
+static inline long
+_dispatch_assume(long e, long line)
+{
 	if (!e) _dispatch_bug(line, e);
 	return e;
 }
@@ -535,7 +541,9 @@ static inline long _dispatch_assume(long e, long line) {
 		_e; \
 	})
 #else
-static inline long _dispatch_assume_zero(long e, long line) {
+static inline long
+_dispatch_assume_zero(long e, long line)
+{
 	if (e) _dispatch_bug(line, e);
 	return e;
 }
@@ -850,7 +858,7 @@ _dispatch_ktrace_impl(uint32_t code, uint64_t a, uint64_t b,
 #define _dispatch_hardware_crash() \
 		__asm__(""); __builtin_trap() // <rdar://problem/17464981>
 
-#define _dispatch_set_crash_log_cause_and_message(ac, msg)
+#define _dispatch_set_crash_log_cause_and_message(ac, msg) ((void)(ac))
 #define _dispatch_set_crash_log_message(msg)
 #define _dispatch_set_crash_log_message_dynamic(msg)
 

--- a/src/io.c
+++ b/src/io.c
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef PAGE_SIZE
-#define PAGE_SIZE getpagesize()
+#define PAGE_SIZE ((size_t)getpagesize())
 #endif
 
 #if DISPATCH_DATA_IS_BRIDGED_TO_NSDATA
@@ -1372,7 +1372,7 @@ _dispatch_fd_entry_create_with_fd(dispatch_fd_t fd, uintptr_t hash)
 						break;
 				);
 			}
-			int32_t dev = major(st.st_dev);
+			dev_t dev = major(st.st_dev);
 			// We have to get the disk on the global dev queue. The
 			// barrier queue cannot continue until that is complete
 			dispatch_suspend(fd_entry->barrier_queue);
@@ -2167,7 +2167,7 @@ _dispatch_operation_advise(dispatch_operation_t op, size_t chunk_size)
 	op->advise_offset += advise.ra_count;
 #ifdef __linux__
 	_dispatch_io_syscall_switch(err,
-		readahead(op->fd_entry->fd, advise.ra_offset, advise.ra_count),
+			readahead(op->fd_entry->fd, advise.ra_offset, (size_t)advise.ra_count),
 		case EINVAL: break; // fd does refer to a non-supported filetype
 		default: (void)dispatch_assume_zero(err); break;
 	);

--- a/src/queue.c
+++ b/src/queue.c
@@ -5329,6 +5329,8 @@ _dispatch_root_queue_push(dispatch_queue_t rq, dispatch_object_t dou,
 	if (_dispatch_root_queue_push_needs_override(rq, qos)) {
 		return _dispatch_root_queue_push_override(rq, dou, qos);
 	}
+#else
+	(void)qos;
 #endif
 	_dispatch_root_queue_push_inline(rq, dou, dou, 1);
 }
@@ -5870,7 +5872,7 @@ _dispatch_worker_thread(void *context)
 
 #if DISPATCH_USE_INTERNAL_WORKQUEUE
 	if (monitored) {
-		_dispatch_workq_worker_unregister(dq,  qc->dgq_qos);
+		_dispatch_workq_worker_unregister(dq, qc->dgq_qos);
 	}
 #endif
 	(void)os_atomic_inc2o(qc, dgq_thread_pool_size, release);
@@ -5962,6 +5964,7 @@ _dispatch_runloop_root_queue_wakeup_4CF(dispatch_queue_t dq)
 	_dispatch_runloop_queue_wakeup(dq, 0, false);
 }
 
+#if TARGET_OS_MAC
 dispatch_runloop_handle_t
 _dispatch_runloop_root_queue_get_port_4CF(dispatch_queue_t dq)
 {
@@ -5970,6 +5973,7 @@ _dispatch_runloop_root_queue_get_port_4CF(dispatch_queue_t dq)
 	}
 	return _dispatch_runloop_queue_get_handle(dq);
 }
+#endif
 
 static void
 _dispatch_runloop_queue_handle_init(void *ctxt)

--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -101,7 +101,7 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 	switch (c) {
 	case _dispatch_hw_config_logical_cpus:
 	case _dispatch_hw_config_physical_cpus:
-		return sysconf(_SC_NPROCESSORS_CONF);
+		return (uint32_t)sysconf(_SC_NPROCESSORS_CONF);
 	case _dispatch_hw_config_active_cpus:
 		{
 #ifdef __USE_GNU
@@ -110,9 +110,9 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 			// is restricted to a subset of the online cpus (eg via numactl).
 			cpu_set_t cpuset;
 			if (pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset) == 0)
-				return CPU_COUNT(&cpuset);
+				return (uint32_t)CPU_COUNT(&cpuset);
 #endif
-			return sysconf(_SC_NPROCESSORS_ONLN);
+			return (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 		}
 	}
 #else

--- a/src/shims/lock.c
+++ b/src/shims/lock.c
@@ -382,7 +382,7 @@ _dispatch_futex(uint32_t *uaddr, int op, uint32_t val,
 		const struct timespec *timeout, uint32_t *uaddr2, uint32_t val3,
 		int opflags)
 {
-	return syscall(SYS_futex, uaddr, op | opflags, val, timeout, uaddr2, val3);
+	return (int)syscall(SYS_futex, uaddr, op | opflags, val, timeout, uaddr2, val3);
 }
 
 static int
@@ -401,7 +401,7 @@ _dispatch_futex_wake(uint32_t *uaddr, int wake, int opflags)
 {
 	int rc;
 	_dlock_syscall_switch(err,
-		rc = _dispatch_futex(uaddr, FUTEX_WAKE, wake, NULL, NULL, 0, opflags),
+		rc = _dispatch_futex(uaddr, FUTEX_WAKE, (uint32_t)wake, NULL, NULL, 0, opflags),
 		case 0: return;
 		default: DISPATCH_CLIENT_CRASH(err, "futex_wake() failed");
 	);
@@ -412,7 +412,7 @@ _dispatch_futex_lock_pi(uint32_t *uaddr, struct timespec *timeout, int detect,
 	      int opflags)
 {
 	_dlock_syscall_switch(err,
-		_dispatch_futex(uaddr, FUTEX_LOCK_PI, detect, timeout,
+		_dispatch_futex(uaddr, FUTEX_LOCK_PI, (uint32_t)detect, timeout,
 				NULL, 0, opflags),
 		case 0: return;
 		default: DISPATCH_CLIENT_CRASH(errno, "futex_lock_pi() failed");
@@ -606,6 +606,7 @@ _dispatch_gate_wait_slow(dispatch_gate_t dgl, dispatch_lock value,
 		_dispatch_thread_switch(new_value, flags, timeout++);
 #endif
 		(void)timeout;
+		(void)flags;
 	}
 }
 

--- a/src/shims/lock.h
+++ b/src/shims/lock.h
@@ -62,7 +62,7 @@ _dispatch_lock_owner(dispatch_lock lock_value)
 #include <unistd.h>
 #include <sys/syscall.h>   /* For SYS_xxx definitions */
 
-typedef pid_t dispatch_tid;
+typedef uint32_t dispatch_tid;
 typedef uint32_t dispatch_lock;
 
 #define DLOCK_OWNER_MASK			((dispatch_lock)FUTEX_TID_MASK)
@@ -174,8 +174,8 @@ typedef sem_t _dispatch_sema4_t;
 #define _DSEMA4_TIMEOUT() ((errno) = ETIMEDOUT, -1)
 
 void _dispatch_sema4_init(_dispatch_sema4_t *sema, int policy);
-#define _dispatch_sema4_is_created(sema) 1
-#define _dispatch_sema4_create_slow(sema, policy) ((void)0)
+#define _dispatch_sema4_is_created(sema) ((void)sema, 1)
+#define _dispatch_sema4_create_slow(sema, policy) ((void)sema, (void)policy)
 
 #elif USE_WIN32_SEM
 

--- a/src/swift/DispatchStubs.cc
+++ b/src/swift/DispatchStubs.cc
@@ -65,6 +65,29 @@ static void _dispatch_overlay_constructor() {
 #define SWIFT_CC_swift
 #endif
 
+extern "C" dispatch_queue_attr_t _swift_dispatch_queue_concurrent(void);
+extern "C" void _swift_dispatch_apply_current(size_t iterations, __attribute__((__noescape__)) void (^block)(size_t));
+extern "C" dispatch_queue_t _swift_dispatch_get_main_queue(void);
+extern "C" dispatch_data_t _swift_dispatch_data_empty(void);
+extern "C" dispatch_block_t _swift_dispatch_data_destructor_default(void);
+extern "C" dispatch_block_t _swift_dispatch_data_destructor_free(void);
+extern "C" dispatch_block_t _swift_dispatch_data_destructor_munmap(void);
+extern "C" dispatch_block_t _swift_dispatch_block_create_with_qos_class(dispatch_block_flags_t flags, dispatch_qos_class_t qos, int relative_priority, dispatch_block_t block);
+extern "C" dispatch_block_t _swift_dispatch_block_create_noescape(dispatch_block_flags_t flags, dispatch_block_t block);
+extern "C" void _swift_dispatch_block_cancel(dispatch_block_t block);
+extern "C" long _swift_dispatch_block_wait(dispatch_block_t block, dispatch_time_t timeout);
+extern "C" void _swift_dispatch_block_notify(dispatch_block_t block, dispatch_queue_t queue, dispatch_block_t notification_block);
+extern "C" long _swift_dispatch_block_testcancel(dispatch_block_t block);
+extern "C" void _swift_dispatch_async(dispatch_queue_t queue, dispatch_block_t block);
+extern "C" void _swift_dispatch_group_async(dispatch_group_t group, dispatch_queue_t queue, dispatch_block_t block);
+extern "C" void _swift_dispatch_sync(dispatch_queue_t queue, dispatch_block_t block);
+extern "C" void _swift_dispatch_release(dispatch_object_t obj);
+extern "C" void _swift_dispatch_retain(dispatch_object_t obj);
+#if !USE_OBJC
+extern "C" void * objc_retainAutoreleasedReturnValue(void *obj);
+#endif
+
+
 SWIFT_CC(swift) DISPATCH_RUNTIME_STDLIB_INTERFACE
 extern "C" dispatch_queue_attr_t
 _swift_dispatch_queue_concurrent(void) {
@@ -174,6 +197,7 @@ _swift_dispatch_retain(dispatch_object_t obj) {
 }
 
 #define SOURCE(t)                                                              \
+  extern "C" dispatch_source_type_t _swift_dispatch_source_type_##t(void);     \
   SWIFT_CC(swift)                                                              \
   DISPATCH_RUNTIME_STDLIB_INTERFACE extern "C" dispatch_source_type_t  \
   _swift_dispatch_source_type_##t(void) {                                      \

--- a/src/voucher.c
+++ b/src/voucher.c
@@ -1550,12 +1550,14 @@ _voucher_create_accounting_voucher(voucher_t voucher)
 	return NULL;
 }
 
+#if HAVE_MACH
 voucher_t
 voucher_create_with_mach_msg(mach_msg_header_t *msg)
 {
 	(void)msg;
 	return NULL;
 }
+#endif
 
 #if VOUCHER_ENABLE_GET_MACH_VOUCHER
 mach_voucher_t


### PR DESCRIPTION
work in progress on cleaning up code so it can be compiled
with the same set of warning flags used on Darwin. This is an inital
pass through the C files in src to resolve warnings. Most warnings
are related to implicit size/sign conversions between integral types.