### PR TITLE
Revert "Fix compilation warnings in extended test suite"

### DIFF
--- a/tests/bsdtests.c
+++ b/tests/bsdtests.c
@@ -189,20 +189,6 @@ test_long_format(long actual, long expected, const char* format, ...)
 }
 
 void
-_test_sizet(const char* file, long line, const char* desc, size_t actual, size_t expected)
-{
-	_test_print(file, line, desc,
-		(actual == expected), "%zd", actual, "%zd", expected);
-}
-
-void
-test_sizet_format(size_t actual, size_t expected, const char* format, ...)
-{
-	GENERATE_DESC
-	_test_sizet(NULL, 0, desc, actual, expected);
-}
-
-void
 _test_uint64(const char* file, long line, const char* desc, uint64_t actual, uint64_t expected)
 {
 	_test_print(file, line, desc,
@@ -267,32 +253,6 @@ test_long_greater_than_or_equal_format(long actual, long expected_max, const cha
 {
 	GENERATE_DESC
 	_test_long_greater_than_or_equal(NULL, 0, desc, actual, expected_max);
-}
-
-void
-_test_sizet_less_than(const char* file, long line, const char* desc, size_t actual, size_t expected_max)
-{
-	_test_print(file, line, desc, (actual < expected_max), "%zd", actual, "<%zd", expected_max);
-}
-
-void
-test_sizet_less_than_format(size_t actual, size_t expected_max, const char* format, ...)
-{
-	GENERATE_DESC
-	_test_sizet_less_than(NULL, 0, desc, actual, expected_max);
-}
-
-void
-_test_sizet_less_than_or_equal(const char* file, long line, const char* desc, size_t actual, size_t expected_max)
-{
-	_test_print(file, line, desc, (actual <= expected_max), "%zd", actual, "<=%zd", expected_max);
-}
-
-void
-test_sizet_less_than_or_equal_format(size_t actual, size_t expected_max, const char* format, ...)
-{
-	GENERATE_DESC
-	_test_sizet_less_than_or_equal(NULL, 0, desc, actual, expected_max);
 }
 
 void

--- a/tests/bsdtests.h
+++ b/tests/bsdtests.h
@@ -91,10 +91,6 @@ void _test_long(const char* file, long line, const char* desc, long actual, long
 #define test_long(a,b,c) _test_long(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_long_format(long actual, long expected, const char *format, ...) __printflike(3,4);
 
-void _test_sizet(const char* file, long line, const char* desc, size_t actual, size_t expected);
-#define test_sizet(a,b,c) _test_sizet(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_sizet_format(size_t actual, size_t expected, const char *format, ...) __printflike(3,4);
-
 void _test_uint64(const char* file, long line, const char* desc, uint64_t actual, uint64_t expected);
 #define test_uint64(a,b,c) _test_uint64(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_uint64_format(uint64_t actual, uint64_t expected, const char* desc, ...);
@@ -114,14 +110,6 @@ void test_long_less_than_or_equal_format(long actual, long max_expected, const c
 void _test_long_greater_than_or_equal(const char* file, long line, const char* desc, long actual, long expected_min);
 #define test_long_greater_than_or_equal(a,b,c) _test_long_greater_than_or_equal(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_long_greater_than_or_equal_format(long actual, long expected_min, const char *format, ...) __printflike(3,4);
-
-void _test_sizet_less_than(const char* file, long line, const char* desc, size_t actual, size_t max_expected);
-#define test_sizet_less_than(a,b,c) _test_sizet_less_than(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_sizet_less_than_format(size_t actual, size_t max_expected, const char *format, ...) __printflike(3,4);
-
-void _test_sizet_less_than_or_equal(const char* file, long line, const char* desc, size_t actual, size_t max_expected);
-#define test_sizet_less_than_or_equal(a,b,c) _test_sizet_less_than_or_equal(__SOURCE_FILE__, __LINE__, a, b, c)
-void test_sizet_less_than_or_equal_format(size_t actual, size_t max_expected, const char *format, ...) __printflike(3,4);
 
 void _test_double_less_than_or_equal(const char* file, long line, const char* desc, double val, double max_expected);
 #define test_double_less_than_or_equal(d, v, m) _test_double_less_than_or_equal(__SOURCE_FILE__, __LINE__, d, v, m)

--- a/tests/dispatch_cascade.c
+++ b/tests/dispatch_cascade.c
@@ -37,7 +37,7 @@ union {
 	char padding[64];
 } indices[BLOCKS];
 
-size_t iterations = (QUEUES * BLOCKS) / 4;
+size_t iterations = QUEUES * BLOCKS * 0.25;
 
 static void
 noop(void *ctxt __attribute__((unused)))
@@ -57,7 +57,7 @@ cleanup(void *ctxt __attribute__((unused)))
 	exit(0);
 }
 
-static void
+void
 histogram(void)
 {
 	size_t counts[QUEUES] = {};
@@ -92,7 +92,7 @@ histogram(void)
 	}
 }
 
-static void
+void
 cascade(void* context)
 {
 	size_t idx, *idxptr = context;

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -101,12 +101,12 @@ test_concur_async(size_t n, size_t qw)
 	if (qw > 1) {
 		size_t concurrency = MIN(n * workers, qw);
 		if (done > min_acceptable_concurrency) {
-			test_sizet_less_than_or_equal("concurrently completed workers", done, concurrency);
+			test_long_less_than_or_equal("concurrently completed workers", done, concurrency);
 		} else {
-			test_sizet("concurrently completed workers", done, concurrency);
+			test_long("concurrently completed workers", done, concurrency);
 		}
 	} else {
-		test_sizet_less_than_or_equal("concurrently completed workers", done, 1);
+		test_long_less_than_or_equal("concurrently completed workers", done, 1);
 	}
 
 	for (i = 0, mc = mcs; i < n; i++, mc++) {
@@ -116,9 +116,9 @@ test_concur_async(size_t n, size_t qw)
 
 	size_t expect = MIN(n, qw);
 	if (max_concur > min_acceptable_concurrency) {
-		test_sizet_less_than_or_equal("max submission concurrency", max_concur, expect);
+		test_long_less_than_or_equal("max submission concurrency", max_concur, expect);
 	} else {
-		test_sizet("max submission concurrency", max_concur, expect);
+		test_long("max submission concurrency", max_concur, expect);
 	}
 
 	dispatch_group_wait(gw, DISPATCH_TIME_FOREVER);
@@ -159,9 +159,9 @@ test_concur_sync(size_t n, size_t qw)
 
 	size_t expect = qw == 1 ? 1 : n;
 	if (max_concur > min_acceptable_concurrency) {
-		test_sizet_less_than_or_equal("max sync concurrency", max_concur, expect);
+		test_long_less_than_or_equal("max sync concurrency", max_concur, expect);
 	} else {
-		test_sizet("max sync concurrency", max_concur, expect);
+		test_long("max sync concurrency", max_concur, expect);
 	}
 }
 
@@ -190,9 +190,9 @@ test_concur_apply(size_t n, size_t qw)
 
 	size_t expect = MIN(n, qw);
 	if (max_concur > min_acceptable_concurrency) {
-		test_sizet_less_than_or_equal("max apply concurrency", max_concur, expect);
+		test_long_less_than_or_equal("max apply concurrency", max_concur, expect);
 	} else {
-		test_sizet("max apply concurrency", max_concur, expect);
+		test_long("max apply concurrency", max_concur, expect);
 	}
 }
 
@@ -231,19 +231,19 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	dispatch_test_start("Dispatch Private Concurrent/Wide Queue"); // <rdar://problem/8049506&8169448&8186485>
 
 #ifdef __linux__
-	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
 #else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
 #endif
 	size_t n = activecpu / 2 > 1 ? activecpu / 2 : 1, w = activecpu * 2;
-	min_acceptable_concurrency = (uint32_t)n;
+	min_acceptable_concurrency = n;
 	dispatch_queue_t tq, ttq;
 	long qw, tqw, ttqw;
 	const char *ql, *tql, *ttql;
 	size_t qi, tqi, ttqi;
 	long qws[] = {
-		0, LONG_MAX, (long)w, 1, // 0 <=> global queue
+		0, LONG_MAX, w, 1, // 0 <=> global queue
 	};
 
 	g = dispatch_group_create();
@@ -262,16 +262,16 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 							"queue hierarchy: %s -> %s -> %s\n",
 							use_group_async ? "_group" : "", ql, tql, ttql);
 					fflush(stdout);
-					test_concur_async(n, (size_t)MIN(qw, MIN(tqw, ttqw)));
+					test_concur_async(n, MIN(qw, MIN(tqw, ttqw)));
 				}
 				fprintf(stdout, "Testing dispatch_sync on "
 						"queue hierarchy: %s -> %s -> %s\n", ql, tql, ttql);
 				fflush(stdout);
-				test_concur_sync(w, (size_t)MIN(qw, MIN(tqw, ttqw)));
+				test_concur_sync(w, MIN(qw, MIN(tqw, ttqw)));
 				fprintf(stdout, "Testing dispatch_apply on "
 						"queue hierarchy: %s -> %s -> %s\n", ql, tql, ttql);
 				fflush(stdout);
-				test_concur_apply(activecpu, (size_t)MIN(qw, MIN(tqw, ttqw)));
+				test_concur_apply(activecpu, MIN(qw, MIN(tqw, ttqw)));
 				dispatch_release(q);
 			}
 			dispatch_release(tq);

--- a/tests/dispatch_drift.c
+++ b/tests/dispatch_drift.c
@@ -48,14 +48,14 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	uint64_t interval = 1000000000 / 100;
 	double interval_d = interval / 1000000000.0;
 	// for 25 seconds
-	unsigned int target = (unsigned int)(25.0 / interval_d);
+	unsigned int target = 25 / interval_d;
 
 	dispatch_test_start("Dispatch Timer Drift");
 
 	dispatch_source_t t = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
 	test_ptr_notnull("dispatch_source_create", t);
 
-	dispatch_source_set_timer(t, dispatch_time(DISPATCH_TIME_NOW, (int64_t)interval), interval, 0);
+	dispatch_source_set_timer(t, dispatch_time(DISPATCH_TIME_NOW, interval), interval, 0);
 
 	dispatch_source_set_event_handler(t, ^{
 		struct timeval now_tv;

--- a/tests/dispatch_pingpong.c
+++ b/tests/dispatch_pingpong.c
@@ -27,14 +27,14 @@
 uint32_t count = 0;
 const uint32_t final = 1000000; // 10M
 
-static void
+void
 pingpongloop(dispatch_group_t group, dispatch_queue_t ping, dispatch_queue_t pong, size_t counter)
 {
 	//printf("[%p] %s: %lu\n", (void*)(uintptr_t)pthread_self(), dispatch_queue_get_label(dispatch_get_current_queue()), counter);
 	if (counter < final) {
 		dispatch_group_async(group, pong, ^{ pingpongloop(group, pong, ping, counter+1); });
 	} else {
-		count = (uint32_t)counter;
+		count = counter;
 	}
 }
 

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -75,14 +75,14 @@ static volatile long iterations;
 static long total;
 static size_t prio0, priorities = PRIORITIES;
 
-static int
+int
 n_blocks(void)
 {
 	static dispatch_once_t pred;
 	static int n;
 	dispatch_once(&pred, ^{
 #ifdef __linux__
-		n = (int)sysconf(_SC_NPROCESSORS_CONF);
+		n = sysconf(_SC_NPROCESSORS_CONF);
 #else
 		size_t l = sizeof(n);
 		int rc = sysctlbyname("hw.ncpu", &n, &l, NULL, 0);
@@ -93,7 +93,7 @@ n_blocks(void)
 	return n;
 }
 
-static void
+void
 histogram(void)
 {
 	long completed = 0;
@@ -126,7 +126,7 @@ histogram(void)
 	}
 }
 
-static void
+void
 cpubusy(void* context)
 {
 	if (done) return;
@@ -152,7 +152,7 @@ cpubusy(void* context)
 	}
 }
 
-static void
+void
 submit_work(dispatch_queue_t queue, void* context)
 {
 	int i;
@@ -174,7 +174,7 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	priorities--;
 #endif
 
-	iterations = total = ((int)priorities * n_blocks()) / 2;
+	iterations = total = (priorities * n_blocks()) * 0.50;
 
 #if USE_SET_TARGET_QUEUE
 	dispatch_test_start("Dispatch Priority (Set Target Queue)");

--- a/tests/dispatch_read.c
+++ b/tests/dispatch_read.c
@@ -35,7 +35,7 @@
 static size_t bytes_total;
 static size_t bytes_read;
 
-static void
+void
 test_fin(void *cxt)
 {
 	test_ptr("test_fin run", cxt, cxt);
@@ -59,7 +59,7 @@ main(void)
 		perror(path);
 		exit(EXIT_FAILURE);
 	}
-	bytes_total = (size_t)sb.st_size;
+	bytes_total = sb.st_size;
 
 	if (fcntl(infd, F_SETFL, O_NONBLOCK) != 0) {
 		perror(path);
@@ -74,7 +74,7 @@ main(void)
 	dispatch_queue_t main_q = dispatch_get_main_queue();
 	test_ptr_notnull("dispatch_get_main_queue", main_q);
 
-	dispatch_source_t reader = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)infd, 0, main_q);
+	dispatch_source_t reader = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, infd, 0, main_q);
 	test_ptr_notnull("dispatch_source_create", reader);
 	assert(reader);
 
@@ -85,11 +85,11 @@ main(void)
 		const ssize_t bufsiz = 1024*500; // 500 KB buffer
 		static char buffer[1024*500];	// 500 KB buffer
 		ssize_t actual = read(infd, buffer, sizeof(buffer));
-		bytes_read += (size_t)actual;
+		bytes_read += actual;
 		printf("bytes read: %zd\n", actual);
 		if (actual < bufsiz) {
 			actual = read(infd, buffer, sizeof(buffer));
-			bytes_read += (size_t)actual;
+			bytes_read += actual;
 			// confirm EOF condition
 			test_long("EOF", actual, 0);
 			dispatch_source_cancel(reader);
@@ -97,7 +97,7 @@ main(void)
 	});
 
 	dispatch_source_set_cancel_handler(reader, ^{
-		test_sizet("Bytes read", bytes_read, bytes_total);
+		test_long("Bytes read", bytes_read, bytes_total);
 		int res = close(infd);
 		test_errno("close", res == -1 ? errno : 0, 0);
 		dispatch_release(reader);

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -47,7 +47,7 @@
 #endif
 #endif
 
-static void
+void
 test_fin(void *cxt)
 {
 	test_ptr("test_fin run", cxt, cxt);
@@ -71,7 +71,7 @@ dispatch_read2(dispatch_fd_t fd,
 		test_stop();
 	}
 	dispatch_source_t reader = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ,
-			(uintptr_t)fd, 0, queue);
+			fd, 0, queue);
 	test_ptr_notnull("reader", reader);
 
 	__block size_t bytes_read = 0;
@@ -85,8 +85,8 @@ dispatch_read2(dispatch_fd_t fd,
 			err = errno;
 		}
 		if (actual > 0) {
-			bytes_read += (size_t)actual;
-			dispatch_data_t tmp_data = dispatch_data_create(buffer, (size_t)actual,
+			bytes_read += actual;
+			dispatch_data_t tmp_data = dispatch_data_create(buffer, actual,
 					NULL, DISPATCH_DATA_DESTRUCTOR_FREE);
 			dispatch_data_t concat = dispatch_data_create_concat(data,tmp_data);
 			dispatch_release(tmp_data);
@@ -97,7 +97,7 @@ dispatch_read2(dispatch_fd_t fd,
 		if (actual < bufsiz || bytes_read >= length) {
 			char foo[2];
 			actual = read(fd, foo, 2);
-			bytes_read += (size_t)actual;
+			bytes_read += actual;
 			// confirm EOF condition
 			test_long("EOF", actual, 0);
 			dispatch_source_cancel(reader);
@@ -138,17 +138,17 @@ test_read(void)
 		test_errno("fstat", errno, 0);
 		test_stop();
 	}
-	size_t size = (size_t)sb.st_size;
+	size_t size = sb.st_size;
 	dispatch_group_t g = dispatch_group_create();
 	void (^b)(dispatch_data_t, int) = ^(dispatch_data_t d, int error) {
 		test_errno("read error", error, 0);
-		test_sizet("dispatch data size", d ? dispatch_data_get_size(d) : 0, size);
+		test_long("dispatch data size", d ? dispatch_data_get_size(d) : 0, size);
 		if (d) {
 			const void *contig_buf;
 			size_t contig_size;
 			dispatch_data_t tmp = dispatch_data_create_map(d, &contig_buf,
 					&contig_size);
-			test_sizet("dispatch data contig size", contig_size, size);
+			test_long("dispatch data contig size", contig_size, size);
 			if (contig_size) {
 				// Validate the copied buffer is similar to what we expect
 				char *buf = (char*)malloc(size);
@@ -208,7 +208,7 @@ test_read_write(void)
 		}
 		close(in);
 		size_t siz_out = dispatch_data_get_size(data_in);
-		test_sizet("read size", siz_out, siz_in);
+		test_long("read size", siz_out, siz_in);
 		dispatch_retain(data_in);
 		data = data_in;
 		dispatch_write(out, data, q, ^(dispatch_data_t data_out, int err_out) {
@@ -225,7 +225,7 @@ test_read_write(void)
 				}
 				close(out);
 				size_t siz_cmp = dispatch_data_get_size(cmp);
-				test_sizet("readback size", siz_cmp, siz_out);
+				test_long("readback size", siz_cmp, siz_out);
 				const void *data_buf, *cmp_buf;
 				dispatch_data_t data_map, cmp_map;
 				data_map = dispatch_data_create_map(data, &data_buf, NULL);
@@ -277,7 +277,7 @@ test_read_writes(void) // <rdar://problem/7785143>
 		}
 		close(in);
 		siz_out = dispatch_data_get_size(data_in);
-		test_sizet("read size", siz_out, siz_in);
+		test_long("read size", siz_out, siz_in);
 		dispatch_retain(data_in);
 		data = data_in;
 		dispatch_data_t data_chunks[chunks_out];
@@ -314,7 +314,7 @@ test_read_writes(void) // <rdar://problem/7785143>
 		}
 		close(out);
 		size_t siz_cmp = dispatch_data_get_size(cmp);
-		test_sizet("readback size", siz_cmp, siz_out);
+		test_long("readback size", siz_cmp, siz_out);
 		const void *data_buf, *cmp_buf;
 		dispatch_data_t data_map, cmp_map;
 		data_map = dispatch_data_create_map(data, &data_buf, NULL);
@@ -383,8 +383,8 @@ test_writes_reads_eagain(void) // rdar://problem/8333366
 	close(in);
 	close(*(fd+1));
 	test_group_wait(g);
-	test_sizet("dispatch_read deliveries", deliveries, chunks);
-	test_sizet("dispatch_read data size", siz_acc, siz);
+	test_long("dispatch_read deliveries", deliveries, chunks);
+	test_long("dispatch_read data size", siz_acc, siz);
 	close(*fd);
 	Block_release(b);
 	dispatch_release(g);

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -126,9 +126,9 @@ test_readsync(dispatch_queue_t rq, dispatch_queue_t wq, size_t n)
 	}
 	free(mrs);
 
-	test_sizet("max readers", max_readers, n);
-	test_sizet("max writers", max_writers, 1);
-	test_sizet("concurrent readers & writers", crw, 0);
+	test_long("max readers", max_readers, n);
+	test_long("max writers", max_writers, 1);
+	test_long("concurrent readers & writers", crw, 0);
 }
 
 int
@@ -138,7 +138,7 @@ main(void)
 
 	uint32_t activecpu, wq_max_threads;
 #ifdef __linux__
-	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
 	// don't want to parse /proc/sys/kernel/threads-max
 	wq_max_threads = activecpu * NTHREADS + 2;
 #else

--- a/tests/dispatch_suspend_timer.c
+++ b/tests/dispatch_suspend_timer.c
@@ -30,7 +30,7 @@
 dispatch_source_t tweedledee;
 dispatch_source_t tweedledum;
 
-static void
+void
 fini(void *cxt)
 {
 	test_ptr_notnull("finalizer ran", cxt);
@@ -39,7 +39,7 @@ fini(void *cxt)
 	}
 }
 
-static void
+void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Suspend Timer");


### PR DESCRIPTION
Reverts apple/swift-corelibs-libdispatch#290

Sorry to revert, but this breaks Swift CI incremental bots and PR testing (so it's blocking all other work)

swift-corelibs-libdispatch/os/linux_base.h:16:10: fatal error: 'config/config_ac.h' file not found
#include <config/config_ac.h>
         ^

https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04/4182/console
