### PR TITLE
shims: improve Windows CPU configuration scanning

### DIFF
--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -43,8 +43,6 @@
 #error "could not determine pointer size as a constant int"
 #endif // __SIZEOF_POINTER__
 
-#if !TARGET_OS_WIN32
-
 typedef enum {
 	_dispatch_hw_config_logical_cpus,
 	_dispatch_hw_config_physical_cpus,
@@ -115,6 +113,65 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 			return (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 		}
 	}
+#elif TARGET_OS_WIN32
+	PSYSTEM_LOGICAL_PROCESSOR_INFORMATION slpiInfo = NULL;
+	PSYSTEM_LOGICAL_PROCESSOR_INFORMATION slpiCurrent = NULL;
+	DWORD dwProcessorLogicalCount = 0;
+	DWORD dwProcessorPackageCount = 0;
+	DWORD dwProcessorCoreCount = 0;
+	DWORD dwSize = 0;
+
+	while (true) {
+		DWORD dwResult;
+
+		if (GetLogicalProcessorInformation(slpiInfo, &dwSize))
+			break;
+
+		dwResult = GetLastError();
+
+		if (slpiInfo)
+			free(slpiInfo);
+
+		if (dwResult == ERROR_INSUFFICIENT_BUFFER) {
+			slpiInfo = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)malloc(dwSize);
+			dispatch_assert(slpiInfo);
+		} else {
+			slpiInfo = NULL;
+			dwSize = 0;
+			break;
+		}
+	}
+
+	dispatch_assert(dwSize % sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) == 0);
+	for (slpiCurrent = slpiInfo;
+	     dwSize >= sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+	     slpiCurrent++, dwSize -= sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION)) {
+		switch (slpiCurrent->Relationship) {
+		case RelationProcessorCore:
+			++dwProcessorCoreCount;
+			dwProcessorLogicalCount += __popcnt64(slpiCurrent->ProcessorMask);
+			break;
+		case RelationProcessorPackage:
+			++dwProcessorPackageCount;
+			break;
+		case RelationNumaNode:
+		case RelationCache:
+		case RelationGroup:
+		case RelationAll:
+			break;
+		}
+	}
+
+	free(slpiInfo);
+
+	switch (c) {
+	case _dispatch_hw_config_logical_cpus:
+		return dwProcessorLogicalCount;
+	case _dispatch_hw_config_physical_cpus:
+		return dwProcessorPackageCount;
+	case _dispatch_hw_config_active_cpus:
+		return dwProcessorCoreCount;
+	}
 #else
 	const char *name = NULL;
 	int r;
@@ -159,32 +216,5 @@ _dispatch_hw_config_init(void)
 #undef dispatch_hw_config_init
 
 #endif // DISPATCH_HAVE_HW_CONFIG_COMMPAGE
-
-#else // TARGET_OS_WIN32
-
-static inline long
-_dispatch_count_bits(unsigned long value)
-{
-	long bits = 0;
-	while (value) {
-		bits += (value & 1);
-		value = value >> 1;
-	}
-	return bits;
-}
-
-static inline uint32_t
-_dispatch_get_ncpus(void)
-{
-	uint32_t val;
-	DWORD_PTR procmask, sysmask;
-	if (GetProcessAffinityMask(GetCurrentProcess(), &procmask, &sysmask)) {
-		val = _dispatch_count_bits(procmask);
-	} else {
-		val = 1;
-	}
-	return val;
-}
-#endif // TARGET_OS_WIN32
 
 #endif /* __DISPATCH_SHIMS_HW_CONFIG__ */


### PR DESCRIPTION
Use the newer Windows APIs to detect the windows CPU state.  This allows
us to collect all of the CPU configuration information to properly
affinitise work to the preferred CPU.