### PR TITLE
build: use `CMAKE_COMMAND` instead of hardcoded cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 cmake_minimum_required(VERSION 3.4.3)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 project(dispatch
         VERSION 1.3
@@ -30,6 +30,7 @@ include(CheckLibraryExists)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
 include(SwiftSupport)
+include(DispatchUtilities)
 
 set(SWIFT_LIBDIR "lib" CACHE PATH "Library folder name, defined by swift main buildscript")
 set(INSTALL_LIBDIR "${SWIFT_LIBDIR}" CACHE PATH "Path where the libraries should be installed")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,16 +91,17 @@ option(BUILD_SHARED_LIBS "build shared libraries" ON)
 
 option(ENABLE_TESTING "build libdispatch tests" ON)
 
+option(USE_LLD_LINKER "use the lld linker" OFF)
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
    CMAKE_SYSTEM_NAME STREQUAL FreeBSD OR
-   CMAKE_SYSTEM_NAME STREQUAL Android)
+   CMAKE_SYSTEM_NAME STREQUAL Android AND
+   NOT USE_LLD_LINKER)
   set(USE_GOLD_LINKER_DEFAULT ON)
 else()
   set(USE_GOLD_LINKER_DEFAULT OFF)
 endif()
 option(USE_GOLD_LINKER "use the gold linker" ${USE_GOLD_LINKER_DEFAULT})
-
-option(USE_LLD_LINKER "use the lld linker" OFF)
 
 option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via _Thread_local" ON)
 set(DISPATCH_USE_THREAD_LOCAL_STORAGE ${ENABLE_THREAD_LOCAL_STORAGE})

--- a/cmake/modules/DispatchUtilities.cmake
+++ b/cmake/modules/DispatchUtilities.cmake
@@ -1,0 +1,15 @@
+
+function(dispatch_set_linker target)
+  if(USE_GOLD_LINKER)
+    set_property(TARGET ${target}
+                 APPEND_STRING
+                 PROPERTY LINK_FLAGS
+                   -fuse-ld=gold)
+  endif()
+  if(USE_LLD_LINKER)
+    set_property(TARGET ${target}
+                 APPEND_STRING
+                 PROPERTY LINK_FLAGS
+                   -fuse-ld=lld)
+  endif()
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,18 +212,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
                  "-Xlinker -dead_strip"
                  "-Xlinker -alias_list -Xlinker ${CMAKE_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
 endif()
-if(USE_GOLD_LINKER)
-  set_property(TARGET dispatch
-               APPEND_STRING
-               PROPERTY LINK_FLAGS
-                 -fuse-ld=gold)
-endif()
-if(USE_LLD_LINKER)
-  set_property(TARGET dispatch
-               APPEND_STRING
-               PROPERTY LINK_FLAGS
-                 -fuse-ld=lld)
-endif()
+dispatch_set_linker(dispatch)
 
 # Temporary staging; the various swift projects that depend on libdispatch
 # all expect libdispatch.so to be in src/.libs/libdispatch.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,8 +230,8 @@ endif()
 # So for now, make a copy so we don't have to do a coordinated commit across
 # all the swift projects to change this assumption.
 add_custom_command(TARGET dispatch POST_BUILD
-                   COMMAND cmake -E make_directory .libs
-                   COMMAND cmake -E copy $<TARGET_FILE:dispatch> .libs
+                   COMMAND ${CMAKE_COMMAND} -E make_directory .libs
+                   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dispatch> .libs
                    COMMENT "Copying libdispatch to .libs")
 
 install(TARGETS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,16 +140,16 @@ set(DISPATCH_C_TESTS
 # Excluded by default for purposes of Swift CI
 if(EXTENDED_TEST_SUITE)
   list(APPEND DISPATCH_C_TESTS
-	priority
-	concur
-	read
-	read2
-	suspend_timer
-	pingpong
-	drift
-	readsync
-	cascade
-	io)
+       priority
+       concur
+       read
+       read2
+       suspend_timer
+       pingpong
+       drift
+       readsync
+       cascade
+       io)
   # an oddball; dispatch_priority.c compiled with -DUSE_SET_TARGET_QUEUE=1
   add_unit_test(dispatch_priority2 SOURCES dispatch_priority.c)
   target_compile_options(dispatch_priority2 PRIVATE -DUSE_SET_TARGET_QUEUE=1)
@@ -158,10 +158,10 @@ endif()
 # add C tests for platform-specific functionality when applicable
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   list(APPEND DISPATCH_C_TESTS
-	deadname
-	proc
-	vm
-	vnode)
+       deadname
+       proc
+       vm
+       vnode)
 endif()
 
 foreach(test ${DISPATCH_C_TESTS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 
 add_executable(bsdtestharness
                bsdtestharness.c)
+dispatch_set_linker(bsdtestharness)
 target_include_directories(bsdtestharness
                            PRIVATE
                              ${CMAKE_CURRENT_BINARY_DIR}
@@ -84,6 +85,7 @@ function(add_unit_test name)
   target_compile_options(${name} PRIVATE -fblocks)
   # TODO(compnerd) make this portable
   target_compile_options(${name} PRIVATE -Wall -Wno-deprecated-declarations)
+  dispatch_set_linker(${name})
   target_link_libraries(${name} PRIVATE dispatch Threads::Threads)
   if(WITH_BLOCKS_RUNTIME)
     target_link_libraries(${name} PRIVATE BlocksRuntime)


### PR DESCRIPTION
This ensures that the cmake used to build is the cmake invoked when
running the custom command.  In the case that `cmake` is not in PATH,
you would fail to invoke the command, failing the build.