### PR TITLE
A few updates to enable building on Raspberry PI/Ubuntu 16.04

### DIFF
--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -419,7 +419,7 @@ _dispatch_timeout_program(uint32_t tidx, uint64_t target,
 
 	if (target < INT64_MAX) {
 		struct itimerspec its = { .it_value = {
-			.tv_sec  = target / NSEC_PER_SEC,
+			.tv_sec  = (time_t)(target / NSEC_PER_SEC),
 			.tv_nsec = target % NSEC_PER_SEC,
 		} };
 		dispatch_assume_zero(timerfd_settime(timer->det_fd, TFD_TIMER_ABSTIME,

--- a/tests/dispatch_starfish.c
+++ b/tests/dispatch_starfish.c
@@ -72,7 +72,7 @@ collect(void *context __attribute__((unused)))
 
 	printf("lap: %zd\n", lap_count_down);
 	printf("count: %lu\n", COUNT);
-	printf("delta: %lu ns\n", delta);
+	printf("delta: %lu ns\n", (unsigned long)delta);
 	printf("math: %Lf ns / lap\n", math);
 
 	for (i = 0; i < COUNT; i++) {

--- a/tests/dispatch_timer.c
+++ b/tests/dispatch_timer.c
@@ -63,8 +63,8 @@ test_timer(void)
 
 		dispatch_source_set_event_handler(s, ^{
 			if (!finalized) {
-				test_long_less_than("timer number", j, stop_at);
-				fprintf(stderr, "timer[%lu]\n", j);
+				test_long_less_than("timer number", (long)j, stop_at);
+				fprintf(stderr, "timer[%lu]\n", (unsigned long)j);
 			}
 			dispatch_release(s);
 		});


### PR DESCRIPTION
I ran into some compilation failures while building on the Raspberry PI Model 3. These issues were simply type conversion warnings that resulted in errors (due to -Werror in the compilation settings.)

There may be more related issues, but what is attached is the minimal set of changes required to get it to build for me.

My setup: Raspberry PI 3 Model B

```
$ uname -a
Linux rpi 4.9.37-v7+ #1017 SMP Thu Jul 13 11:26:04 BST 2017 armv7l armv7l armv7l GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.3 LTS
Release:        16.04
Codename:       xenial

${SRCROOT}/swift/utils/build-script --preset=buildbot_linux_1604 install_destdir="${SRCROOT}/__install"  installable_package="${SRCROOT}/__install.tar.gz"
```

My apologies for not providing the exact compilation error output. It would take hours to produce those errors. If they are needed, I can restart that process to do so.