### PR TITLE
Properly pick up new events when reusing a muxnote

### DIFF
--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -270,7 +270,7 @@ _dispatch_unote_register(dispatch_unote_t du,
 			if (_dispatch_epoll_update(dmn, events, EPOLL_CTL_MOD) < 0) {
 				dmn = NULL;
 			} else {
-				dmn->dmn_events = events;
+				dmn->dmn_events |= events;
 				dmn->dmn_disarmed_events &= ~events;
 			}
 		}


### PR DESCRIPTION
Changes for SR-5759 introduced a bug where disarmed events got dropped when
a muxnote is reused, due to erroneously setting dmn->dmn_events to the
combination of new events and currently armed events.

Combining existing events with the combination of new events and armed events
implements the intended behavior.