### PR TITLE
SR-4677: avoid SIGSEGV if _dispatch_muxnote_create returns NULL

### DIFF
--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -276,11 +276,13 @@ _dispatch_unote_register(dispatch_unote_t du,
 		}
 	} else {
 		dmn = _dispatch_muxnote_create(du, events);
-		if (_dispatch_epoll_update(dmn, events, EPOLL_CTL_ADD) < 0) {
-			_dispatch_muxnote_dispose(dmn);
-			dmn = NULL;
-		} else {
-			TAILQ_INSERT_TAIL(dmb, dmn, dmn_list);
+		if (dmn) {
+			if (_dispatch_epoll_update(dmn, events, EPOLL_CTL_ADD) < 0) {
+				_dispatch_muxnote_dispose(dmn);
+				dmn = NULL;
+			} else {
+				TAILQ_INSERT_TAIL(dmb, dmn, dmn_list);
+			}
 		}
 	}
 


### PR DESCRIPTION
It is possible for _dispatch_muxnote_create to return NULL, this error
condition was not being handled in dispatch_unote_register leading to
an immediate SIGSEGV when it happened.