### PR TITLE
Use snprintf instead of _snprintf on Windows

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -928,7 +928,7 @@ _dispatch_ktrace_impl(uint32_t code, uint64_t a, uint64_t b,
 		dispatch_assert(_length != -1); \
 		_msg = (char *)malloc((unsigned)_length + 1); \
 		dispatch_assert(_msg); \
-		_snprintf(_msg, (unsigned)_length, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, ##__VA_ARGS__); \
+		snprintf(_msg, (unsigned)_length + 1, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, ##__VA_ARGS__); \
 		_dispatch_assert_crash(_msg); \
 		free(_msg); \
 	} while (0)

--- a/src/shims/generic_win_stubs.h
+++ b/src/shims/generic_win_stubs.h
@@ -44,7 +44,6 @@ typedef __typeof__(_Generic((__SIZE_TYPE__)0,                                  \
 #define O_NONBLOCK 04000
 
 #define bzero(ptr,len) memset((ptr), 0, (len))
-#define snprintf _snprintf
 
 #endif
 


### PR DESCRIPTION
_snprintf does not guarantee null termination if the size argument is too small.
Starting with VS2015, the UCRT provides a C99-compliant snprintf. Use it, and
also fix a related issue where _dispatch_client_assert_fail was passing a
too-small size.