### PR TITLE
linux: update header used for `major` macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ check_include_files("sys/cdefs.h" HAVE_SYS_CDEFS_H)
 check_include_files("sys/guarded.h" HAVE_SYS_GUARDED_H)
 check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
 check_include_files("sys/types.h" HAVE_SYS_TYPES_H)
+check_include_files("sys/sysmacros.h" HAVE_SYS_SYSMACROS_H)
 check_include_files("unistd.h" HAVE_UNISTD_H)
 check_include_files("objc/objc-internal.h" HAVE_OBJC)
 

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -188,6 +188,9 @@
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine01 HAVE_SYS_TYPES_H
 
+/* Define to 1 if you have the <sys/sysmacros.h> header file.  */
+#cmakedefine01 HAVE_SYS_SYSMACROS_H
+
 /* Define to 1 if you have the <TargetConditionals.h> header file. */
 #cmakedefine HAVE_TARGETCONDITIONALS_H
 

--- a/os/linux_base.h
+++ b/os/linux_base.h
@@ -13,6 +13,11 @@
 #ifndef __OS_LINUX_BASE__
 #define __OS_LINUX_BASE__
 
+#include <config/config_ac.h>
+
+#if HAVE_SYS_SYSMACROS_H
+#include <sys/sysmacros.h>
+#endif
 #include <sys/param.h>
 
 #if HAVE_SYS_CDEFS_H


### PR DESCRIPTION
Newer versions of glibc indicate that they intend to move the `major`
macro from `sys/types.h` to `sys/sysmacros.h`.  Add a check for the
header and include that earlier to ensure that the macro is provided by
the newer header when available/possible.  This avoids an unnecessary
warning from the system headers.