### PR TITLE
Reapply "Fix compilation warnings in extended test suite".

### DIFF
--- a/tests/bsdtests.c
+++ b/tests/bsdtests.c
@@ -189,6 +189,20 @@ test_long_format(long actual, long expected, const char* format, ...)
 }
 
 void
+_test_sizet(const char* file, long line, const char* desc, size_t actual, size_t expected)
+{
+	_test_print(file, line, desc,
+		(actual == expected), "%zd", actual, "%zd", expected);
+}
+
+void
+test_sizet_format(size_t actual, size_t expected, const char* format, ...)
+{
+	GENERATE_DESC
+	_test_sizet(NULL, 0, desc, actual, expected);
+}
+
+void
 _test_uint64(const char* file, long line, const char* desc, uint64_t actual, uint64_t expected)
 {
 	_test_print(file, line, desc,
@@ -253,6 +267,32 @@ test_long_greater_than_or_equal_format(long actual, long expected_max, const cha
 {
 	GENERATE_DESC
 	_test_long_greater_than_or_equal(NULL, 0, desc, actual, expected_max);
+}
+
+void
+_test_sizet_less_than(const char* file, long line, const char* desc, size_t actual, size_t expected_max)
+{
+	_test_print(file, line, desc, (actual < expected_max), "%zd", actual, "<%zd", expected_max);
+}
+
+void
+test_sizet_less_than_format(size_t actual, size_t expected_max, const char* format, ...)
+{
+	GENERATE_DESC
+	_test_sizet_less_than(NULL, 0, desc, actual, expected_max);
+}
+
+void
+_test_sizet_less_than_or_equal(const char* file, long line, const char* desc, size_t actual, size_t expected_max)
+{
+	_test_print(file, line, desc, (actual <= expected_max), "%zd", actual, "<=%zd", expected_max);
+}
+
+void
+test_sizet_less_than_or_equal_format(size_t actual, size_t expected_max, const char* format, ...)
+{
+	GENERATE_DESC
+	_test_sizet_less_than_or_equal(NULL, 0, desc, actual, expected_max);
 }
 
 void

--- a/tests/bsdtests.h
+++ b/tests/bsdtests.h
@@ -91,6 +91,10 @@ void _test_long(const char* file, long line, const char* desc, long actual, long
 #define test_long(a,b,c) _test_long(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_long_format(long actual, long expected, const char *format, ...) __printflike(3,4);
 
+void _test_sizet(const char* file, long line, const char* desc, size_t actual, size_t expected);
+#define test_sizet(a,b,c) _test_sizet(__SOURCE_FILE__, __LINE__, a, b, c)
+void test_sizet_format(size_t actual, size_t expected, const char *format, ...) __printflike(3,4);
+
 void _test_uint64(const char* file, long line, const char* desc, uint64_t actual, uint64_t expected);
 #define test_uint64(a,b,c) _test_uint64(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_uint64_format(uint64_t actual, uint64_t expected, const char* desc, ...);
@@ -110,6 +114,14 @@ void test_long_less_than_or_equal_format(long actual, long max_expected, const c
 void _test_long_greater_than_or_equal(const char* file, long line, const char* desc, long actual, long expected_min);
 #define test_long_greater_than_or_equal(a,b,c) _test_long_greater_than_or_equal(__SOURCE_FILE__, __LINE__, a, b, c)
 void test_long_greater_than_or_equal_format(long actual, long expected_min, const char *format, ...) __printflike(3,4);
+
+void _test_sizet_less_than(const char* file, long line, const char* desc, size_t actual, size_t max_expected);
+#define test_sizet_less_than(a,b,c) _test_sizet_less_than(__SOURCE_FILE__, __LINE__, a, b, c)
+void test_sizet_less_than_format(size_t actual, size_t max_expected, const char *format, ...) __printflike(3,4);
+
+void _test_sizet_less_than_or_equal(const char* file, long line, const char* desc, size_t actual, size_t max_expected);
+#define test_sizet_less_than_or_equal(a,b,c) _test_sizet_less_than_or_equal(__SOURCE_FILE__, __LINE__, a, b, c)
+void test_sizet_less_than_or_equal_format(size_t actual, size_t max_expected, const char *format, ...) __printflike(3,4);
 
 void _test_double_less_than_or_equal(const char* file, long line, const char* desc, double val, double max_expected);
 #define test_double_less_than_or_equal(d, v, m) _test_double_less_than_or_equal(__SOURCE_FILE__, __LINE__, d, v, m)

--- a/tests/dispatch_cascade.c
+++ b/tests/dispatch_cascade.c
@@ -37,7 +37,7 @@ union {
 	char padding[64];
 } indices[BLOCKS];
 
-size_t iterations = QUEUES * BLOCKS * 0.25;
+size_t iterations = (QUEUES * BLOCKS) / 4;
 
 static void
 noop(void *ctxt __attribute__((unused)))
@@ -57,7 +57,7 @@ cleanup(void *ctxt __attribute__((unused)))
 	exit(0);
 }
 
-void
+static void
 histogram(void)
 {
 	size_t counts[QUEUES] = {};
@@ -92,7 +92,7 @@ histogram(void)
 	}
 }
 
-void
+static void
 cascade(void* context)
 {
 	size_t idx, *idxptr = context;

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -101,12 +101,12 @@ test_concur_async(size_t n, size_t qw)
 	if (qw > 1) {
 		size_t concurrency = MIN(n * workers, qw);
 		if (done > min_acceptable_concurrency) {
-			test_long_less_than_or_equal("concurrently completed workers", done, concurrency);
+			test_sizet_less_than_or_equal("concurrently completed workers", done, concurrency);
 		} else {
-			test_long("concurrently completed workers", done, concurrency);
+			test_sizet("concurrently completed workers", done, concurrency);
 		}
 	} else {
-		test_long_less_than_or_equal("concurrently completed workers", done, 1);
+		test_sizet_less_than_or_equal("concurrently completed workers", done, 1);
 	}
 
 	for (i = 0, mc = mcs; i < n; i++, mc++) {
@@ -116,9 +116,9 @@ test_concur_async(size_t n, size_t qw)
 
 	size_t expect = MIN(n, qw);
 	if (max_concur > min_acceptable_concurrency) {
-		test_long_less_than_or_equal("max submission concurrency", max_concur, expect);
+		test_sizet_less_than_or_equal("max submission concurrency", max_concur, expect);
 	} else {
-		test_long("max submission concurrency", max_concur, expect);
+		test_sizet("max submission concurrency", max_concur, expect);
 	}
 
 	dispatch_group_wait(gw, DISPATCH_TIME_FOREVER);
@@ -159,9 +159,9 @@ test_concur_sync(size_t n, size_t qw)
 
 	size_t expect = qw == 1 ? 1 : n;
 	if (max_concur > min_acceptable_concurrency) {
-		test_long_less_than_or_equal("max sync concurrency", max_concur, expect);
+		test_sizet_less_than_or_equal("max sync concurrency", max_concur, expect);
 	} else {
-		test_long("max sync concurrency", max_concur, expect);
+		test_sizet("max sync concurrency", max_concur, expect);
 	}
 }
 
@@ -190,9 +190,9 @@ test_concur_apply(size_t n, size_t qw)
 
 	size_t expect = MIN(n, qw);
 	if (max_concur > min_acceptable_concurrency) {
-		test_long_less_than_or_equal("max apply concurrency", max_concur, expect);
+		test_sizet_less_than_or_equal("max apply concurrency", max_concur, expect);
 	} else {
-		test_long("max apply concurrency", max_concur, expect);
+		test_sizet("max apply concurrency", max_concur, expect);
 	}
 }
 
@@ -231,19 +231,19 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	dispatch_test_start("Dispatch Private Concurrent/Wide Queue"); // <rdar://problem/8049506&8169448&8186485>
 
 #ifdef __linux__
-	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
+	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);
 #endif
 	size_t n = activecpu / 2 > 1 ? activecpu / 2 : 1, w = activecpu * 2;
-	min_acceptable_concurrency = n;
+	min_acceptable_concurrency = (uint32_t)n;
 	dispatch_queue_t tq, ttq;
 	long qw, tqw, ttqw;
 	const char *ql, *tql, *ttql;
 	size_t qi, tqi, ttqi;
 	long qws[] = {
-		0, LONG_MAX, w, 1, // 0 <=> global queue
+		0, LONG_MAX, (long)w, 1, // 0 <=> global queue
 	};
 
 	g = dispatch_group_create();
@@ -262,16 +262,16 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 							"queue hierarchy: %s -> %s -> %s\n",
 							use_group_async ? "_group" : "", ql, tql, ttql);
 					fflush(stdout);
-					test_concur_async(n, MIN(qw, MIN(tqw, ttqw)));
+					test_concur_async(n, (size_t)MIN(qw, MIN(tqw, ttqw)));
 				}
 				fprintf(stdout, "Testing dispatch_sync on "
 						"queue hierarchy: %s -> %s -> %s\n", ql, tql, ttql);
 				fflush(stdout);
-				test_concur_sync(w, MIN(qw, MIN(tqw, ttqw)));
+				test_concur_sync(w, (size_t)MIN(qw, MIN(tqw, ttqw)));
 				fprintf(stdout, "Testing dispatch_apply on "
 						"queue hierarchy: %s -> %s -> %s\n", ql, tql, ttql);
 				fflush(stdout);
-				test_concur_apply(activecpu, MIN(qw, MIN(tqw, ttqw)));
+				test_concur_apply(activecpu, (size_t)MIN(qw, MIN(tqw, ttqw)));
 				dispatch_release(q);
 			}
 			dispatch_release(tq);

--- a/tests/dispatch_drift.c
+++ b/tests/dispatch_drift.c
@@ -48,14 +48,14 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	uint64_t interval = 1000000000 / 100;
 	double interval_d = interval / 1000000000.0;
 	// for 25 seconds
-	unsigned int target = 25 / interval_d;
+	unsigned int target = (unsigned int)(25.0 / interval_d);
 
 	dispatch_test_start("Dispatch Timer Drift");
 
 	dispatch_source_t t = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
 	test_ptr_notnull("dispatch_source_create", t);
 
-	dispatch_source_set_timer(t, dispatch_time(DISPATCH_TIME_NOW, interval), interval, 0);
+	dispatch_source_set_timer(t, dispatch_time(DISPATCH_TIME_NOW, (int64_t)interval), interval, 0);
 
 	dispatch_source_set_event_handler(t, ^{
 		struct timeval now_tv;

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -52,7 +52,7 @@
 #endif
 #endif
 
-void
+static void
 test_fin(void *cxt)
 {
 	test_ptr("test_fin run", cxt, cxt);
@@ -96,7 +96,7 @@ test_io_close(int with_timer, bool from_path)
 		test_errno("fstat", errno, 0);
 		test_stop();
 	}
-	const size_t size = sb.st_size / chunks;
+	const size_t size = (size_t)sb.st_size / chunks;
 	const int expected_error = with_timer? ECANCELED : 0;
 	dispatch_source_t t = NULL;
 	dispatch_group_t g = dispatch_group_create();
@@ -142,7 +142,7 @@ test_io_close(int with_timer, bool from_path)
 	for (i = 0; i < chunks; i++) {
 		data[i] = dispatch_data_empty;
 		dispatch_group_enter(g);
-		dispatch_io_read(io, i * size, size, dispatch_get_global_queue(0,0),
+		dispatch_io_read(io, (off_t)(i * size), size, dispatch_get_global_queue(0,0),
 				^(bool done, dispatch_data_t d, int error) {
 			if (d) {
 				chunk_size[i] += dispatch_data_get_size(d);
@@ -180,16 +180,16 @@ test_io_close(int with_timer, bool from_path)
 	}
 	for (i = 0; i < chunks; i++) {
 		if (with_timer) {
-			test_long_less_than("chunk size", chunk_size[i], size + 1);
+			test_sizet_less_than("chunk size", chunk_size[i], size + 1);
 		} else {
-			test_long("chunk size", chunk_size[i], size);
+			test_sizet("chunk size", chunk_size[i], size);
 		}
 		total += chunk_size[i];
 	}
 	if (with_timer) {
-		test_long_less_than("total size", total, chunks * size + 1);
+		test_sizet_less_than("total size", total, chunks * size + 1);
 	} else {
-		test_long("total size", total, chunks * size);
+		test_sizet("total size", total, chunks * size);
 	}
 }
 
@@ -251,7 +251,7 @@ test_io_read_write(void)
 		test_errno("fstat", errno, 0);
 		test_stop();
 	}
-	const size_t siz_in = MIN(1024 * 1024, sb.st_size);
+	const size_t siz_in = MIN(1024 * 1024, (size_t)sb.st_size);
 
 	int out = mkstemp(path_out);
 	if (out == -1) {
@@ -283,7 +283,7 @@ test_io_read_write(void)
 	dispatch_group_enter(g);
 	dispatch_io_read(io_in, 0, siz_in, q,
 			^(bool done_in, dispatch_data_t data_in, int err_in) {
-		test_long_less_than("read size", dispatch_data_get_size(data_in),
+		test_sizet_less_than("read size", dispatch_data_get_size(data_in),
 				siz_in);
 		if (data_in) {
 			dispatch_group_enter(g);
@@ -291,11 +291,11 @@ test_io_read_write(void)
 					^(bool done_out, dispatch_data_t data_out, int err_out) {
 				if (done_out) {
 					test_errno("dispatch_io_write", err_out, 0);
-					test_long("remaining write size",
+					test_sizet("remaining write size",
 							data_out ? dispatch_data_get_size(data_out) : 0, 0);
 					dispatch_group_leave(g);
 				} else {
-					test_long_less_than("remaining write size",
+					test_sizet_less_than("remaining write size",
 							dispatch_data_get_size(data_out), siz_in);
 				}
 			});
@@ -321,7 +321,7 @@ test_io_read_write(void)
 		}
 		close(out);
 		size_t siz_cmp = dispatch_data_get_size(cmp);
-		test_long("readback size", siz_cmp, siz_in);
+		test_sizet("readback size", siz_cmp, siz_in);
 		const void *data_buf, *cmp_buf;
 		dispatch_data_t data_map, cmp_map;
 		data_map = dispatch_data_create_map(data, &data_buf, NULL);
@@ -378,7 +378,7 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 				}
 				free(buffer);
 				close(fd);
-				process_data(r);
+				process_data((size_t)r);
 			});
 			break;
 		case DISPATCH_READ_ON_CONCURRENT_QUEUE:
@@ -455,7 +455,7 @@ test_read_dirs(char **paths, dispatch_queue_t queue, dispatch_group_t g,
 		test_ptr_notnull("fts_open failed", tree);
 		test_stop();
 	}
-	unsigned int files_opened = 0;
+	int files_opened = 0;
 	size_t size, total_size = 0;
 	FTSENT *node;
 	while ((node = fts_read(tree)) &&
@@ -465,11 +465,11 @@ test_read_dirs(char **paths, dispatch_queue_t queue, dispatch_group_t g,
 		} else if (node->fts_info == FTS_F) {
 			dispatch_group_enter(g);
 			dispatch_semaphore_wait(s, DISPATCH_TIME_FOREVER);
-			size = node->fts_statp->st_size;
+			size = (size_t)node->fts_statp->st_size;
 			total_size += size;
 			files_opened++;
 			test_async_read(node->fts_path, size, option, queue, ^(size_t len){
-				OSAtomicAdd32(len, bytes);
+				OSAtomicAdd32((int32_t)len, (volatile int32_t *)bytes);
 				dispatch_semaphore_signal(s);
 				dispatch_group_leave(g);
 			});
@@ -485,7 +485,7 @@ test_read_dirs(char **paths, dispatch_queue_t queue, dispatch_group_t g,
 		test_stop();
 	}
 	test_group_wait(g);
-	test_long("total size", *bytes, total_size);
+	test_sizet("total size", *bytes, total_size);
 	return files_opened;
 }
 
@@ -506,7 +506,7 @@ test_read_many_files(void)
 	dispatch_semaphore_t s = dispatch_semaphore_create(maxopenfiles);
 	uint64_t start;
 	volatile uint32_t bytes;
-	unsigned int files_read, i;
+	int files_read, i;
 
 	const dispatch_queue_t queues[] = {
 		[DISPATCH_ASYNC_READ_ON_CONCURRENT_QUEUE] =
@@ -546,7 +546,7 @@ test_read_many_files(void)
 		l.rlim_cur = 2 * maxopenfiles + 256;
 		setrlimit(RLIMIT_NOFILE, &l);
 	}
-	for (i = 0; i < sizeof(queues)/sizeof(dispatch_queue_t); ++i) {
+	for (i = 0; i < (int)(sizeof(queues)/sizeof(dispatch_queue_t)); ++i) {
 		fprintf(stdout, "%s:\n", names[i]);
 		bytes = 0;
 		start = mach_absolute_time();
@@ -610,7 +610,7 @@ test_io_from_io(void) // rdar://problem/8388909
 #else
 		test_errno("error from write to write protected directory", err_out, EACCES);
 #endif
-		test_long("unwritten data", dispatch_data_get_size(data_out), 256);
+		test_sizet("unwritten data", dispatch_data_get_size(data_out), 256);
 		if (!err_out && done) {
 			test_stop();
 		}
@@ -661,11 +661,11 @@ test_io_from_io(void) // rdar://problem/8388909
 				^(bool done, dispatch_data_t data_out, int err_out) {
 			if (done) {
 				test_errno("dispatch_io_write", err_out, 0);
-				test_long("remaining write size",
+				test_sizet("remaining write size",
 						data_out ? dispatch_data_get_size(data_out) : 0, 0);
 				dispatch_group_leave(g);
 			} else {
-				test_long_less_than("remaining write size",
+				test_sizet_less_than("remaining write size",
 						dispatch_data_get_size(data_out), siz_in);
 			}
 		});
@@ -696,7 +696,7 @@ test_io_from_io(void) // rdar://problem/8388909
 	dispatch_release(io2);
 	test_group_wait(g);
 	dispatch_release(g);
-	test_long("readback size", dispatch_data_get_size(data_out), siz_in);
+	test_sizet("readback size", dispatch_data_get_size(data_out), siz_in);
 	dispatch_release(data_out);
 #endif
 }

--- a/tests/dispatch_pingpong.c
+++ b/tests/dispatch_pingpong.c
@@ -27,14 +27,14 @@
 uint32_t count = 0;
 const uint32_t final = 1000000; // 10M
 
-void
+static void
 pingpongloop(dispatch_group_t group, dispatch_queue_t ping, dispatch_queue_t pong, size_t counter)
 {
 	//printf("[%p] %s: %lu\n", (void*)(uintptr_t)pthread_self(), dispatch_queue_get_label(dispatch_get_current_queue()), counter);
 	if (counter < final) {
 		dispatch_group_async(group, pong, ^{ pingpongloop(group, pong, ping, counter+1); });
 	} else {
-		count = counter;
+		count = (uint32_t)counter;
 	}
 }
 

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -75,14 +75,14 @@ static volatile long iterations;
 static long total;
 static size_t prio0, priorities = PRIORITIES;
 
-int
+static int
 n_blocks(void)
 {
 	static dispatch_once_t pred;
 	static int n;
 	dispatch_once(&pred, ^{
 #ifdef __linux__
-		n = sysconf(_SC_NPROCESSORS_CONF);
+		n = (int)sysconf(_SC_NPROCESSORS_CONF);
 #else
 		size_t l = sizeof(n);
 		int rc = sysctlbyname("hw.ncpu", &n, &l, NULL, 0);
@@ -93,7 +93,7 @@ n_blocks(void)
 	return n;
 }
 
-void
+static void
 histogram(void)
 {
 	long completed = 0;
@@ -126,7 +126,7 @@ histogram(void)
 	}
 }
 
-void
+static void
 cpubusy(void* context)
 {
 	if (done) return;
@@ -152,7 +152,7 @@ cpubusy(void* context)
 	}
 }
 
-void
+static void
 submit_work(dispatch_queue_t queue, void* context)
 {
 	int i;
@@ -174,7 +174,7 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	priorities--;
 #endif
 
-	iterations = total = (priorities * n_blocks()) * 0.50;
+	iterations = total = ((int)priorities * n_blocks()) / 2;
 
 #if USE_SET_TARGET_QUEUE
 	dispatch_test_start("Dispatch Priority (Set Target Queue)");

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -126,9 +126,9 @@ test_readsync(dispatch_queue_t rq, dispatch_queue_t wq, size_t n)
 	}
 	free(mrs);
 
-	test_long("max readers", max_readers, n);
-	test_long("max writers", max_writers, 1);
-	test_long("concurrent readers & writers", crw, 0);
+	test_sizet("max readers", max_readers, n);
+	test_sizet("max writers", max_writers, 1);
+	test_sizet("concurrent readers & writers", crw, 0);
 }
 
 int
@@ -138,7 +138,7 @@ main(void)
 
 	uint32_t activecpu, wq_max_threads;
 #ifdef __linux__
-	activecpu = sysconf(_SC_NPROCESSORS_ONLN);
+	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 	// don't want to parse /proc/sys/kernel/threads-max
 	wq_max_threads = activecpu * NTHREADS + 2;
 #else

--- a/tests/dispatch_suspend_timer.c
+++ b/tests/dispatch_suspend_timer.c
@@ -30,7 +30,7 @@
 dispatch_source_t tweedledee;
 dispatch_source_t tweedledum;
 
-void
+static void
 fini(void *cxt)
 {
 	test_ptr_notnull("finalizer ran", cxt);
@@ -39,7 +39,7 @@ fini(void *cxt)
 	}
 }
 
-void
+static void
 test_timer(void)
 {
 	dispatch_test_start("Dispatch Suspend Timer");


### PR DESCRIPTION
This restores pull request #290 from dgrove-oss/fix-warnings-extended-tests.

This was an accidental revert. Somehow the revert button on github led
me to the wrong PR.