### PR TITLE
Fix unistd.h check.

### DIFF
--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#if !defined(HAVE_UNISTD_H) || HAVE_UNISTD_H
+#if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #include <fcntl.h>


### PR DESCRIPTION
This patch fixes this compiler error.

/usr/include/dispatch/dispatch.h:38:45: error: expected value in expression
                                            ^

Fixes: 8af68ef3e4bb ("fix invalid use of config defines in API/SPI headers")
Signed-off-by: Vinson Lee <vlee@freedesktop.org>