### PR TITLE
build: fix symlink creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,21 +201,19 @@ if(leaks_EXECUTABLE)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_custom_command(OUTPUT
-                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+  add_custom_target(module-map-symlinks
+                    ALL
+                    COMMAND
+                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                    COMMAND
+                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
 else()
-  add_custom_command(OUTPUT
-                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+  add_custom_target(module-map-symlinks
+                    ALL
+                    COMMAND
+                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                    COMMAND
+                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
 endif()
 configure_file("${CMAKE_SOURCE_DIR}/cmake/config.h.in"
                "${CMAKE_BINARY_DIR}/config/config_ac.h")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,8 @@ if(CMAKE_SWIFT_COMPILER)
                     SWIFT_FLAGS
                       -I ${CMAKE_SOURCE_DIR}
                       ${swift_optimization_flags})
+  add_dependencies(swiftDispatch
+                     module-map-symlinks)
   target_sources(dispatch
                  PRIVATE
                    swift/DispatchStubs.cc


### PR DESCRIPTION
This adjusts the symlink creation so that it always occurs.  This also
allows us to ensure that we wire up the dependency for the swift module
to the symlink creation.  The CMake based build would fail without this
when trying to build dispatch for SourceKit on Linux.