### PR TITLE
Revert "linux: update header used for `major` macro"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ check_include_files("sys/cdefs.h" HAVE_SYS_CDEFS_H)
 check_include_files("sys/guarded.h" HAVE_SYS_GUARDED_H)
 check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
 check_include_files("sys/types.h" HAVE_SYS_TYPES_H)
-check_include_files("sys/sysmacros.h" HAVE_SYS_SYSMACROS_H)
 check_include_files("unistd.h" HAVE_UNISTD_H)
 check_include_files("objc/objc-internal.h" HAVE_OBJC)
 

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -188,9 +188,6 @@
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine01 HAVE_SYS_TYPES_H
 
-/* Define to 1 if you have the <sys/sysmacros.h> header file.  */
-#cmakedefine01 HAVE_SYS_SYSMACROS_H
-
 /* Define to 1 if you have the <TargetConditionals.h> header file. */
 #cmakedefine HAVE_TARGETCONDITIONALS_H
 

--- a/os/linux_base.h
+++ b/os/linux_base.h
@@ -13,11 +13,6 @@
 #ifndef __OS_LINUX_BASE__
 #define __OS_LINUX_BASE__
 
-#include <config/config_ac.h>
-
-#if HAVE_SYS_SYSMACROS_H
-#include <sys/sysmacros.h>
-#endif
 #include <sys/param.h>
 
 #if HAVE_SYS_CDEFS_H


### PR DESCRIPTION
Reverts apple/swift-corelibs-libdispatch#286

Sorry to revert, but this breaks Swift CI incremental bots and PR testing (so it's blocking all other work)

swift-corelibs-libdispatch/os/linux_base.h:16:10: fatal error: 'config/config_ac.h' file not found
#include <config/config_ac.h>
^

https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04/4182/console