### PR TITLE
Attempt to be better with signed conversions

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -59,7 +59,7 @@ enum {
 static const unsigned char base32_encode_table[] =
 		"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
-static const char base32_decode_table[] = {
+static const signed char base32_decode_table[] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 26,
@@ -67,13 +67,13 @@ static const char base32_decode_table[] = {
 	 3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
 	20, 21, 22, 23, 24, 25
 };
-static const ssize_t base32_decode_table_size = sizeof(base32_decode_table)
-		/ sizeof(*base32_decode_table);
+static const ssize_t base32_decode_table_size =
+		sizeof(base32_decode_table) / sizeof(*base32_decode_table);
 
 static const unsigned char base32hex_encode_table[] =
 		"0123456789ABCDEFGHIJKLMNOPQRSTUV";
 
-static const char base32hex_decode_table[] = {
+static const signed char base32hex_decode_table[] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  0,  1,  2,
@@ -87,7 +87,7 @@ static const ssize_t base32hex_decode_table_size =
 static const unsigned char base64_encode_table[] =
 		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-static const char base64_decode_table[] = {
+static const signed char base64_decode_table[] = {
 	-1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
 	-1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
 	-1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
@@ -99,8 +99,8 @@ static const char base64_decode_table[] = {
 	41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51
 };
 
-static const ssize_t base64_decode_table_size = sizeof(base64_decode_table)
-		/ sizeof(*base64_decode_table);
+static const ssize_t base64_decode_table_size =
+		sizeof(base64_decode_table) / sizeof(*base64_decode_table);
 
 #pragma mark -
 #pragma mark dispatch_transform_buffer
@@ -555,7 +555,7 @@ _dispatch_transform_to_utf16be(dispatch_data_t data)
 
 static dispatch_data_t
 _dispatch_transform_from_base32_with_table(dispatch_data_t data,
-		const char* table, ssize_t table_size)
+		const signed char* table, ssize_t table_size)
 {
 	__block uint64_t x = 0, count = 0, pad = 0;
 
@@ -585,7 +585,7 @@ _dispatch_transform_from_base32_with_table(dispatch_data_t data,
 			}
 			count++;
 
-			char value = table[index];
+			signed char value = table[index];
 			if (value == -2) {
 				value = 0;
 				pad++;
@@ -830,7 +830,7 @@ _dispatch_transform_from_base64(dispatch_data_t data)
 			}
 			count++;
 
-			char value = base64_decode_table[index];
+			signed char value = base64_decode_table[index];
 			if (value == -2) {
 				value = 0;
 				pad++;


### PR DESCRIPTION
Most targets use unsigned chars.  Explicitly change the static tables to
`signed char`.  An alternative  would be to force signed chars during
the compilation of libdispatch.  When building for Linux AArch64, the
use of `-1` causes signed conversion warnings when initializing the
table.