### PR TITLE
Fully initialize ev.data.

### DIFF
--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -391,13 +391,14 @@ _dispatch_timeout_program(uint32_t tidx, uint64_t target,
 	dispatch_epoll_timeout_t timer = &_dispatch_epoll_timeout[clock];
 	struct epoll_event ev = {
 		.events = EPOLLONESHOT | EPOLLIN,
-		.data = { .u32 = timer->det_ident },
+
 	};
 	int op;
 
 	if (target >= INT64_MAX && !timer->det_registered) {
 		return;
 	}
+	ev.data.u32 = timer->det_ident;
 
 	if (unlikely(timer->det_fd < 0)) {
 		clockid_t clockid;


### PR DESCRIPTION
On Linux systems, ev.data is an 8-byte field, but this code currently initializes only 4 bytes of the field, leaving the trailing 4 bytes unininitialized. This causes memory safety tools like Valgrind to complain, as noted in #321.

This patch no longer explicitly initializes `.data`, ensuring that C structure initialization will force the `.data` field to be zero-initialized. Manual checks of the compiled binary show that the compiler correctly initializes the 4 bytes for `.u32` only once, so this change incurs minimal overhead (specifically, setting the next 4 bytes to 0).