### PR TITLE
BlocksRuntime: match the ABI specification for LLP64

### DIFF
--- a/src/BlocksRuntime/Block_private.h
+++ b/src/BlocksRuntime/Block_private.h
@@ -38,8 +38,8 @@ enum {
 
 #define BLOCK_DESCRIPTOR_1 1
 struct Block_descriptor_1 {
-    uintptr_t reserved;
-    uintptr_t size;
+    unsigned long int reserved;
+    unsigned long int size;
 };
 
 #define BLOCK_DESCRIPTOR_2 1


### PR DESCRIPTION
The Blocks ABI v1 defined the `size` and `reserved` fields as `unsigned
long int` rather than `uintptr_t`.  This breaks on LLP64 hosts where
`uintptr_t` is larger than `unsigned long int`.  Make this conform to
the specification.