### PR TITLE
Fixed handling of the AMD64 processor architecture on Windows

### DIFF
--- a/cmake/modules/DispatchWindowsSupport.cmake
+++ b/cmake/modules/DispatchWindowsSupport.cmake
@@ -2,7 +2,7 @@
 function(dispatch_windows_arch_spelling arch var)
   if(${arch} STREQUAL i686)
     set(${var} x86 PARENT_SCOPE)
-  elseif(${arch} STREQUAL x86_64)
+  elseif(${arch} STREQUAL x86_64 OR ${arch} STREQUAL AMD64)
     set(${var} x64 PARENT_SCOPE)
   elseif(${arch} STREQUAL armv7)
     set(${var} arm PARENT_SCOPE)


### PR DESCRIPTION
Invoking cmake on a system where MSVC (2017) sets the PROCESSOR_ARCHITECTURE environment variable to AMD64 would previously fail with this error:

`CMake Error at cmake/modules/DispatchWindowsSupport.cmake:12 (message):
  do not know MSVC spelling for ARCH: `AMD64`
Call Stack (most recent call first):
  CMakeLists.txt:331 (dispatch_windows_arch_spelling)`

We now treat AMD64 like x86_64.
