### PR TITLE
Fix the install path for the toolchain

### DIFF
--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -14,12 +14,12 @@ install(FILES
           source.h
           time.h
         DESTINATION
-          ${CMAKE_INSTALL_FULL_INCLUDEDIR}/dispatch)
+          "${CMAKE_INSTALL_LIBDIR}/swift/dispatch")
 if(ENABLE_SWIFT)
   get_filename_component(MODULE_MAP module.modulemap REALPATH)
   install(FILES
             ${MODULE_MAP}
           DESTINATION
-            ${CMAKE_INSTALL_FULL_INCLUDEDIR}/dispatch)
+            "${CMAKE_INSTALL_LIBDIR}/swift/dispatch")
 endif()
 

--- a/os/CMakeLists.txt
+++ b/os/CMakeLists.txt
@@ -6,5 +6,5 @@ install(FILES
           object.h
           linux_base.h
         DESTINATION
-          "${CMAKE_INSTALL_FULL_INCLUDEDIR}/os")
+          "${CMAKE_INSTALL_LIBDIR}/swift/os")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,7 +202,7 @@ add_custom_command(TARGET dispatch POST_BUILD
 install(TARGETS
           dispatch
         DESTINATION
-          "${CMAKE_INSTALL_LIBDIR}")
+          "${CMAKE_INSTALL_LIBDIR}/swift/${SWIFT_OS}")
 if(ENABLE_SWIFT)
   install(FILES
             ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftmodule


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-6084
<rdar://problem/35040697> [SR-6084]: libdispatch missing from Trunk Development snapshots