### PR TITLE
Independent main queue for Android

### DIFF
--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -107,9 +107,17 @@ public extension DispatchQueue {
 		_swift_dispatch_apply_current(iterations, work)
 	}
 
+	#if os(Android)
+	static var androidSwiftMain = DispatchQueue(label: "AndroidSwiftMain")
+
+	public class var main: DispatchQueue {
+        return DispatchQueue.androidSwiftMain
+	}
+	#else
 	public class var main: DispatchQueue {
 		return DispatchQueue(queue: _swift_dispatch_get_main_queue())
 	}
+	#endif
 
 	@available(OSX, deprecated: 10.10, message: "")
 	@available(*, deprecated: 8.0, message: "")


### PR DESCRIPTION
Hi Apple,

Please excuse the unorthodoxy of this request but this PR creates an independent main queue for Android applications. The OS's main queue is owned by the Java side of an application and work items async-queued to to current main queue are never getting executed. This change allows applications to use this pseudo main queue for synchronising work and only affects applications that are being compiled for Android where the current main queue has no meaning.

Thanks.