### PR TITLE
test suite fixes to prep for enabling additional warnings

### DIFF
--- a/tests/bsdtestharness.c
+++ b/tests/bsdtestharness.c
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
 
 #endif
 	int i;
-	char** newargv = calloc(argc, sizeof(void*));
+	char** newargv = calloc((size_t)argc, sizeof(void*));
 	for (i = 1; i < argc; ++i) {
 		newargv[i-1] = argv[i];
 	}

--- a/tests/bsdtests.c
+++ b/tests/bsdtests.c
@@ -154,7 +154,7 @@ _test_uint32(const char* file, long line, const char* desc, uint32_t actual, uin
 }
 
 void
-test_uint32_format(long actual, long expected, const char *format, ...)
+test_uint32_format(uint32_t actual, uint32_t expected, const char *format, ...)
 {
 	GENERATE_DESC
 	_test_uint32(NULL, 0, desc, actual, expected);
@@ -284,7 +284,10 @@ test_double_less_than_or_equal_format(double val, double max_expected, const cha
 void
 _test_double_equal(const char* file, long line, const char* desc, double val, double expected)
 {
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wfloat-equal"
 	_test_print(file, line, desc, (val == expected), "%f", val, "%f", expected);
+	#pragma clang diagnostic pop
 }
 
 
@@ -296,12 +299,12 @@ test_double_equal_format(double val, double expected, const char *format, ...)
 }
 
 void
-_test_errno(const char* file, long line, const char* desc, long actual, long expected)
+_test_errno(const char* file, long line, const char* desc, int actual, int expected)
 {
 	char* actual_str;
 	char* expected_str;
-	asprintf(&actual_str, "%ld\t%s", actual, actual ? strerror(actual) : "");
-	asprintf(&expected_str, "%ld\t%s", expected, expected ? strerror(expected) : "");
+	asprintf(&actual_str, "%d\t%s", actual, actual ? strerror(actual) : "");
+	asprintf(&expected_str, "%d\t%s", expected, expected ? strerror(expected) : "");
 	_test_print(file, line, desc,
 		(actual == expected), "%s", actual_str, "%s", expected_str);
 	free(actual_str);
@@ -309,7 +312,7 @@ _test_errno(const char* file, long line, const char* desc, long actual, long exp
 }
 
 void
-test_errno_format(long actual, long expected, const char *format, ...)
+test_errno_format(int actual, int expected, const char *format, ...)
 {
 	GENERATE_DESC
 	_test_errno(NULL, 0, desc, actual, expected);
@@ -477,7 +480,7 @@ void
 test_stop_after_delay(void *delay)
 {
 	if (delay != NULL) {
-		sleep((int)(intptr_t)delay);
+		sleep((uint)(intptr_t)delay);
 	}
 
 	test_leaks(NULL);

--- a/tests/bsdtests.h
+++ b/tests/bsdtests.h
@@ -81,11 +81,11 @@ void test_ptr_format(const void* actual, const void* expected, const char *forma
 
 void _test_uint32(const char* file, long line, const char* desc, uint32_t actual, uint32_t expected);
 #define test_uint32(a,b,c) _test_uint32(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_uint32_format(long actual, long expected, const char *format, ...) __printflike(3,4);
+void test_uint32_format(uint32_t actual, uint32_t expected, const char *format, ...) __printflike(3,4);
 
 void _test_int32(const char* file, long line, const char* desc, int32_t actual, int32_t expected);
 #define test_int32(a,b,c) _test_int32(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_sint32_format(int32_t actual, int32_t expected, const char* format, ...) __printflike(3,4);
+void test_int32_format(int32_t actual, int32_t expected, const char* format, ...) __printflike(3,4);
 
 void _test_long(const char* file, long line, const char* desc, long actual, long expected);
 #define test_long(a,b,c) _test_long(__SOURCE_FILE__, __LINE__, a, b, c)
@@ -123,9 +123,9 @@ void _test_double_equal(const char* file, long line, const char* desc, double va
 #define test_double_equal(d, v, m) _test_double_equal(__SOURCE_FILE__, __LINE__, d, v, m)
 void test_double_equal_format(double val, double expected, const char *format, ...) __printflike(3,4);
 
-void _test_errno(const char* file, long line, const char* desc, long actual, long expected);
+void _test_errno(const char* file, long line, const char* desc, int actual, int expected);
 #define test_errno(a,b,c) _test_errno(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_errno_format(long actual, long expected, const char *format, ...) __printflike(3,4);
+void test_errno_format(int actual, int expected, const char *format, ...) __printflike(3,4);
 
 #ifndef __linux__
 void _test_mach_error(const char* file, long line, const char* desc, mach_error_t actual, mach_error_t expected);

--- a/tests/dispatch_after.c
+++ b/tests/dispatch_after.c
@@ -32,14 +32,15 @@
 
 #include "dispatch_test.h"
 
-void
+static void
 done(void *arg /*__unused */)
 {
+	(void)arg;
 	sleep(1);
 	test_stop();
 }
 
-void
+static void
 test_after(void)
 {
 	__block dispatch_time_t time_a_min, time_a, time_a_max;
@@ -49,29 +50,29 @@ test_after(void)
 	dispatch_test_start("Dispatch After");
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		time_a_min = dispatch_time(0,  5.5*NSEC_PER_SEC);
-		time_a     = dispatch_time(0,   6*NSEC_PER_SEC);
-		time_a_max = dispatch_time(0,  6.5*NSEC_PER_SEC);
+		time_a_min = dispatch_time(0,  (int64_t)(5.5*NSEC_PER_SEC));
+		time_a     = dispatch_time(0,   (int64_t)(6*NSEC_PER_SEC));
+		time_a_max = dispatch_time(0,  (int64_t)(6.5*NSEC_PER_SEC));
 		dispatch_after(time_a, dispatch_get_main_queue(), ^{
 			dispatch_time_t now_a = dispatch_time(0, 0);
-			test_long_less_than("can't finish faster than 5.5s", 0, now_a - time_a_min);
-			test_long_less_than("must finish faster than  6.5s", 0, time_a_max - now_a);
+			test_long_less_than("can't finish faster than 5.5s", 0, (long)(now_a - time_a_min));
+			test_long_less_than("must finish faster than  6.5s", 0, (long)(time_a_max - now_a));
 
-			time_b_min = dispatch_time(0,  1.5*NSEC_PER_SEC);
-			time_b     = dispatch_time(0,    2*NSEC_PER_SEC);
-			time_b_max = dispatch_time(0,  2.5*NSEC_PER_SEC);
+			time_b_min = dispatch_time(0,  (int64_t)(1.5*NSEC_PER_SEC));
+			time_b     = dispatch_time(0,  (int64_t)(2*NSEC_PER_SEC));
+			time_b_max = dispatch_time(0,  (int64_t)(2.5*NSEC_PER_SEC));
 			dispatch_after(time_b, dispatch_get_main_queue(), ^{
 				dispatch_time_t now_b = dispatch_time(0, 0);
-				test_long_less_than("can't finish faster than 1.5s", 0, now_b - time_b_min);
-				test_long_less_than("must finish faster than  2.5s", 0, time_b_max - now_b);
+				test_long_less_than("can't finish faster than 1.5s", 0, (long)(now_b - time_b_min));
+				test_long_less_than("must finish faster than  2.5s", 0, (long)(time_b_max - now_b));
 
 				time_c_min = dispatch_time(0,  0*NSEC_PER_SEC);
 				time_c     = dispatch_time(0,  0*NSEC_PER_SEC);
-				time_c_max = dispatch_time(0,  .5*NSEC_PER_SEC);
+				time_c_max = dispatch_time(0,  (int64_t)(.5*NSEC_PER_SEC));
 				dispatch_after(time_c, dispatch_get_main_queue(), ^{
 					dispatch_time_t now_c = dispatch_time(0, 0);
-					test_long_less_than("can't finish faster than 0s", 0, now_c - time_c_min);
-					test_long_less_than("must finish faster than .5s", 0, time_c_max - now_c);
+					test_long_less_than("can't finish faster than 0s", 0, (long)(now_c - time_c_min));
+					test_long_less_than("must finish faster than .5s", 0, (long)(time_c_max - now_c));
 
 					dispatch_async_f(dispatch_get_main_queue(), NULL, done);
 				});

--- a/tests/dispatch_api.c
+++ b/tests/dispatch_api.c
@@ -23,7 +23,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-void
+static void
 work(void *context __attribute__((unused)))
 {
 	test_stop();

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -47,7 +47,7 @@ static volatile int all_done = 0;
  * the optimizer from cutting the whole thing out as dead code.
  */
 static volatile unsigned int busythread_useless;
-void busythread(void *ignored)
+static void busythread(void *ignored)
 {
 	(void)ignored;
 	/* prevent i and j been optimized out */
@@ -73,16 +73,16 @@ void busythread(void *ignored)
  * <rdar://problem/10718199> dispatch_apply should not block waiting on other
  * threads while calling thread is available
  */
-void test_apply_contended(dispatch_queue_t dq)
+static void test_apply_contended(dispatch_queue_t dq)
 {
 	uint32_t activecpu;
 #ifdef __linux__
-	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
+	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
 #endif
-	int tIndex, n_threads = activecpu;
+	int tIndex, n_threads = (int)activecpu;
 	dispatch_group_t grp = dispatch_group_create();
 
 	for(tIndex = 0; tIndex < n_threads; tIndex++) {
@@ -97,11 +97,11 @@ void test_apply_contended(dispatch_queue_t dq)
 	volatile __block int32_t count = 0;
 	const int32_t final = 32;
 
-	unsigned int before = busy_threads_started;
+	int32_t before = busy_threads_started;
 	dispatch_apply(final, dq, ^(size_t i __attribute__((unused))) {
 		OSAtomicIncrement32(&count);
 	});
-	unsigned int after = busy_threads_finished;
+	int32_t after = busy_threads_finished;
 
 	test_long("contended: threads started before apply", before, n_threads);
 	test_long("contended: count", count, final);

--- a/tests/dispatch_c99.c
+++ b/tests/dispatch_c99.c
@@ -32,7 +32,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-void
+static void
 work(void *context __attribute__((unused)))
 {
 	test_stop();

--- a/tests/dispatch_data.c
+++ b/tests/dispatch_data.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <dispatch/dispatch.h>
 #ifdef __APPLE__
@@ -59,7 +60,7 @@ test_concat(void)
 		dispatch_release(data2);
 
 		test_long("Data size of concatenated dispatch data",
-				dispatch_data_get_size(concat), 34);
+				  (long)dispatch_data_get_size(concat), 34);
 
 		const void* contig;
 		size_t contig_size;
@@ -68,7 +69,7 @@ test_concat(void)
 
 		dispatch_release(concat);
 		dispatch_release(contig_data);
-		test_long("Contiguous memory size", contig_size, 34);
+		test_long("Contiguous memory size", (long)contig_size, 34);
 		dispatch_async(dispatch_get_main_queue(), ^{
 			test_long("buffer2 destroyed", buffer2_destroyed, true);
 			dispatch_group_leave(g);

--- a/tests/dispatch_group.c
+++ b/tests/dispatch_group.c
@@ -43,8 +43,8 @@
 
 static void test_group_notify(void*);
 
-dispatch_group_t
-create_group(size_t count, int delay)
+static dispatch_group_t
+create_group(size_t count, unsigned int delay)
 {
 	size_t i;
 
@@ -143,7 +143,7 @@ test_group_notify2(long cycle, dispatch_group_t tested)
 		dispatch_group_async(group, q, ^{
 			// Seems to trigger a little more reliably with some work being
 			// done in this block
-			eh = sin(M_1_PI / cycle);
+			eh = (float)sin(M_1_PI / cycle);
 		});
 	}
 	dispatch_group_leave(group);

--- a/tests/dispatch_queue_finalizer.c
+++ b/tests/dispatch_queue_finalizer.c
@@ -30,7 +30,7 @@
 
 void *ctxt_magic = NULL;
 
-void
+static void
 finalize(void *ctxt)
 {
 	test_ptr_null("finalizer ran", NULL);
@@ -38,7 +38,7 @@ finalize(void *ctxt)
 	test_stop();
 }
 
-void
+static void
 never_call(void *ctxt)
 {
 	test_ptr_notnull("never_call should not run", NULL);

--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -28,7 +28,7 @@
 #include "dispatch_test.h"
 #include <bsdtests.h>
 
-static size_t actual;
+static ssize_t actual;
 
 void stage1(int stage);
 void stage2(void);
@@ -49,13 +49,13 @@ stage1(int stage)
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	test_ptr_notnull("main_q", main_q);
 
-	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, main_q);
+	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)fd, 0, main_q);
 	test_ptr_notnull("select source", source);
 
 	dispatch_source_set_event_handler(source, ^{
 		size_t buffer_size = 500*1024;
 		char buffer[500*1024];
-		size_t sz = read(fd, buffer, buffer_size);
+		ssize_t sz = read(fd, buffer, buffer_size);
 		test_double_less_than_or_equal("kevent read 1", sz, buffer_size+1);
 		dispatch_source_cancel(source);
 	});
@@ -109,25 +109,24 @@ stage2(void)
 		exit(EXIT_FAILURE);
 	}
 
-	size_t expected = sb.st_size;
+	ssize_t expected = sb.st_size;
 	actual = 0;
 
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	test_ptr_notnull("main_q", main_q);
 
-	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, main_q);
+	dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)fd, 0, main_q);
 	test_ptr_notnull("kevent source", source);
 
 	dispatch_source_set_event_handler(source, ^{
 		size_t est = dispatch_source_get_data(source);
 		test_double_less_than_or_equal("estimated", est, expected - actual);
-		size_t buffer_size = 500*1024;
 		char buffer[500*1024];
-		size_t sz = read(fd, buffer, buffer_size);
+		ssize_t sz = read(fd, buffer, sizeof(buffer));
 		actual += sz;
-		if (sz < buffer_size)
+		if (sz < (ssize_t)sizeof(buffer))
 		{
-			sz = read(fd, buffer, buffer_size);
+			sz = read(fd, buffer, sizeof(buffer));
 			actual += sz;
 			test_long("EOF", sz, 0);
 			dispatch_source_cancel(source);

--- a/tests/dispatch_sema.c
+++ b/tests/dispatch_sema.c
@@ -31,7 +31,7 @@
 int
 main(void)
 {
-	static size_t total;
+	static long total;
 	dispatch_semaphore_t dsema;
 
 	dispatch_test_start("Dispatch Semaphore");

--- a/tests/dispatch_starfish.c
+++ b/tests/dispatch_starfish.c
@@ -81,7 +81,7 @@ collect(void *context __attribute__((unused)))
 
 	// our malloc could be a lot better,
 	// this result is really a malloc torture test
-	test_long_less_than("Latency" , (unsigned long)math, ACCEPTABLE_LATENCY);
+	test_long_less_than("Latency" , (long)math, ACCEPTABLE_LATENCY);
 
 	if (--lap_count_down) {
 		return do_test();

--- a/tests/dispatch_timer.c
+++ b/tests/dispatch_timer.c
@@ -30,7 +30,7 @@
 
 static bool finalized = false;
 
-void
+static void
 test_fin(void *cxt)
 {
 	test_ptr("finalizer ran", cxt, cxt);
@@ -38,7 +38,7 @@ test_fin(void *cxt)
 	test_stop();
 }
 
-void
+static void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Source Timer");
@@ -48,7 +48,7 @@ test_timer(void)
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	//test_ptr("dispatch_get_main_queue", main_q, dispatch_get_current_queue());
 
-	uint64_t j;
+	int64_t j;
 
 	// create timers in two classes:
 	//  * ones that should trigger before the test ends
@@ -58,7 +58,8 @@ test_timer(void)
 		dispatch_source_t s = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_global_queue(0, 0));
 		test_ptr_notnull("dispatch_source_create", s);
 
-		dispatch_source_set_timer(s, dispatch_time(DISPATCH_TIME_NOW, j * NSEC_PER_SEC + NSEC_PER_SEC / 10), DISPATCH_TIME_FOREVER, 0);
+		int64_t delta = (int64_t)((uint64_t)j * NSEC_PER_SEC + NSEC_PER_SEC / 10);
+		dispatch_source_set_timer(s, dispatch_time(DISPATCH_TIME_NOW, delta), DISPATCH_TIME_FOREVER, 0);
 
 		dispatch_source_set_event_handler(s, ^{
 			if (!finalized) {

--- a/tests/dispatch_timer_bit31.c
+++ b/tests/dispatch_timer_bit31.c
@@ -28,7 +28,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-void
+static void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Source Timer, bit 31");

--- a/tests/dispatch_timer_bit63.c
+++ b/tests/dispatch_timer_bit63.c
@@ -28,7 +28,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-void
+static void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Source Timer, bit 63");

--- a/tests/dispatch_timer_set_time.c
+++ b/tests/dispatch_timer_set_time.c
@@ -29,7 +29,7 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
-void
+static void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Update Timer");

--- a/tests/dispatch_timer_short.c
+++ b/tests/dispatch_timer_short.c
@@ -48,12 +48,14 @@ static uint64_t start, last;
 
 #define elapsed_ms(x) (((now-(x))*tbi.numer/tbi.denom)/(1000ull*NSEC_PER_USEC))
 
+static
 void
 test_fin(void *cxt)
 {
+	unsigned long finalCount = (unsigned long)count;
 	fprintf(stderr, "Called back every %llu us on average\n",
-			(delay/count)/NSEC_PER_USEC);
-	test_long_less_than("Frequency", 1, ceil((double)delay/(count*interval)));
+			(delay/finalCount)/NSEC_PER_USEC);
+	test_long_less_than("Frequency", 1, (long)ceil((double)delay/(finalCount*interval)));
 	int i;
 	for (i = 0; i < N; i++) {
 		dispatch_source_cancel(t[i]);
@@ -66,6 +68,7 @@ test_fin(void *cxt)
 	test_stop();
 }
 
+static
 void
 test_short_timer(void)
 {

--- a/tests/linux_port.h
+++ b/tests/linux_port.h
@@ -41,7 +41,7 @@ mach_absolute_time()
 {
 	struct timeval tv;
 	gettimeofday(&tv,NULL);
-	return (1000ull)*((unsigned long long)tv.tv_sec*(1000000ull)+ tv.tv_usec);
+	return (1000ull)*((unsigned long long)tv.tv_sec*(1000000ull) + (unsigned long long)tv.tv_usec);
 }
 
 static inline


### PR DESCRIPTION
fixes to allow clean compilation of test suite with additional
clang warnings enabled.

Updated version of #274 that leaves out the problematic change to dispatch_c99.c that broke the build.  There is a divergence between autotools and cmake compilation flags for dispatch_c99.c (autotools compiles this test without ${BSD_OVERLAY_CFLAGS} while CMake compiles all tests with ${BSD_OVERLAY_CFLAGS}).  We can fix that later.
