### PR TITLE
Fully initialize the epoll_data structure.

### DIFF
--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -391,7 +391,12 @@ _dispatch_timeout_program(uint32_t tidx, uint64_t target,
 	dispatch_epoll_timeout_t timer = &_dispatch_epoll_timeout[clock];
 	struct epoll_event ev = {
 		.events = EPOLLONESHOT | EPOLLIN,
-		.data = { .u32 = timer->det_ident },
+		.data = {
+			.ptr = NULL,
+			.fd = 0,
+			.u32 = timer->det_ident,
+			.u64 = 0
+		},
 	};
 	int op;
 


### PR DESCRIPTION
While running a simple libdispatch-using application on Linux under Valgrind, I noticed that Valgrind complained that the `struct epoll_event` initialized in this function was not fully initialized:

```
==3103== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==3103==    at 0x5DBE63A: epoll_ctl (syscall-template.S:81)
==3103==    by 0x4075493: _dispatch_timeout_program (in /usr/lib/swift/linux/libdispatch.so)
==3103==    by 0x407534F: _dispatch_event_loop_timer_arm (in /usr/lib/swift/linux/libdispatch.so)
==3103==    by 0x4072391: _dispatch_timers_program (in /usr/lib/swift/linux/libdispatch.so)
==3103==    by 0x40712D9: _dispatch_mgr_invoke (in /usr/lib/swift/linux/libdispatch.so)
==3103==    by 0x407118D: _dispatch_mgr_thread (in /usr/lib/swift/linux/libdispatch.so)
```

While this is unlikely to cause any bugs today (none of those fields are accessed anywhere else), we can save ourselves the risk of future pain by initialising those portions of the structure appropriately before we pass it to the kernel.