### PR TITLE
Simplify DispatchData.append(_: UnsafeBufferPointer<T>)

### DIFF
--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -168,10 +168,7 @@ public struct DispatchData : RandomAccessCollection {
 	///
 	/// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
 	public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-		let count = buffer.count * MemoryLayout<SourceType>.stride;
-		buffer.baseAddress?.withMemoryRebound(to: UInt8.self, capacity: count) {
-			self.append($0, count: count)
-		}
+		self.append(UnsafeRawBufferPointer(buffer))
 	}
 
 	private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: Range<Index>) {


### PR DESCRIPTION
The deprecation warning guides us towards UnsafeRawBufferPointer, so sure, let's use that.

Corelibs version of apple/swift#16080. No intended functionality change.