### PR TITLE
SR-2100 - Add support for multi-lib systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ include(CheckSymbolExists)
 include(GNUInstallDirs)
 include(SwiftSupport)
 
-set(INSTALL_LIBDIR "lib" CACHE PATH "Path where the libraries should be installed")
+set(SWIFT_LIBDIR "lib" CACHE PATH "Library folder name, defined by swift main buildscript")
+set(INSTALL_LIBDIR "${SWIFT_LIBDIR}" CACHE PATH "Path where the libraries should be installed")
 set(WITH_BLOCKS_RUNTIME "" CACHE PATH "Path to blocks runtime")
 
 include(DispatchAppleOptions)
@@ -55,7 +56,7 @@ if(ENABLE_SWIFT)
   string(TOLOWER ${CMAKE_SYSTEM_NAME} SWIFT_OS)
   get_swift_host_arch(SWIFT_HOST_ARCH)
 
-  set(SWIFT_RUNTIME_LIBDIR ${SWIFT_TOOLCHAIN}/lib/swift/${SWIFT_OS}/${SWIFT_HOST_ARCH})
+  set(SWIFT_RUNTIME_LIBDIR ${SWIFT_TOOLCHAIN}/${SWIFT_LIBDIR}/swift/${SWIFT_OS}/${SWIFT_HOST_ARCH})
 
   add_library(swiftCore
               SHARED IMPORTED GLOBAL)


### PR DESCRIPTION
Supersedes #348. 

[SR-2100 - Add support for multi-lib systems](https://bugs.swift.org/browse/SR-2100)

Use the new SWIFT_LIBDIR cmake variable defined by swift's build-script (pending pull request), so
Linux distributions using lib64 instead of lib for 64-bit libraries could install
swift without the need for patches, like Fedora.

@MadCoder - Now a new clean branch from #348.