### PR TITLE
[gardening] Use `Optional.map` over `flatMap` where appropriate

### DIFF
--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -42,7 +42,7 @@ public extension DispatchIO {
 
 	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: @escaping (_ data: DispatchData?, _ error: Int32) -> Void) {
 		dispatch_write(toFileDescriptor, data.__wrapped.__wrapped, queue.__wrapped) { (data: dispatch_data_t?, error: Int32) in
-			handler(data.flatMap { DispatchData(borrowedData: $0) }, error)
+			handler(data.map { DispatchData(borrowedData: $0) }, error)
 		}
 	}
 
@@ -90,13 +90,13 @@ public extension DispatchIO {
 
 	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
 		dispatch_io_read(self.__wrapped, offset, length, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
-			ioHandler(done, data.flatMap { DispatchData(borrowedData: $0) }, error)
+			ioHandler(done, data.map { DispatchData(borrowedData: $0) }, error)
 		}
 	}
 
 	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
 		dispatch_io_write(self.__wrapped, offset, data.__wrapped.__wrapped, queue.__wrapped) { (done: Bool, data: dispatch_data_t?, error: Int32) in
-			ioHandler(done, data.flatMap { DispatchData(borrowedData: $0) }, error)
+			ioHandler(done, data.map { DispatchData(borrowedData: $0) }, error)
 		}
 	}
 

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -329,8 +329,8 @@ public extension DispatchQueue {
 
 	public func setSpecific<T>(key: DispatchSpecificKey<T>, value: T?) {
 		let k = Unmanaged.passUnretained(key).toOpaque()
-		let v = value.flatMap { _DispatchSpecificValue(value: $0) }
-		let p = v.flatMap { Unmanaged.passRetained($0).toOpaque() }
+		let v = value.map { _DispatchSpecificValue(value: $0) }
+		let p = v.map { Unmanaged.passRetained($0).toOpaque() }
 		dispatch_queue_set_specific(self.__wrapped, k, p, _destructDispatchSpecificValue)
 	}
 


### PR DESCRIPTION
Ref: https://github.com/apple/swift/pull/15142

---

The initializers used here are not optional ones, so there is no need to use `flatMap`.

- https://github.com/apple/swift-corelibs-libdispatch/blob/9295346d20e52c9ff4d82906fd85287d8636c542/src/swift/Data.swift#L100-L102
- https://github.com/apple/swift-corelibs-libdispatch/blob/9295346d20e52c9ff4d82906fd85287d8636c542/src/swift/Queue.swift#L22-L25