### PR TITLE
protect unistd.h inclusion with HAVE_UNISTD_H

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,6 @@ check_include_files("strings.h" HAVE_STRINGS_H)
 check_include_files("sys/guarded.h" HAVE_SYS_GUARDED_H)
 check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
 check_include_files("sys/types.h" HAVE_SYS_TYPES_H)
-check_include_files("unistd.h" HAVE_UNISTD_H)
 check_include_files("objc/objc-internal.h" HAVE_OBJC)
 
 if(HAVE_MACH)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -192,9 +192,6 @@
 /* Define to 1 if you have the <TargetConditionals.h> header file. */
 #cmakedefine HAVE_TARGETCONDITIONALS_H
 
-/* Define to 1 if you have the <unistd.h> header file. */
-#cmakedefine01 HAVE_UNISTD_H
-
 /* Define to 1 if you have the `_pthread_workqueue_init' function. */
 #cmakedefine HAVE__PTHREAD_WORKQUEUE_INIT
 

--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#if !defined(HAVE_UNISTD_H) || HAVE_UNISTD_H
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 #include <fcntl.h>

--- a/private/private.h
+++ b/private/private.h
@@ -41,7 +41,7 @@
 #include <mach/mach.h>
 #include <mach/message.h>
 #endif
-#if HAVE_UNISTD_H
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 #include <pthread.h>

--- a/src/internal.h
+++ b/src/internal.h
@@ -285,7 +285,7 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if HAVE_UNISTD_H
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -903,7 +903,9 @@ libdispatch_init(void)
 }
 
 #if DISPATCH_USE_THREAD_LOCAL_STORAGE
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <sys/syscall.h>
 
 #ifndef __ANDROID__

--- a/tests/Foundation/bench.mm
+++ b/tests/Foundation/bench.mm
@@ -31,7 +31,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>

--- a/tests/bsdtestharness.c
+++ b/tests/bsdtestharness.c
@@ -23,7 +23,9 @@
 #include <spawn.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <signal.h>
 #ifdef __APPLE__
 #include <mach/clock_types.h>

--- a/tests/bsdtests.c
+++ b/tests/bsdtests.c
@@ -25,7 +25,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include <sys/errno.h>
 #include <sys/wait.h>

--- a/tests/bsdtests.h
+++ b/tests/bsdtests.h
@@ -41,7 +41,9 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <stdint.h>
 

--- a/tests/cffd.c
+++ b/tests/cffd.c
@@ -22,7 +22,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <sys/param.h>
 #include <sys/ucred.h>

--- a/tests/dispatch_after.c
+++ b/tests/dispatch_after.c
@@ -20,7 +20,9 @@
 
 #include <dispatch/dispatch.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <assert.h>
 #ifdef __APPLE__

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -20,7 +20,9 @@
 
 #include <dispatch/dispatch.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <assert.h>
 #ifdef __APPLE__

--- a/tests/dispatch_cascade.c
+++ b/tests/dispatch_cascade.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <dispatch/dispatch.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 
 #include <bsdtests.h>

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -20,7 +20,9 @@
 
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>

--- a/tests/dispatch_context_for_key.c
+++ b/tests/dispatch_context_for_key.c
@@ -21,7 +21,9 @@
 #include <dispatch/dispatch.h>
 #include <stdlib.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <assert.h>
 
 #include <bsdtests.h>

--- a/tests/dispatch_deadname.c
+++ b/tests/dispatch_deadname.c
@@ -24,7 +24,9 @@
 #include <mach/mach.h>
 #endif
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <assert.h>
 

--- a/tests/dispatch_drift.c
+++ b/tests/dispatch_drift.c
@@ -23,7 +23,9 @@
 #endif
 #include <dispatch/dispatch.h>
 #include <sys/time.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef __APPLE__

--- a/tests/dispatch_group.c
+++ b/tests/dispatch_group.c
@@ -19,7 +19,9 @@
  */
 
 #include <dispatch/dispatch.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -25,7 +25,9 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include <fts.h>
 #ifdef __APPLE__

--- a/tests/dispatch_io_net.c
+++ b/tests/dispatch_io_net.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include <netdb.h>
 #include <sys/types.h>

--- a/tests/dispatch_overcommit.c
+++ b/tests/dispatch_overcommit.c
@@ -25,7 +25,9 @@
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <assert.h>
 #ifdef __APPLE__

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <assert.h>
 #ifdef __APPLE__

--- a/tests/dispatch_proc.c
+++ b/tests/dispatch_proc.c
@@ -20,7 +20,9 @@
 
 #include <dispatch/dispatch.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <assert.h>
 #include <spawn.h>

--- a/tests/dispatch_queue_finalizer.c
+++ b/tests/dispatch_queue_finalizer.c
@@ -19,7 +19,9 @@
  */
 
 #include <dispatch/dispatch.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/dispatch_read.c
+++ b/tests/dispatch_read.c
@@ -24,7 +24,9 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <errno.h>
 
 #include <dispatch/dispatch.h>

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -25,7 +25,9 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include <fts.h>
 #ifdef __APPLE__

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -21,7 +21,9 @@
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else

--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <sys/stat.h>
 #include <dispatch/dispatch.h>
 

--- a/tests/dispatch_sema.c
+++ b/tests/dispatch_sema.c
@@ -19,7 +19,9 @@
  */
 
 #include <dispatch/dispatch.h>
+#if !USE_WIN32_SEM
 #include <pthread.h>
+#endif
 #include <stdio.h>
 #include <assert.h>
 

--- a/tests/dispatch_sync_on_main.c
+++ b/tests/dispatch_sync_on_main.c
@@ -22,7 +22,9 @@
 #include <dispatch/private.h>
 #include <stdlib.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #include <CoreFoundation/CoreFoundation.h>
 
 #include <bsdtests.h>

--- a/tests/dispatch_test.c
+++ b/tests/dispatch_test.c
@@ -27,7 +27,9 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #if __has_include(<sys/event.h>)
 #define HAS_SYS_EVENT_H 1
 #include <sys/event.h>

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -21,7 +21,9 @@
 #include <sys/event.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 #ifdef __APPLE__
 #include <libkern/OSAtomic.h>
 #endif

--- a/tests/dispatch_vnode.c
+++ b/tests/dispatch_vnode.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#endif
 
 #include <dispatch/dispatch.h>
 


### PR DESCRIPTION
This ensures that all the inclusions of unistd.h inclusion are protected
with the check that the header exists.  This header is only available on
unix like environments to define the standard of compliance.  This
protection is needed for other environments like Windows.