### PR TITLE
build: add the default search paths for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   dispatch_windows_arch_spelling(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_MSVC_ARCH)
   dispatch_windows_include_for_arch(${DISPATCH_MSVC_ARCH} DISPATCH_INCLUDES)
   include_directories(BEFORE SYSTEM ${DISPATCH_INCLUDES})
+  dispatch_windows_lib_for_arch(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_LIBDIR)
+  link_directories(${DISPATCH_LIBDIR})
 endif()
 
 add_subdirectory(dispatch)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,13 @@ target_link_libraries(dispatch PRIVATE Threads::Threads)
 if(WITH_BLOCKS_RUNTIME)
   target_link_libraries(dispatch PRIVATE BlocksRuntime)
 endif()
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_link_libraries(dispatch
+                        PRIVATE
+                          WS2_32
+                          WinMM
+                          synchronization)
+endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set_property(TARGET dispatch
                APPEND_STRING


### PR DESCRIPTION
When building for Windows on Linux, we need to explicitly setup the
linker search paths.  These are derivable from the UCRT version and the
WinSDK base directories which are expected environment variables.  This
is also how the swift build system finds the directories.  Enable this
to avoid having the user explicitly setup the `LIB` environment variable
for the linker to find the system import libraries.