### PR TITLE
Increase test timeout value by 4x

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,7 +104,7 @@ function(add_unit_test name)
            COMMAND bsdtestharness $<TARGET_FILE:${name}>)
   set_tests_properties(${name}
                        PROPERTIES
-                         TIMEOUT 30
+                         TIMEOUT 120
                          DEPENDS bsdtestharness
                          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(NOT leaks_EXECUTABLE)


### PR DESCRIPTION
Seek to avoid spurious test timeouts in Swift CI by
raising limit for individual test execution from 30
seconds to 120 seconds.