### PR TITLE
SwiftOverlay: add explicit casts

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -40,14 +40,14 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(flags.rawValue),
+		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(UInt32(flags.rawValue)),
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
 
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
-		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(flags.rawValue), noescapeBlock)
+		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(UInt32(flags.rawValue)), noescapeBlock)
 	}
 
 	public func perform() {

--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -166,7 +166,7 @@ public extension DispatchGroup {
 public extension DispatchSemaphore {
 	@discardableResult
 	public func signal() -> Int {
-		return dispatch_semaphore_signal(self.__wrapped)
+		return Int(dispatch_semaphore_signal(self.__wrapped))
 	}
 
 	public func wait() {

--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -35,13 +35,13 @@ public extension DispatchIO {
 	}
 
 	public class func read(fromFileDescriptor: Int32, maxLength: Int, runningHandlerOn queue: DispatchQueue, handler: @escaping (_ data: DispatchData, _ error: Int32) -> Void) {
-		dispatch_read(fromFileDescriptor, maxLength, queue.__wrapped) { (data: dispatch_data_t, error: Int32) in
+		dispatch_read(dispatch_fd_t(fromFileDescriptor), maxLength, queue.__wrapped) { (data: dispatch_data_t, error: Int32) in
 			handler(DispatchData(borrowedData: data), error)
 		}
 	}
 
 	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: @escaping (_ data: DispatchData?, _ error: Int32) -> Void) {
-		dispatch_write(toFileDescriptor, data.__wrapped.__wrapped, queue.__wrapped) { (data: dispatch_data_t?, error: Int32) in
+		dispatch_write(dispatch_fd_t(toFileDescriptor), data.__wrapped.__wrapped, queue.__wrapped) { (data: dispatch_data_t?, error: Int32) in
 			handler(data.map { DispatchData(borrowedData: $0) }, error)
 		}
 	}
@@ -101,10 +101,10 @@ public extension DispatchIO {
 	}
 
 	public func setInterval(interval: DispatchTimeInterval, flags: IntervalFlags = []) {
-		dispatch_io_set_interval(self.__wrapped, UInt64(interval.rawValue), flags.rawValue)
+		dispatch_io_set_interval(self.__wrapped, UInt64(interval.rawValue), dispatch_io_interval_flags_t(flags.rawValue))
 	}
 
 	public func close(flags: CloseFlags = []) {
-		dispatch_io_close(self.__wrapped, flags.rawValue)
+		dispatch_io_close(self.__wrapped, dispatch_io_close_flags_t(flags.rawValue))
 	}
 }

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -115,7 +115,7 @@ public extension DispatchQueue {
 	@available(macOS, deprecated: 10.10, message: "")
 	@available(*, deprecated: 8.0, message: "")
 	public class func global(priority: GlobalQueuePriority) -> DispatchQueue {
-		return DispatchQueue(queue: CDispatch.dispatch_get_global_queue(priority._translatedValue, 0))
+		return DispatchQueue(queue: CDispatch.dispatch_get_global_queue(Int(priority._translatedValue), 0))
 	}
 
 	@available(macOS 10.10, iOS 8.0, *)

--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -189,7 +189,7 @@ public extension DispatchSource {
 	}
 
 	public class func makeTimerSource(flags: TimerFlags = [], queue: DispatchQueue? = nil) -> DispatchSourceTimer {
-		let source = dispatch_source_create(_swift_dispatch_source_type_TIMER(), 0, flags.rawValue, queue?.__wrapped)
+		let source = dispatch_source_create(_swift_dispatch_source_type_TIMER(), 0, UInt(flags.rawValue), queue?.__wrapped)
 		return DispatchSource(source: source) as DispatchSourceTimer
 	}
 
@@ -268,13 +268,11 @@ public extension DispatchSourceProcess {
 	}
 
 	public var data: DispatchSource.ProcessEvent {
-		let data = dispatch_source_get_data(self as! DispatchSource)
-		return DispatchSource.ProcessEvent(rawValue: data)
+		return DispatchSource.ProcessEvent(rawValue: (self as! DispatchSource).data)
 	}
 
 	public var mask: DispatchSource.ProcessEvent {
-		let mask = dispatch_source_get_mask(self as! DispatchSource)
-		return DispatchSource.ProcessEvent(rawValue: mask)
+		return DispatchSource.ProcessEvent(rawValue: (self as! DispatchSource).mask)
 	}
 }
 #endif
@@ -627,12 +625,12 @@ public extension DispatchSourceFileSystemObject {
 
 	public var data: DispatchSource.FileSystemEvent {
 		let data = dispatch_source_get_data((self as! DispatchSource).__wrapped)
-		return DispatchSource.FileSystemEvent(rawValue: data)
+		return DispatchSource.FileSystemEvent(rawValue: UInt(data))
 	}
 
 	public var mask: DispatchSource.FileSystemEvent {
 		let data = dispatch_source_get_mask((self as! DispatchSource).__wrapped)
-		return DispatchSource.FileSystemEvent(rawValue: data)
+		return DispatchSource.FileSystemEvent(rawValue: UInt(data))
 	}
 }
 #endif
@@ -644,7 +642,7 @@ public extension DispatchSourceUserDataAdd {
 	/// - parameter data: the value to add to the current pending data. A value of zero
 	///		has no effect and will not result in the submission of the event handler block.
 	public func add(data: UInt) {
-		dispatch_source_merge_data((self as! DispatchSource).__wrapped, data)
+		dispatch_source_merge_data((self as! DispatchSource).__wrapped, UInt(data))
 	}
 }
 
@@ -655,7 +653,7 @@ public extension DispatchSourceUserDataOr {
 	/// - parameter data: The value to OR into the current pending data. A value of zero
 	///		has no effect and will not result in the submission of the event handler block.
 	public func or(data: UInt) {
-		dispatch_source_merge_data((self as! DispatchSource).__wrapped, data)
+		dispatch_source_merge_data((self as! DispatchSource).__wrapped, UInt(data))
 	}
 }
 
@@ -667,6 +665,6 @@ public extension DispatchSourceUserDataReplace {
 	///		A value of zero will be stored but will not result in the submission of the event
 	///		handler block.
 	public func replace(data: UInt) {
-		dispatch_source_merge_data((self as! DispatchSource).__wrapped, data)
+		dispatch_source_merge_data((self as! DispatchSource).__wrapped, UInt(data))
 	}
 }

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -76,7 +76,7 @@ public class DispatchSemaphore : DispatchObject {
 	}
 
 	public init(value: Int) {
-		__wrapped = dispatch_semaphore_create(value)
+		__wrapped = dispatch_semaphore_create(Int(value))
 	}
 
 	deinit {
@@ -93,17 +93,17 @@ public class DispatchIO : DispatchObject {
 
 	internal init(__type: UInt, fd: Int32, queue: DispatchQueue,
 				  handler: @escaping (_ error: Int32) -> Void) {
-		__wrapped = dispatch_io_create(__type, fd, queue.__wrapped, handler)
+		__wrapped = dispatch_io_create(dispatch_io_type_t(__type), dispatch_fd_t(fd), queue.__wrapped, handler)
 	}
 
 	internal init(__type: UInt, path: UnsafePointer<Int8>, oflag: Int32,
 				  mode: mode_t, queue: DispatchQueue, handler: @escaping (_ error: Int32) -> Void) {
-		__wrapped = dispatch_io_create_with_path(__type, path, oflag, mode, queue.__wrapped, handler)
+		__wrapped = dispatch_io_create_with_path(dispatch_io_type_t(__type), path, oflag, mode, queue.__wrapped, handler)
 	}
 
 	internal init(__type: UInt, io: DispatchIO,
 				  queue: DispatchQueue, handler: @escaping (_ error: Int32) -> Void) {
-		__wrapped = dispatch_io_create_with_io(__type, io.__wrapped, queue.__wrapped, handler)
+		__wrapped = dispatch_io_create_with_io(dispatch_io_type_t(__type), io.__wrapped, queue.__wrapped, handler)
 	}
 
 	deinit {
@@ -115,7 +115,7 @@ public class DispatchIO : DispatchObject {
 	}
 
 	public var fileDescriptor: Int32 {
-		return dispatch_io_get_descriptor(__wrapped)
+		return Int32(dispatch_io_get_descriptor(__wrapped))
 	}
 
 	public func setLimit(highWater: Int) {


### PR DESCRIPTION
Silence the errors when building for the Windows x86_64 target caused by
the type mismatches from the C/swift bridging.  This also has been built
for Linux-x86_64.