### PR TITLE
Revert "test suite fixes to prep for enabling additional warnings"

### DIFF
--- a/tests/bsdtestharness.c
+++ b/tests/bsdtestharness.c
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
 
 #endif
 	int i;
-	char** newargv = calloc((size_t)argc, sizeof(void*));
+	char** newargv = calloc(argc, sizeof(void*));
 	for (i = 1; i < argc; ++i) {
 		newargv[i-1] = argv[i];
 	}

--- a/tests/bsdtests.c
+++ b/tests/bsdtests.c
@@ -154,7 +154,7 @@ _test_uint32(const char* file, long line, const char* desc, uint32_t actual, uin
 }
 
 void
-test_uint32_format(uint32_t actual, uint32_t expected, const char *format, ...)
+test_uint32_format(long actual, long expected, const char *format, ...)
 {
 	GENERATE_DESC
 	_test_uint32(NULL, 0, desc, actual, expected);
@@ -284,10 +284,7 @@ test_double_less_than_or_equal_format(double val, double max_expected, const cha
 void
 _test_double_equal(const char* file, long line, const char* desc, double val, double expected)
 {
-	#pragma clang diagnostic push
-	#pragma clang diagnostic ignored "-Wfloat-equal"
 	_test_print(file, line, desc, (val == expected), "%f", val, "%f", expected);
-	#pragma clang diagnostic pop
 }
 
 
@@ -299,12 +296,12 @@ test_double_equal_format(double val, double expected, const char *format, ...)
 }
 
 void
-_test_errno(const char* file, long line, const char* desc, int actual, int expected)
+_test_errno(const char* file, long line, const char* desc, long actual, long expected)
 {
 	char* actual_str;
 	char* expected_str;
-	asprintf(&actual_str, "%d\t%s", actual, actual ? strerror(actual) : "");
-	asprintf(&expected_str, "%d\t%s", expected, expected ? strerror(expected) : "");
+	asprintf(&actual_str, "%ld\t%s", actual, actual ? strerror(actual) : "");
+	asprintf(&expected_str, "%ld\t%s", expected, expected ? strerror(expected) : "");
 	_test_print(file, line, desc,
 		(actual == expected), "%s", actual_str, "%s", expected_str);
 	free(actual_str);
@@ -312,7 +309,7 @@ _test_errno(const char* file, long line, const char* desc, int actual, int expec
 }
 
 void
-test_errno_format(int actual, int expected, const char *format, ...)
+test_errno_format(long actual, long expected, const char *format, ...)
 {
 	GENERATE_DESC
 	_test_errno(NULL, 0, desc, actual, expected);
@@ -480,7 +477,7 @@ void
 test_stop_after_delay(void *delay)
 {
 	if (delay != NULL) {
-		sleep((uint)(intptr_t)delay);
+		sleep((int)(intptr_t)delay);
 	}
 
 	test_leaks(NULL);

--- a/tests/bsdtests.h
+++ b/tests/bsdtests.h
@@ -81,11 +81,11 @@ void test_ptr_format(const void* actual, const void* expected, const char *forma
 
 void _test_uint32(const char* file, long line, const char* desc, uint32_t actual, uint32_t expected);
 #define test_uint32(a,b,c) _test_uint32(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_uint32_format(uint32_t actual, uint32_t expected, const char *format, ...) __printflike(3,4);
+void test_uint32_format(long actual, long expected, const char *format, ...) __printflike(3,4);
 
 void _test_int32(const char* file, long line, const char* desc, int32_t actual, int32_t expected);
 #define test_int32(a,b,c) _test_int32(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_int32_format(int32_t actual, int32_t expected, const char* format, ...) __printflike(3,4);
+void test_sint32_format(int32_t actual, int32_t expected, const char* format, ...) __printflike(3,4);
 
 void _test_long(const char* file, long line, const char* desc, long actual, long expected);
 #define test_long(a,b,c) _test_long(__SOURCE_FILE__, __LINE__, a, b, c)
@@ -123,9 +123,9 @@ void _test_double_equal(const char* file, long line, const char* desc, double va
 #define test_double_equal(d, v, m) _test_double_equal(__SOURCE_FILE__, __LINE__, d, v, m)
 void test_double_equal_format(double val, double expected, const char *format, ...) __printflike(3,4);
 
-void _test_errno(const char* file, long line, const char* desc, int actual, int expected);
+void _test_errno(const char* file, long line, const char* desc, long actual, long expected);
 #define test_errno(a,b,c) _test_errno(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_errno_format(int actual, int expected, const char *format, ...) __printflike(3,4);
+void test_errno_format(long actual, long expected, const char *format, ...) __printflike(3,4);
 
 #ifndef __linux__
 void _test_mach_error(const char* file, long line, const char* desc, mach_error_t actual, mach_error_t expected);

--- a/tests/dispatch_after.c
+++ b/tests/dispatch_after.c
@@ -32,15 +32,14 @@
 
 #include "dispatch_test.h"
 
-static void
+void
 done(void *arg /*__unused */)
 {
-	(void)arg;
 	sleep(1);
 	test_stop();
 }
 
-static void
+void
 test_after(void)
 {
 	__block dispatch_time_t time_a_min, time_a, time_a_max;
@@ -50,29 +49,29 @@ test_after(void)
 	dispatch_test_start("Dispatch After");
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		time_a_min = dispatch_time(0,  (int64_t)(5.5*NSEC_PER_SEC));
-		time_a     = dispatch_time(0,   (int64_t)(6*NSEC_PER_SEC));
-		time_a_max = dispatch_time(0,  (int64_t)(6.5*NSEC_PER_SEC));
+		time_a_min = dispatch_time(0,  5.5*NSEC_PER_SEC);
+		time_a     = dispatch_time(0,   6*NSEC_PER_SEC);
+		time_a_max = dispatch_time(0,  6.5*NSEC_PER_SEC);
 		dispatch_after(time_a, dispatch_get_main_queue(), ^{
 			dispatch_time_t now_a = dispatch_time(0, 0);
-			test_long_less_than("can't finish faster than 5.5s", 0, (long)(now_a - time_a_min));
-			test_long_less_than("must finish faster than  6.5s", 0, (long)(time_a_max - now_a));
+			test_long_less_than("can't finish faster than 5.5s", 0, now_a - time_a_min);
+			test_long_less_than("must finish faster than  6.5s", 0, time_a_max - now_a);
 
-			time_b_min = dispatch_time(0,  (int64_t)(1.5*NSEC_PER_SEC));
-			time_b     = dispatch_time(0,  (int64_t)(2*NSEC_PER_SEC));
-			time_b_max = dispatch_time(0,  (int64_t)(2.5*NSEC_PER_SEC));
+			time_b_min = dispatch_time(0,  1.5*NSEC_PER_SEC);
+			time_b     = dispatch_time(0,    2*NSEC_PER_SEC);
+			time_b_max = dispatch_time(0,  2.5*NSEC_PER_SEC);
 			dispatch_after(time_b, dispatch_get_main_queue(), ^{
 				dispatch_time_t now_b = dispatch_time(0, 0);
-				test_long_less_than("can't finish faster than 1.5s", 0, (long)(now_b - time_b_min));
-				test_long_less_than("must finish faster than  2.5s", 0, (long)(time_b_max - now_b));
+				test_long_less_than("can't finish faster than 1.5s", 0, now_b - time_b_min);
+				test_long_less_than("must finish faster than  2.5s", 0, time_b_max - now_b);
 
 				time_c_min = dispatch_time(0,  0*NSEC_PER_SEC);
 				time_c     = dispatch_time(0,  0*NSEC_PER_SEC);
-				time_c_max = dispatch_time(0,  (int64_t)(.5*NSEC_PER_SEC));
+				time_c_max = dispatch_time(0,  .5*NSEC_PER_SEC);
 				dispatch_after(time_c, dispatch_get_main_queue(), ^{
 					dispatch_time_t now_c = dispatch_time(0, 0);
-					test_long_less_than("can't finish faster than 0s", 0, (long)(now_c - time_c_min));
-					test_long_less_than("must finish faster than .5s", 0, (long)(time_c_max - now_c));
+					test_long_less_than("can't finish faster than 0s", 0, now_c - time_c_min);
+					test_long_less_than("must finish faster than .5s", 0, time_c_max - now_c);
 
 					dispatch_async_f(dispatch_get_main_queue(), NULL, done);
 				});

--- a/tests/dispatch_api.c
+++ b/tests/dispatch_api.c
@@ -23,7 +23,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-static void
+void
 work(void *context __attribute__((unused)))
 {
 	test_stop();

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -47,7 +47,7 @@ static volatile int all_done = 0;
  * the optimizer from cutting the whole thing out as dead code.
  */
 static volatile unsigned int busythread_useless;
-static void busythread(void *ignored)
+void busythread(void *ignored)
 {
 	(void)ignored;
 	/* prevent i and j been optimized out */
@@ -73,16 +73,16 @@ static void busythread(void *ignored)
  * <rdar://problem/10718199> dispatch_apply should not block waiting on other
  * threads while calling thread is available
  */
-static void test_apply_contended(dispatch_queue_t dq)
+void test_apply_contended(dispatch_queue_t dq)
 {
 	uint32_t activecpu;
 #ifdef __linux__
-	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
 #else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
 #endif
-	int tIndex, n_threads = (int)activecpu;
+	int tIndex, n_threads = activecpu;
 	dispatch_group_t grp = dispatch_group_create();
 
 	for(tIndex = 0; tIndex < n_threads; tIndex++) {
@@ -97,11 +97,11 @@ static void test_apply_contended(dispatch_queue_t dq)
 	volatile __block int32_t count = 0;
 	const int32_t final = 32;
 
-	int32_t before = busy_threads_started;
+	unsigned int before = busy_threads_started;
 	dispatch_apply(final, dq, ^(size_t i __attribute__((unused))) {
 		OSAtomicIncrement32(&count);
 	});
-	int32_t after = busy_threads_finished;
+	unsigned int after = busy_threads_finished;
 
 	test_long("contended: threads started before apply", before, n_threads);
 	test_long("contended: count", count, final);

--- a/tests/dispatch_c99.c
+++ b/tests/dispatch_c99.c
@@ -21,10 +21,18 @@
 #include <dispatch/dispatch.h>
 #include <stdlib.h>
 
+#ifdef __linux__
+// On Linux normally comes from libbsd overlay files,
+// but the headers are not c99 compliant so we compile
+// this test case without $(BSD_OVERLAY_CFLAGS)
+#define __printflike(a,b) __attribute__((format(printf, a, b)))
+#include <inttypes.h>
+#endif
+
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-static void
+void
 work(void *context __attribute__((unused)))
 {
 	test_stop();

--- a/tests/dispatch_data.c
+++ b/tests/dispatch_data.c
@@ -19,7 +19,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <dispatch/dispatch.h>
 #ifdef __APPLE__
@@ -60,7 +59,7 @@ test_concat(void)
 		dispatch_release(data2);
 
 		test_long("Data size of concatenated dispatch data",
-				  (long)dispatch_data_get_size(concat), 34);
+				dispatch_data_get_size(concat), 34);
 
 		const void* contig;
 		size_t contig_size;
@@ -69,7 +68,7 @@ test_concat(void)
 
 		dispatch_release(concat);
 		dispatch_release(contig_data);
-		test_long("Contiguous memory size", (long)contig_size, 34);
+		test_long("Contiguous memory size", contig_size, 34);
 		dispatch_async(dispatch_get_main_queue(), ^{
 			test_long("buffer2 destroyed", buffer2_destroyed, true);
 			dispatch_group_leave(g);

--- a/tests/dispatch_group.c
+++ b/tests/dispatch_group.c
@@ -43,8 +43,8 @@
 
 static void test_group_notify(void*);
 
-static dispatch_group_t
-create_group(size_t count, unsigned int delay)
+dispatch_group_t
+create_group(size_t count, int delay)
 {
 	size_t i;
 
@@ -143,7 +143,7 @@ test_group_notify2(long cycle, dispatch_group_t tested)
 		dispatch_group_async(group, q, ^{
 			// Seems to trigger a little more reliably with some work being
 			// done in this block
-			eh = (float)sin(M_1_PI / cycle);
+			eh = sin(M_1_PI / cycle);
 		});
 	}
 	dispatch_group_leave(group);

--- a/tests/dispatch_io_net.c
+++ b/tests/dispatch_io_net.c
@@ -48,7 +48,7 @@ extern char **environ;
 #endif
 
 #ifdef __linux__
-#define _NSGetExecutablePath(ef,bs) (*(bs)=(size_t)snprintf(ef,*(bs),"%s",argv[0]),0)
+#define _NSGetExecutablePath(ef,bs) (*(bs)=snprintf(ef,*(bs),"%s",argv[0]),0)
 #endif
 
 #if DISPATCHTEST_IO
@@ -79,9 +79,9 @@ main(int argc, char** argv)
 			test_stop();
 		}
 
-		memcpy(&server.sin_addr, he->h_addr_list[0], (size_t)he->h_length);
+		memcpy(&server.sin_addr, he->h_addr_list[0], he->h_length);
 		server.sin_family = AF_INET;
-		server.sin_port = (in_port_t)atoi(argv[1]);
+		server.sin_port = atoi(argv[1]);
 
 		fprintf(stderr, "Client-connecting on port ... %d\n", server.sin_port);
 
@@ -111,7 +111,7 @@ main(int argc, char** argv)
 			test_errno("client-fstat", errno, 0);
 			test_stop();
 		}
-		size_t size = (size_t)sb.st_size;
+		size_t size = sb.st_size;
 
 		__block dispatch_data_t g_d1 = dispatch_data_empty;
 		__block dispatch_data_t g_d2 = dispatch_data_empty;
@@ -123,7 +123,7 @@ main(int argc, char** argv)
 				^(dispatch_data_t d1, int error) {
 			test_errno("Client-dict-read error", error, 0);
 			test_long("Client-dict-dispatch data size",
-					  (long)dispatch_data_get_size(d1), (long)size);
+					dispatch_data_get_size(d1), size);
 			dispatch_retain(d1);
 			g_d1 = d1;
 			dispatch_group_leave(g);
@@ -146,8 +146,8 @@ main(int argc, char** argv)
 		dispatch_read(sockfd, SIZE_MAX, dispatch_get_global_queue(0, 0), b);
 		test_group_wait(g);
 		test_errno("Client-read error", g_error, 0);
-		test_long("Client-dispatch data size", (long)dispatch_data_get_size(g_d2),
-				  (long)size);
+		test_long("Client-dispatch data size", dispatch_data_get_size(g_d2),
+				size);
 
 		size_t dict_contig_size, socket_contig_size;
 		const void *dict_contig_buf, *socket_contig_buf;
@@ -201,7 +201,7 @@ main(int argc, char** argv)
 				addr1.sin_port);
 
 		char exec_filename [256] = {};
-		size_t bufsize = 256;
+		uint32_t bufsize = 256;
 
 		if (_NSGetExecutablePath(exec_filename, &bufsize) == -1) {
 			fprintf(stderr, "Failed to get path name for running executable\n");
@@ -250,7 +250,7 @@ main(int argc, char** argv)
 			test_errno("fstat", errno, 0);
 			goto stop_test;
 		}
-		size_t size = (size_t)sb.st_size;
+		size_t size = sb.st_size;
 
 		dispatch_group_t g = dispatch_group_create();
 		dispatch_group_enter(g);
@@ -258,8 +258,8 @@ main(int argc, char** argv)
 				^(dispatch_data_t d, int r_err){
 			fprintf(stderr, "Server-dispatch_read()\n");
 			test_errno("Server-read error", r_err, 0);
-			test_long("Server-dispatch data size", (long)dispatch_data_get_size(d),
-					  (long)size);
+			test_long("Server-dispatch data size", dispatch_data_get_size(d),
+					size);
 
 			// convenience method handlers should only be called once
 			if (dispatch_data_get_size(d)!= size) {

--- a/tests/dispatch_queue_finalizer.c
+++ b/tests/dispatch_queue_finalizer.c
@@ -30,7 +30,7 @@
 
 void *ctxt_magic = NULL;
 
-static void
+void
 finalize(void *ctxt)
 {
 	test_ptr_null("finalizer ran", NULL);
@@ -38,7 +38,7 @@ finalize(void *ctxt)
 	test_stop();
 }
 
-static void
+void
 never_call(void *ctxt)
 {
 	test_ptr_notnull("never_call should not run", NULL);

--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -28,7 +28,7 @@
 #include "dispatch_test.h"
 #include <bsdtests.h>
 
-static ssize_t actual;
+static size_t actual;
 
 void stage1(int stage);
 void stage2(void);
@@ -49,13 +49,13 @@ stage1(int stage)
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	test_ptr_notnull("main_q", main_q);
 
-	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)fd, 0, main_q);
+	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, main_q);
 	test_ptr_notnull("select source", source);
 
 	dispatch_source_set_event_handler(source, ^{
 		size_t buffer_size = 500*1024;
 		char buffer[500*1024];
-		ssize_t sz = read(fd, buffer, buffer_size);
+		size_t sz = read(fd, buffer, buffer_size);
 		test_double_less_than_or_equal("kevent read 1", sz, buffer_size+1);
 		dispatch_source_cancel(source);
 	});
@@ -109,24 +109,25 @@ stage2(void)
 		exit(EXIT_FAILURE);
 	}
 
-	ssize_t expected = sb.st_size;
+	size_t expected = sb.st_size;
 	actual = 0;
 
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	test_ptr_notnull("main_q", main_q);
 
-	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)fd, 0, main_q);
+	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, main_q);
 	test_ptr_notnull("kevent source", source);
 
 	dispatch_source_set_event_handler(source, ^{
 		size_t est = dispatch_source_get_data(source);
 		test_double_less_than_or_equal("estimated", est, expected - actual);
+		size_t buffer_size = 500*1024;
 		char buffer[500*1024];
-		ssize_t sz = read(fd, buffer, sizeof(buffer));
+		size_t sz = read(fd, buffer, buffer_size);
 		actual += sz;
-		if (sz < (ssize_t)sizeof(buffer))
+		if (sz < buffer_size)
 		{
-			sz = read(fd, buffer, sizeof(buffer));
+			sz = read(fd, buffer, buffer_size);
 			actual += sz;
 			test_long("EOF", sz, 0);
 			dispatch_source_cancel(source);

--- a/tests/dispatch_sema.c
+++ b/tests/dispatch_sema.c
@@ -31,7 +31,7 @@
 int
 main(void)
 {
-	static long total;
+	static size_t total;
 	dispatch_semaphore_t dsema;
 
 	dispatch_test_start("Dispatch Semaphore");

--- a/tests/dispatch_starfish.c
+++ b/tests/dispatch_starfish.c
@@ -81,7 +81,7 @@ collect(void *context __attribute__((unused)))
 
 	// our malloc could be a lot better,
 	// this result is really a malloc torture test
-	test_long_less_than("Latency" , (long)math, ACCEPTABLE_LATENCY);
+	test_long_less_than("Latency" , (unsigned long)math, ACCEPTABLE_LATENCY);
 
 	if (--lap_count_down) {
 		return do_test();

--- a/tests/dispatch_timer.c
+++ b/tests/dispatch_timer.c
@@ -30,7 +30,7 @@
 
 static bool finalized = false;
 
-static void
+void
 test_fin(void *cxt)
 {
 	test_ptr("finalizer ran", cxt, cxt);
@@ -38,7 +38,7 @@ test_fin(void *cxt)
 	test_stop();
 }
 
-static void
+void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Source Timer");
@@ -48,7 +48,7 @@ test_timer(void)
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	//test_ptr("dispatch_get_main_queue", main_q, dispatch_get_current_queue());
 
-	int64_t j;
+	uint64_t j;
 
 	// create timers in two classes:
 	//  * ones that should trigger before the test ends
@@ -58,8 +58,7 @@ test_timer(void)
 		dispatch_source_t s = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_global_queue(0, 0));
 		test_ptr_notnull("dispatch_source_create", s);
 
-		int64_t delta = (int64_t)((uint64_t)j * NSEC_PER_SEC + NSEC_PER_SEC / 10);
-		dispatch_source_set_timer(s, dispatch_time(DISPATCH_TIME_NOW, delta), DISPATCH_TIME_FOREVER, 0);
+		dispatch_source_set_timer(s, dispatch_time(DISPATCH_TIME_NOW, j * NSEC_PER_SEC + NSEC_PER_SEC / 10), DISPATCH_TIME_FOREVER, 0);
 
 		dispatch_source_set_event_handler(s, ^{
 			if (!finalized) {

--- a/tests/dispatch_timer_bit31.c
+++ b/tests/dispatch_timer_bit31.c
@@ -28,7 +28,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-static void
+void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Source Timer, bit 31");

--- a/tests/dispatch_timer_bit63.c
+++ b/tests/dispatch_timer_bit63.c
@@ -28,7 +28,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-static void
+void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Source Timer, bit 63");

--- a/tests/dispatch_timer_set_time.c
+++ b/tests/dispatch_timer_set_time.c
@@ -29,7 +29,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-static void
+void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Update Timer");

--- a/tests/dispatch_timer_short.c
+++ b/tests/dispatch_timer_short.c
@@ -48,14 +48,12 @@ static uint64_t start, last;
 
 #define elapsed_ms(x) (((now-(x))*tbi.numer/tbi.denom)/(1000ull*NSEC_PER_USEC))
 
-static
 void
 test_fin(void *cxt)
 {
-	unsigned long finalCount = (unsigned long)count;
 	fprintf(stderr, "Called back every %llu us on average\n",
-			(delay/finalCount)/NSEC_PER_USEC);
-	test_long_less_than("Frequency", 1, (long)ceil((double)delay/(finalCount*interval)));
+			(delay/count)/NSEC_PER_USEC);
+	test_long_less_than("Frequency", 1, ceil((double)delay/(count*interval)));
 	int i;
 	for (i = 0; i < N; i++) {
 		dispatch_source_cancel(t[i]);
@@ -68,7 +66,6 @@ test_fin(void *cxt)
 	test_stop();
 }
 
-static
 void
 test_short_timer(void)
 {

--- a/tests/linux_port.h
+++ b/tests/linux_port.h
@@ -41,7 +41,7 @@ mach_absolute_time()
 {
 	struct timeval tv;
 	gettimeofday(&tv,NULL);
-	return (1000ull)*((unsigned long long)tv.tv_sec*(1000000ull) + (unsigned long long)tv.tv_usec);
+	return (1000ull)*((unsigned long long)tv.tv_sec*(1000000ull)+ tv.tv_usec);
 }
 
 static inline


### PR DESCRIPTION
Reverts apple/swift-corelibs-libdispatch#274

I believe this broke the build, eg https://ci.swift.org//job/oss-swift-incremental-RA-linux-ubuntu-14_04/3550/consoleFull#1160775376ee1a197b-acac-4b17-83cf-a53b95139a76

```
/home/buildnode/disk2/workspace/oss-swift-incremental-RA-linux-ubuntu-14_04/swift-corelibs-libdispatch/tests/bsdtests.h:72:72: error: expected function body after function declarator
void test_ptr_notnull_format(const void *ptr, const char *format, ...) __printflike(2, 3);
                                                                       ^
/home/buildnode/disk2/workspace/oss-swift-incremental-RA-linux-ubuntu-14_04/swift-corelibs-libdispatch/tests/bsdtests.h:80:89: error: expected function body after function declarator
void test_ptr_format(const void* actual, const void* expected, const char *format, ...) __printflike(3,4);
                                                                                        ^
```