### PR TITLE
[CMake] Set CMAKE_INSTALL_LIBDIR path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ enable_testing()
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_STANDARD 11)
 
+set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Path where the libraries should be installed")
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Looks like overriding this from CLI did not work so hardcode it for now.