### PR TITLE
BlocksRuntime: adjust implementation for Windows x64

### DIFF
--- a/src/BlocksRuntime/runtime.c
+++ b/src/BlocksRuntime/runtime.c
@@ -28,25 +28,22 @@
 #define os_assert(_x) assert(_x)
 #endif
 
-#if TARGET_OS_WIN32
-#define _CRT_SECURE_NO_WARNINGS 1
-#include <windows.h>
-static __inline bool OSAtomicCompareAndSwapLong(long oldl, long newl, long volatile *dst) 
-{ 
-    // fixme barrier is overkill -- see objc-os.h
-    long original = InterlockedCompareExchange(dst, newl, oldl);
-    return (original == oldl);
-}
+#if !defined(__has_builtin)
+#define __has_builtin(builtin) 0
+#endif
 
-static __inline bool OSAtomicCompareAndSwapInt(int oldi, int newi, int volatile *dst) 
-{ 
-    // fixme barrier is overkill -- see objc-os.h
-    int original = InterlockedCompareExchange(dst, newi, oldi);
-    return (original == oldi);
-}
+#if __has_builtin(__sync_bool_compare_and_swap)
+#define OSAtomicCompareAndSwapInt(_Old, _New, _Ptr)                            \
+  __sync_bool_compare_and_swap(_Ptr, _Old, _New)
 #else
-#define OSAtomicCompareAndSwapLong(_Old, _New, _Ptr) __sync_bool_compare_and_swap(_Ptr, _Old, _New)
-#define OSAtomicCompareAndSwapInt(_Old, _New, _Ptr) __sync_bool_compare_and_swap(_Ptr, _Old, _New)
+#define _CRT_SECURE_NO_WARNINGS 1
+#include <Windows.h>
+static __inline bool OSAtomicCompareAndSwapInt(int oldi, int newi,
+                                               int volatile *dst) {
+  // fixme barrier is overkill -- see objc-os.h
+  int original = InterlockedCompareExchange((LONG volatile *)dst, newi, oldi);
+  return (original == oldi);
+}
 #endif
 
 /***********************
@@ -141,13 +138,13 @@ static bool latching_decr_int_now_zero(volatile int32_t *where) {
 /***********************
 GC support stub routines
 ************************/
-#if !TARGET_OS_WIN32
+#if !defined(_MSC_VER) || defined(__clang__)
 #pragma mark GC Support Routines
 #endif
 
 
 
-static void *_Block_alloc_default(const unsigned long size, const bool initialCountIsOne, const bool isObject) {
+static void *_Block_alloc_default(size_t size, const bool initialCountIsOne, const bool isObject) {
 	(void)initialCountIsOne;
 	(void)isObject;
     return malloc(size);
@@ -207,7 +204,7 @@ static void _Block_destructInstance_default(const void *aBlock) {
 GC support callout functions - initially set to stub routines
 ***************************************************************************/
 
-static void *(*_Block_allocator)(const unsigned long, const bool isOne, const bool isObject) = _Block_alloc_default;
+static void *(*_Block_allocator)(size_t, const bool isOne, const bool isObject) = _Block_alloc_default;
 static void (*_Block_deallocator)(const void *) = (void (*)(const void *))free;
 static void (*_Block_assign)(void *value, void **destptr) = _Block_assign_default;
 static void (*_Block_setHasRefcount)(const void *ptr, const bool hasRefcount) = _Block_setHasRefcount_default;
@@ -226,7 +223,7 @@ GC support SPI functions - called from ObjC runtime and CoreFoundation
 // Public SPI
 // Called from objc-auto to turn on GC.
 // version 3, 4 arg, but changed 1st arg
-void _Block_use_GC( void *(*alloc)(const unsigned long, const bool isOne, const bool isObject),
+void _Block_use_GC( void *(*alloc)(size_t, const bool isOne, const bool isObject),
                     void (*setHasRefcount)(const void *, const bool),
                     void (*gc_assign)(void *, void **),
                     void (*gc_assign_weak)(const void *, void *),
@@ -249,7 +246,7 @@ void _Block_use_GC( void *(*alloc)(const unsigned long, const bool isOne, const 
 }
 
 // transitional
-void _Block_use_GC5( void *(*alloc)(const unsigned long, const bool isOne, const bool isObject),
+void _Block_use_GC5( void *(*alloc)(size_t, const bool isOne, const bool isObject),
                     void (*setHasRefcount)(const void *, const bool),
                     void (*gc_assign)(void *, void **),
                     void (*gc_assign_weak)(const void *, void *)) {
@@ -339,7 +336,7 @@ static void _Block_call_dispose_helper(struct Block_layout *aBlock)
 Internal Support routines for copying
 ********************************************************************************/
 
-#if !TARGET_OS_WIN32
+#if !defined(_MSC_VER) || defined(__clang__)
 #pragma mark Copy/Release support
 #endif
 
@@ -500,7 +497,7 @@ static void _Block_byref_release(const void *arg) {
  *
  ***********************************************************/
 
-#if !TARGET_OS_WIN32
+#if !defined(_MSC_VER) || defined(__clang__)
 #pragma mark SPI/API
 #endif
 
@@ -632,7 +629,7 @@ const char * _Block_extended_layout(void *aBlock)
     else return desc3->layout;
 }
 
-#if !TARGET_OS_WIN32
+#if !defined(_MSC_VER) || defined(__clang__)
 #pragma mark Compiler SPI entry points
 #endif
 


### PR DESCRIPTION
This adjust the BlocksRuntime to work on Windows x64 which is an LLP64
environment.  This primarily comes down to using `size_t` for the size
parameter for the allocation routines.  A secondary change which is
needed is the type cast for the `InterlockedCompareExchange` operation
on Windows.  A small cleanup is included which removes the definition of
an unused function.