### PR TITLE
Report crash messages on Windows to the CRT

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -293,6 +293,7 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 #endif
 #if defined(_WIN32)
 #include <io.h>
+#include <crtdbg.h>
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -876,9 +877,19 @@ _dispatch_ktrace_impl(uint32_t code, uint64_t a, uint64_t b,
 #define _dispatch_hardware_crash() \
 		__asm__(""); __builtin_trap() // <rdar://problem/17464981>
 
+#ifdef _WIN32
+#define _dispatch_set_crash_log_cause_and_message(ac, msg) do { \
+		(void)(ac); \
+		_dispatch_set_crash_log_message_dynamic((msg)); \
+	} while (0)
+#define _dispatch_set_crash_log_message(msg) \
+		_dispatch_set_crash_log_message_dynamic((msg))
+#define _dispatch_set_crash_log_message_dynamic(msg) _RPTF0(_CRT_ASSERT, (msg))
+#else
 #define _dispatch_set_crash_log_cause_and_message(ac, msg) ((void)(ac))
 #define _dispatch_set_crash_log_message(msg)
 #define _dispatch_set_crash_log_message_dynamic(msg)
+#endif
 
 #if HAVE_MACH
 // MIG_REPLY_MISMATCH means either:


### PR DESCRIPTION
Provide a Windows implementation of the `_dispatch_set_crash_log_*` macros which
pass the crash message to the CRT using _RPTF0. If libdispatch is linked against
a debug version of msvcrt, this will display a dialog with detailed information
about the crash and provide an option to attach a debugger. On release versions
of msvcrt, this reporting is a no-op.

Example of what this dialog looks like (from an actual issue I encountered):

![Screenshot](https://i.imgur.com/aQRxoR4.png)