### PR TITLE
[SR-5773] Requeue the stream handler if the read would block

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2075,7 +2075,9 @@ pick:
 		_dispatch_stream_complete_operation(stream, op);
 		// Fall through
 	case DISPATCH_OP_RESUME:
-		if (_dispatch_stream_operation_avail(stream)) {
+		if (_dispatch_stream_operation_avail(stream) && !stream->source_running) {
+			dispatch_async_f(stream->dq, stream->dq, _dispatch_stream_queue_handler);
+		} else if (_dispatch_stream_operation_avail(stream)) {
 			stream->source_running = true;
 			dispatch_resume(_dispatch_stream_source(stream, op));
 		}


### PR DESCRIPTION
There is a chance that the [`read`](https://github.com/apple/swift-corelibs-libdispatch/blob/a618b468b94ad6abb14a19af76e33018700af6bc/src/io.c#L2379) operation could return a `EAGAIN` or `EWOULDBLOCK` because the file descriptor used in the `read` operation of `_dispatch_operation_perform` has been marked with [`O_NONBLOCK`](https://github.com/apple/swift-corelibs-libdispatch/blob/a618b468b94ad6abb14a19af76e33018700af6bc/src/io.c#L1474).

The existing code assumed that `EAGAIN` or `EWOULDBLOCK` would only happen when there was [no existing `dispatch_source_t`](https://github.com/apple/swift-corelibs-libdispatch/blob/a618b468b94ad6abb14a19af76e33018700af6bc/src/io.c#L1973-L1975). Because of this assumption, it would call [`_dispatch_stream_source`](https://github.com/apple/swift-corelibs-libdispatch/blob/a618b468b94ad6abb14a19af76e33018700af6bc/src/io.c#L2080) which would [create a `dispatch_source_t` and register an event handler](https://github.com/apple/swift-corelibs-libdispatch/blob/a618b468b94ad6abb14a19af76e33018700af6bc/src/io.c#L1969-L2001).

The bug occurs when `EAGAIN` or `EWOULDBLOCK` is returned from `read` when a `dispatch_source_t` has already been allocated. This patch, explicitly watches for the the described condition where the `dispatch_source_t` was already created and then explicitly queues another call to `_dispatch_stream_queue_handler` which re-attempts the `read` operation.
    
Fixes [SR-5773](https://bugs.swift.org/browse/SR-5773).