### PR TITLE
build: support lld as the linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,8 @@ else()
 endif()
 option(USE_GOLD_LINKER "use the gold linker" ${USE_GOLD_LINKER_DEFAULT})
 
+option(USE_LLD_LINKER "use the lld linker" OFF)
+
 option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via __thread" ON)
 set(DISPATCH_USE_THREAD_LOCAL_STORAGE ${ENABLE_THREAD_LOCAL_STORAGE})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,6 +211,12 @@ if(USE_GOLD_LINKER)
                PROPERTY LINK_FLAGS
                  -fuse-ld=gold)
 endif()
+if(USE_LLD_LINKER)
+  set_property(TARGET dispatch
+               APPEND_STRING
+               PROPERTY LINK_FLAGS
+                 -fuse-ld=lld)
+endif()
 
 # Temporary staging; the various swift projects that depend on libdispatch
 # all expect libdispatch.so to be in src/.libs/libdispatch.so


### PR DESCRIPTION
For cross-compiling to Windows, lld is a requirement.  It also can be
used for ELF targets.  Add an option to have lld be used as the linker
to mirror the gold option.