### PR TITLE
Use _Thread_local for thread-local storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ option(USE_GOLD_LINKER "use the gold linker" ${USE_GOLD_LINKER_DEFAULT})
 
 option(USE_LLD_LINKER "use the lld linker" OFF)
 
-option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via __thread" ON)
+option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via _Thread_local" ON)
 set(DISPATCH_USE_THREAD_LOCAL_STORAGE ${ENABLE_THREAD_LOCAL_STORAGE})
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -2,7 +2,7 @@
 /* Define if building pthread work queues from source */
 #cmakedefine01 DISPATCH_USE_INTERNAL_WORKQUEUE
 
-/* Enable usage of thread local storage via __thread */
+/* Enable usage of thread local storage via _Thread_local */
 #cmakedefine01 DISPATCH_USE_THREAD_LOCAL_STORAGE
 
 /* Define to 1 if you have the declaration of `CLOCK_MONOTONIC', and to 0 if

--- a/src/init.c
+++ b/src/init.c
@@ -112,7 +112,7 @@ void (*_dispatch_end_NSAutoReleasePool)(void *);
 #endif
 
 #if DISPATCH_USE_THREAD_LOCAL_STORAGE
-__thread struct dispatch_tsd __dispatch_tsd;
+_Thread_local struct dispatch_tsd __dispatch_tsd;
 #if defined(_WIN32)
 DWORD __dispatch_tsd_key;
 #else

--- a/src/shims/tsd.h
+++ b/src/shims/tsd.h
@@ -115,7 +115,6 @@ _dispatch_thread_key_create(DWORD *k, void (DISPATCH_TSD_DTOR_CC *d)(void *))
 	dispatch_assert_zero((*k = FlsAlloc(d)));
 }
 
-extern __declspec(thread) struct dispatch_tsd __dispatch_tsd;
 extern DWORD __dispatch_tsd_key;
 
 #else
@@ -127,7 +126,6 @@ _dispatch_thread_key_create(pthread_key_t *k, void (DISPATCH_TSD_DTOR_CC *d)(voi
 	dispatch_assert_zero(pthread_key_create(k, d));
 }
 
-extern __thread struct dispatch_tsd __dispatch_tsd;
 extern pthread_key_t __dispatch_tsd_key;
 
 #endif
@@ -155,6 +153,8 @@ struct dispatch_tsd {
 	void *dispatch_voucher_key;
 	void *dispatch_deferred_items_key;
 };
+
+extern _Thread_local struct dispatch_tsd __dispatch_tsd;
 
 extern void libdispatch_tsd_init(void);
 extern void _libdispatch_tsd_cleanup(void *ctx);


### PR DESCRIPTION
When building for Windows, shims/tsd.h declares __dispatch_tsd with
__declspec(thread). init.c needs to match this or else it will not compile with
newer versions of Clang.