### PR TITLE
add_swift_library: removed dependency on swiftc

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -60,7 +60,6 @@ function(add_swift_library library)
                        ${module_directory}/${ASL_MODULE_NAME}.swiftdoc
                      DEPENDS
                        ${ASL_SOURCES}
-                       ${CMAKE_SWIFT_COMPILER}
                        ${ASL_DEPENDS}
                      COMMAND
                        ${CMAKE_COMMAND} -E make_directory ${module_directory}


### PR DESCRIPTION
I'm actually not really sure whether that's the right fix. This is the problem that I was seeing:

Configure lib dispatch with cmake like this:

`cmake -G "Ninja" ... -DENABLE_SWIFT=YES -DCMAKE_SWIFT_COMPILER="C:/.../swift-windows-amd64/bin/swiftc" -DSWIFT_RUNTIME_LIBDIR="C:/.../swift-windows-amd64/lib/swift/windows/x86_64"`

Then try to build with cmake like this:

`cmake --build "libdispatch-windows-amd64"`

which then results in this error from Ninja:

`ninja: error: 'C:/.../swift-windows-amd64/bin/swiftc', needed by 'src/swiftDispatch.o', missing and no known rule to make it`

Because the path to the swift compiler is added as a dependency to the src/swiftDispatch.o build target. But that's odd because there's no rule in the libdispatch ninja file to build the swift compiler and that wouldn't really make sense anyway.

So I've removed that dependency and that allows ninja to start building the Swift portion of libdispatch (which fails to complete for unrelated reasons).
