### PR TITLE
build: explicitly link tests to swiftCore swiftOnoneSupport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,32 @@ dispatch_common_warnings()
 option(ENABLE_DISPATCH_INIT_CONSTRUCTOR "enable libdispatch_init as a constructor" ON)
 set(USE_LIBDISPATCH_INIT_CONSTRUCTOR ${ENABLE_DISPATCH_INIT_CONSTRUCTOR})
 
-# TODO(compnerd) swift options
+option(ENABLE_SWIFT "enable libdispatch swift overlay" OFF)
+if(ENABLE_SWIFT)
+  if(NOT CMAKE_SWIFT_COMPILER)
+    message(FATAL_ERROR "CMAKE_SWIFT_COMPILER must be defined to enable swift")
+  endif()
+
+  get_filename_component(SWIFT_TOOLCHAIN ${CMAKE_SWIFT_COMPILER} DIRECTORY)
+  get_filename_component(SWIFT_TOOLCHAIN ${SWIFT_TOOLCHAIN} DIRECTORY)
+
+  string(TOLOWER ${CMAKE_SYSTEM_NAME} SWIFT_OS)
+  set(SWIFT_RUNTIME_LIBDIR ${SWIFT_TOOLCHAIN}/lib/swift/${SWIFT_OS}/${CMAKE_SYSTEM_PROCESSOR})
+
+  add_library(swiftCore
+              SHARED IMPORTED GLOBAL)
+  set_target_properties(swiftCore
+                        PROPERTIES
+                          IMPORTED_LOCATION
+                            ${SWIFT_RUNTIME_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}swiftCore${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+  add_library(swiftSwiftOnoneSupport
+              SHARED IMPORTED GLOBAL)
+  set_target_properties(swiftSwiftOnoneSupport
+                        PROPERTIES
+                          IMPORTED_LOCATION
+                           ${SWIFT_RUNTIME_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}swiftSwiftOnoneSupport${CMAKE_SHARED_LIBRARY_SUFFIX})
+endif()
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 

--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -14,11 +14,12 @@ install(FILES
           source.h
           time.h
         DESTINATION
-          ${CMAKE_INSTALL_FULL_INCLUDEDIR}/dispatch/)
+          ${CMAKE_INSTALL_FULL_INCLUDEDIR}/dispatch)
 if(ENABLE_SWIFT)
+  get_filename_component(MODULE_MAP module.modulemap REALPATH)
   install(FILES
-            module.modulemap
+            ${MODULE_MAP}
           DESTINATION
-            ${CMAKE_INSTALL_FULL_INCLUEDIR}/dispatch/)
+            ${CMAKE_INSTALL_FULL_INCLUDEDIR}/dispatch)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ if(HAVE_OBJC)
                    data.m
                    object.m)
 endif()
-if(CMAKE_SWIFT_COMPILER)
+if(ENABLE_SWIFT)
   set(swift_optimization_flags)
   if(CMAKE_BUILD_TYPE MATCHES Release)
     set(swift_optimization_flags -O)
@@ -203,4 +203,11 @@ install(TARGETS
           dispatch
         DESTINATION
           "${CMAKE_INSTALL_FULL_LIBDIR}")
+if(ENABLE_SWIFT)
+  install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftmodule
+            ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftdoc
+          DESTINATION
+            "${CMAKE_INSTALL_FULL_LIBDIR}/swift/${SWIFT_OS}/${CMAKE_SYSTEM_PROCESSOR}")
+endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,19 +2,6 @@
 execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_SOURCE_DIR}/private" "${CMAKE_CURRENT_BINARY_DIR}/dispatch")
 execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/leaks-wrapper.sh" "${CMAKE_CURRENT_BINARY_DIR}/leaks-wrapper")
 
-# TODO(compnerd) hoist this out of the test directory
-if(SWIFT_RUNTIME_LIBDIR)
-  add_library(swiftCore SHARED IMPORTED)
-  set_target_properties(swiftCore
-                        PROPERTIES
-                          IMPORTED_LOCATION ${SWIFT_RUNTIME_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}swiftCore${CMAKE_SHARED_LIBRARY_SUFFIX})
-
-  add_library(swiftSwiftOnoneSupport SHARED IMPORTED)
-  set_target_properties(swiftSwiftOnoneSupport
-                        PROPERTIES
-                          IMPORTED_LOCATION ${SWIFT_RUNTIME_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}swiftSwiftOnoneSupport${CMAKE_SHARED_LIBRARY_SUFFIX})
-endif()
-
 add_library(bsdtests
             STATIC
               bsdtests.c
@@ -74,10 +61,11 @@ function(add_unit_test name)
                                ${CMAKE_CURRENT_BINARY_DIR}
                                ${CMAKE_CURRENT_SOURCE_DIR}
                                ${CMAKE_SOURCE_DIR})
-  if(CMAKE_SWIFT_COMPILER)
-	# For testing in swift.org CI system; make deadlines lenient by default
-	# to reduce probability of test failures due to machine load.
-	target_compile_options(${name} PRIVATE -DLENIENT_DEADLINES=1)
+  if(ENABLE_SWIFT)
+    # For testing in swift.org CI system; make deadlines lenient by default
+    # to reduce probability of test failures due to machine load.
+    target_compile_options(${name} PRIVATE -DLENIENT_DEADLINES=1)
+    target_link_libraries(${name} PRIVATE swiftCore swiftSwiftOnoneSupport)
   endif()
   if(WITH_BLOCKS_RUNTIME)
     target_include_directories(${name}


### PR DESCRIPTION
Add explicit links against the swift runtime for the tests which may
use the swift runtime.  This prevents link failures for the swift tests.