### PR TITLE
build: ensure that dependencies are tracked properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,20 +247,26 @@ if(leaks_EXECUTABLE)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_custom_target(module-map-symlinks
-                    ALL
-                    COMMAND
-                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                    COMMAND
-                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+  add_custom_command(OUTPUT
+                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
+                     COMMAND
+                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                     COMMAND
+                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
 else()
-  add_custom_target(module-map-symlinks
-                    ALL
-                    COMMAND
-                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                    COMMAND
-                      ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+  add_custom_command(OUTPUT
+                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
+                     COMMAND
+                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                     COMMAND
+                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
 endif()
+add_custom_target(module-map-symlinks
+                  DEPENDS
+                     "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                     "${CMAKE_SOURCE_DIR}/private/module.modulemap")
 configure_file("${CMAKE_SOURCE_DIR}/cmake/config.h.in"
                "${CMAKE_BINARY_DIR}/config/config_ac.h")
 add_definitions(-DHAVE_CONFIG_H)

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -4,7 +4,7 @@ include(CMakeParseArguments)
 function(add_swift_library library)
   set(options)
   set(single_value_options MODULE_NAME;MODULE_LINK_NAME;MODULE_PATH;MODULE_CACHE_PATH;OUTPUT;TARGET)
-  set(multiple_value_options SOURCES;SWIFT_FLAGS;CFLAGS)
+  set(multiple_value_options SOURCES;SWIFT_FLAGS;CFLAGS;DEPENDS)
 
   cmake_parse_arguments(ASL "${options}" "${single_value_options}" "${multiple_value_options}" ${ARGN})
 
@@ -61,6 +61,7 @@ function(add_swift_library library)
                      DEPENDS
                        ${ASL_SOURCES}
                        ${CMAKE_SWIFT_COMPILER}
+                       ${ASL_DEPENDS}
                      COMMAND
                        ${CMAKE_COMMAND} -E make_directory ${module_directory}
                      COMMAND

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,9 +100,9 @@ if(ENABLE_SWIFT)
                       -fmodule-map-file=${CMAKE_SOURCE_DIR}/dispatch/module.modulemap
                     SWIFT_FLAGS
                       -I ${CMAKE_SOURCE_DIR}
-                      ${swift_optimization_flags})
-  add_dependencies(swiftDispatch
-                     module-map-symlinks)
+                      ${swift_optimization_flags}
+                    DEPENDS
+                      ${CMAKE_SOURCE_DIR}/dispatch/module.modulemap)
   target_sources(dispatch
                  PRIVATE
                    swift/DispatchStubs.cc


### PR DESCRIPTION
Use `add_custom_command` and `add_custom_target`.  This ensures that the
ordering dependencies are properly honoured by ninja.  This fixes an
issue where sometimes I would see `swiftDispatch` being built prior to
the module map symlinks being established.