### PR TITLE
build: add a dependency on the swift compiler

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -57,6 +57,7 @@ function(add_swift_library library)
                        ${module_directory}/${ASL_MODULE_NAME}.swiftdoc
                      DEPENDS
                        ${ASL_SOURCES}
+                       ${CMAKE_SWIFT_COMPILER}
                      COMMAND
                        ${CMAKE_COMMAND} -E make_directory ${module_directory}
                      COMMAND


### PR DESCRIPTION
Add a dependency on the swift compiler to ensure that a change to the
compiler will rebuild the swift portions.