### PR TITLE
dispatch: adjust for LLP64 environments

### DIFF
--- a/dispatch/once.h
+++ b/dispatch/once.h
@@ -38,7 +38,7 @@ __BEGIN_DECLS
  * Note: static and global variables default to zero.
  */
 DISPATCH_SWIFT3_UNAVAILABLE("Use lazily initialized globals instead")
-typedef long dispatch_once_t;
+typedef intptr_t dispatch_once_t;
 
 #if defined(__x86_64__) || defined(__i386__) || defined(__s390x__)
 #define DISPATCH_ONCE_INLINE_FASTPATH 1

--- a/src/source.c
+++ b/src/source.c
@@ -300,7 +300,7 @@ _dispatch_source_handler_free(dispatch_source_t ds, long kind)
 
 DISPATCH_ALWAYS_INLINE
 static inline void
-_dispatch_source_handler_replace(dispatch_source_t ds, long kind,
+_dispatch_source_handler_replace(dispatch_source_t ds, uintptr_t kind,
 		dispatch_continuation_t dc)
 {
 	if (!dc->dc_func) {
@@ -321,14 +321,14 @@ _dispatch_source_set_handler_slow(void *context)
 	dispatch_assert(dx_type(ds) == DISPATCH_SOURCE_KEVENT_TYPE);
 
 	dispatch_continuation_t dc = context;
-	long kind = (long)dc->dc_data;
+	void *kind = dc->dc_data;
 	dc->dc_data = NULL;
-	_dispatch_source_handler_replace(ds, kind, dc);
+	_dispatch_source_handler_replace(ds, (uintptr_t)kind, dc);
 }
 
 DISPATCH_NOINLINE
 static void
-_dispatch_source_set_handler(dispatch_source_t ds, long kind,
+_dispatch_source_set_handler(dispatch_source_t ds, uintptr_t kind,
 		dispatch_continuation_t dc)
 {
 	dispatch_assert(dx_type(ds) == DISPATCH_SOURCE_KEVENT_TYPE);


### PR DESCRIPTION
LLP64 environments use a 32-bit long value.  This would result in
truncation as the `long` is used to transfer a pointer value here.
Adjust the types accordingly.  Since the width on LP64 environments is
equivalent in this change, this should only impact LLP64 environments
and be ABI stable otherwise.