### PR TITLE
Stub out unimplemented Windows functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(dispatch
               event/event_epoll.c
               event/event_internal.h
               event/event_kevent.c
+              event/event_windows.c
               firehose/firehose_internal.h
               shims/android_stubs.h
               shims/atomic.h

--- a/src/event/event_config.h
+++ b/src/event/event_config.h
@@ -25,13 +25,16 @@
 #	include <sys/eventfd.h>
 #	define DISPATCH_EVENT_BACKEND_EPOLL 1
 #	define DISPATCH_EVENT_BACKEND_KEVENT 0
+#	define DISPATCH_EVENT_BACKEND_WINDOWS 0
 #elif __has_include(<sys/event.h>)
 #	include <sys/event.h>
 #	define DISPATCH_EVENT_BACKEND_EPOLL 0
 #	define DISPATCH_EVENT_BACKEND_KEVENT 1
+#	define DISPATCH_EVENT_BACKEND_WINDOWS 0
 #elif defined(_WIN32)
 #	define DISPATCH_EVENT_BACKEND_EPOLL 0
 #	define DISPATCH_EVENT_BACKEND_KEVENT 0
+#	define DISPATCH_EVENT_BACKEND_WINDOWS 1
 #else
 #	error unsupported event loop
 #endif

--- a/src/event/event_internal.h
+++ b/src/event/event_internal.h
@@ -418,7 +418,9 @@ void _dispatch_unote_resume(dispatch_unote_t du);
 bool _dispatch_unote_unregister(dispatch_unote_t du, uint32_t flags);
 void _dispatch_unote_dispose(dispatch_unote_t du);
 
+#if !DISPATCH_EVENT_BACKEND_WINDOWS
 void _dispatch_event_loop_atfork_child(void);
+#endif
 #define DISPATCH_EVENT_LOOP_CONSUME_2 DISPATCH_WAKEUP_CONSUME_2
 #define DISPATCH_EVENT_LOOP_OVERRIDE  0x80000000
 void _dispatch_event_loop_poke(dispatch_wlh_t wlh, uint64_t dq_state,

--- a/src/event/event_windows.c
+++ b/src/event/event_windows.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018 Apple Inc. All rights reserved.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_START@
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_END@
+ */
+
+#include "internal.h"
+#if DISPATCH_EVENT_BACKEND_WINDOWS
+
+#pragma mark dispatch_unote_t
+
+bool
+_dispatch_unote_register(dispatch_unote_t du DISPATCH_UNUSED,
+		dispatch_wlh_t wlh DISPATCH_UNUSED,
+		dispatch_priority_t pri DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+	return false;
+}
+
+void
+_dispatch_unote_resume(dispatch_unote_t du DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
+
+bool
+_dispatch_unote_unregister(dispatch_unote_t du DISPATCH_UNUSED,
+		uint32_t flags DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+	return false;
+}
+
+#pragma mark timers
+
+void
+_dispatch_event_loop_timer_arm(uint32_t tidx DISPATCH_UNUSED,
+		dispatch_timer_delay_s range DISPATCH_UNUSED,
+		dispatch_clock_now_cache_t nows DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
+
+void
+_dispatch_event_loop_timer_delete(uint32_t tidx DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
+
+#pragma mark dispatch_loop
+
+void
+_dispatch_event_loop_poke(dispatch_wlh_t wlh DISPATCH_UNUSED,
+		uint64_t dq_state DISPATCH_UNUSED, uint32_t flags DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
+
+DISPATCH_NOINLINE
+void
+_dispatch_event_loop_drain(uint32_t flags DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
+
+void
+_dispatch_event_loop_wake_owner(dispatch_sync_context_t dsc,
+		dispatch_wlh_t wlh, uint64_t old_state, uint64_t new_state)
+{
+	(void)dsc; (void)wlh; (void)old_state; (void)new_state;
+}
+
+void
+_dispatch_event_loop_wait_for_ownership(dispatch_sync_context_t dsc)
+{
+	if (dsc->dsc_release_storage) {
+		_dispatch_queue_release_storage(dsc->dc_data);
+	}
+}
+
+void
+_dispatch_event_loop_end_ownership(dispatch_wlh_t wlh, uint64_t old_state,
+		uint64_t new_state, uint32_t flags)
+{
+	(void)wlh; (void)old_state; (void)new_state; (void)flags;
+}
+
+#if DISPATCH_WLH_DEBUG
+void
+_dispatch_event_loop_assert_not_owned(dispatch_wlh_t wlh)
+{
+	(void)wlh;
+}
+#endif
+
+void
+_dispatch_event_loop_leave_immediate(dispatch_wlh_t wlh, uint64_t dq_state)
+{
+	(void)wlh; (void)dq_state;
+}
+
+#endif // DISPATCH_EVENT_BACKEND_WINDOWS

--- a/src/shims/generic_win_stubs.c
+++ b/src/shims/generic_win_stubs.c
@@ -1,3 +1,23 @@
+#include "internal.h"
+
+/*
+ * This file contains stubbed out functions we are using during
+ * the initial Windows port.  When the port is complete, this file
+ * should be empty (and thus removed).
+ */
+
+void
+_dispatch_runloop_queue_dispose(dispatch_queue_t dq DISPATCH_UNUSED,
+		bool *allow_free DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
+
+void
+_dispatch_runloop_queue_xref_dispose(dispatch_queue_t dq DISPATCH_UNUSED)
+{
+	WIN_PORT_ERROR();
+}
 
 /*
  * Stubbed out static data

--- a/src/shims/generic_win_stubs.h
+++ b/src/shims/generic_win_stubs.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include <Windows.h>
+#include <crtdbg.h>
 
 #include <io.h>
 #include <process.h>
@@ -46,5 +47,8 @@ typedef __typeof__(_Generic((__SIZE_TYPE__)0,                                  \
 #define bzero(ptr,len) memset((ptr), 0, (len))
 #define snprintf _snprintf
 
-#endif
+// Report when an unported code path executes.
+#define WIN_PORT_ERROR() \
+		_RPTF1(_CRT_ASSERT, "WIN_PORT_ERROR in %s", __FUNCTION__)
 
+#endif


### PR DESCRIPTION
Provide stubs for unimplemented Windows functions so that dispatch.dll can link
and we can start building the tests. If one of these stubs is called, it will be
reported to the CRT.