### PR TITLE
build: support system installed BlocksRuntime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ include(DispatchUtilities)
 
 set(SWIFT_LIBDIR "lib" CACHE PATH "Library folder name, defined by swift main buildscript")
 set(INSTALL_LIBDIR "${SWIFT_LIBDIR}" CACHE PATH "Path where the libraries should be installed")
-set(WITH_BLOCKS_RUNTIME "" CACHE PATH "Path to blocks runtime")
 
 include(DispatchAppleOptions)
 include(DispatchSanitization)
@@ -133,14 +132,14 @@ endif()
 
 option(INSTALL_PRIVATE_HEADERS "installs private headers in the same location as the public ones" OFF)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
-   CMAKE_SYSTEM_NAME STREQUAL Android OR
-   CMAKE_SYSTEM_NAME STREQUAL FreeBSD OR
-   CMAKE_SYSTEM_NAME STREQUAL Windows)
+find_package(BlocksRuntime QUIET)
+if(NOT BlocksRuntime_FOUND)
+  set(BlocksRuntime_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/BlocksRuntime)
+
   add_library(BlocksRuntime
               STATIC
                 ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/data.c
-                ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/runtime.c)            
+                ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/runtime.c)
   set_target_properties(BlocksRuntime
                         PROPERTIES
                           POSITION_INDEPENDENT_CODE TRUE)
@@ -149,8 +148,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
                           PROPERTIES
                             INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
   endif()
-  set(WITH_BLOCKS_RUNTIME "${CMAKE_SOURCE_DIR}/src/BlocksRuntime" CACHE PATH "Path to blocks runtime" FORCE)
-  
+
+  add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
+
   install(FILES
             ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/Block.h
           DESTINATION
@@ -161,9 +161,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux OR
             DESTINATION
               "${INSTALL_BLOCK_HEADERS_DIR}")
   endif()
-else()
-  # TODO(compnerd) support system installed BlocksRuntime
-  # find_package(BlocksRuntime REQUIRED)
 endif()
 
 check_symbol_exists(__GNU_LIBRARY__ "features.h" _GNU_SOURCE)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,7 +130,7 @@ Typical configuration line for FreeBSD 8.x and 9.x to build libdispatch with
 clang and blocks support:
 
     ```
-    cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DWITH_BLOCKS_RUNTIME=/usr/local/lib <path-to-source>
+    cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBlocksRuntime_INCLUDE_DIR=/usr/local/include -DBlocksRuntime_LIBRARIES=/usr/local/lib/libBlocksRuntime.so <path-to-source>
     ninja
     ninja test
     ```

--- a/cmake/modules/FindBlocksRuntime.cmake
+++ b/cmake/modules/FindBlocksRuntime.cmake
@@ -1,0 +1,48 @@
+#.rst:
+# FindBlocksRuntime
+# -----------------
+#
+# Find libBlocksRuntime library and headers.
+#
+# The module defines the following variables:
+#
+# ##
+#
+# BlocksRuntime_FOUND        - true if libBlocksRuntime was found
+# BlocksRuntime_INCLUDE_DIR  - include search path
+# BlocksRuntime_LIBRARIES    - libraries to link
+
+if(BlocksRuntime_INCLUDE_DIR AND BlocksRuntime_LIBRARIES)
+  set(BlocksRuntime_FOUND TRUE)
+else()
+  find_path(BlocksRuntime_INCLUDE_DIR
+            NAMES
+              Blocks.h
+            HINTS
+              ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+  find_library(BlocksRuntime_LIBRARIES
+               NAMES
+                 BlocksRuntime libBlocksRuntime
+               HINTS
+                 ${CMAKE_INSTALL_FULL_LIBDIR})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(BlocksRuntime
+                                    REQUIRED_VARS
+                                      BlocksRuntime_LIBRARIES
+                                      BlocksRuntime_INCLUDE_DIR)
+
+  mark_as_advanced(BlocksRuntime_LIBRARIES BlocksRuntime_INCLUDE_DIR)
+endif()
+
+if(BlocksRuntime_FOUND)
+  if(NOT TARGET BlocksRuntime::BlocksRuntime)
+    add_library(BlocksRuntime::BlocksRuntime UNKNOWN IMPORTED)
+    set_target_properties(BlocksRuntime::BlocksRuntime
+                          PROPERTIES
+                            IMPORTED_LOCATION
+                              ${BlocksRuntime_LIBRARIES}
+                            INTERFACE_INCLUDE_DIRECTORIES
+                              ${BlocksRuntime_INCLUDE_DIR})
+  endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,11 +134,9 @@ target_include_directories(dispatch
                              ${CMAKE_CURRENT_SOURCE_DIR}
                              ${CMAKE_CURRENT_BINARY_DIR}
                              ${CMAKE_SOURCE_DIR}/private)
-if(WITH_BLOCKS_RUNTIME)
-  target_include_directories(dispatch
-                             SYSTEM BEFORE PRIVATE
-                               "${WITH_BLOCKS_RUNTIME}")
-endif()
+target_include_directories(dispatch
+                           SYSTEM BEFORE PRIVATE
+                             "${BlocksRuntime_INCLUDE_DIR}")
 if(WIN32)
   target_compile_definitions(dispatch
                              PRIVATE
@@ -190,10 +188,10 @@ endif()
 if(BSD_OVERLAY_FOUND)
   target_link_libraries(dispatch PRIVATE ${BSD_OVERLAY_LDFLAGS})
 endif()
-target_link_libraries(dispatch PRIVATE Threads::Threads)
-if(WITH_BLOCKS_RUNTIME)
-  target_link_libraries(dispatch PRIVATE BlocksRuntime)
-endif()
+target_link_libraries(dispatch
+                      PRIVATE
+                        Threads::Threads
+                        BlocksRuntime::BlocksRuntime)
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(dispatch
                         PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,11 +72,9 @@ function(add_unit_test name)
     target_compile_options(${name} PRIVATE -DLENIENT_DEADLINES=1)
     target_link_libraries(${name} PRIVATE swiftCore swiftSwiftOnoneSupport)
   endif()
-  if(WITH_BLOCKS_RUNTIME)
-    target_include_directories(${name}
-                               SYSTEM BEFORE PRIVATE
-                                 "${WITH_BLOCKS_RUNTIME}")
-  endif()
+  target_include_directories(${name}
+                             SYSTEM BEFORE PRIVATE
+                               "${BlocksRuntime_INCLUDE_DIR}")
   if(BSD_OVERLAY_FOUND AND NOT AUT_NO_BSD_OVERLAY)
     target_compile_options(${name}
                            PRIVATE
@@ -86,10 +84,11 @@ function(add_unit_test name)
   # TODO(compnerd) make this portable
   target_compile_options(${name} PRIVATE -Wall -Wno-deprecated-declarations)
   dispatch_set_linker(${name})
-  target_link_libraries(${name} PRIVATE dispatch Threads::Threads)
-  if(WITH_BLOCKS_RUNTIME)
-    target_link_libraries(${name} PRIVATE BlocksRuntime)
-  endif()
+  target_link_libraries(${name}
+                        PRIVATE
+                          dispatch
+                          Threads::Threads
+                          BlocksRuntime::BlocksRuntime)
   if(BSD_OVERLAY_FOUND AND NOT AUT_NO_BSD_OVERLAY)
     target_link_libraries(${name}
                           PRIVATE


### PR DESCRIPTION
This uses the standard CMake mechanism for finding the blocks runtime.
If one is not found, one will be provided for you.