### PR TITLE
build: fix the clang-cl executable link command

### DIFF
--- a/cmake/modules/ClangClCompileRules.cmake
+++ b/cmake/modules/ClangClCompileRules.cmake
@@ -3,6 +3,3 @@
 # put a -- before the input file path to force it to be treated as a path.
 string(REPLACE "-c <SOURCE>" "-c -- <SOURCE>" CMAKE_C_COMPILE_OBJECT "${CMAKE_C_COMPILE_OBJECT}")
 string(REPLACE "-c <SOURCE>" "-c -- <SOURCE>" CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT}")
-
-set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-


### PR DESCRIPTION
ClangClCompileRules.cmake overrides CMAKE_C_LINK_EXECUTABLE to invoke the C
compiler, but clang-cl does not accept linker flags, so tests will fail to link.
The default is fine, so delete this line.