### PR TITLE
Added MSVC definitions for the DISPATCH_* macros in dispatch/base.h

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -65,6 +65,29 @@
 #define DISPATCH_ALWAYS_INLINE __attribute__((__always_inline__))
 #define DISPATCH_UNAVAILABLE __attribute__((__unavailable__))
 #define DISPATCH_UNAVAILABLE_MSG(msg) __attribute__((__unavailable__(msg)))
+#elif defined(_MSC_VER)
+#define DISPATCH_NORETURN __declspec(noreturn)
+#define DISPATCH_NOTHROW __declspec(nothrow)
+#define DISPATCH_NONNULL1
+#define DISPATCH_NONNULL2
+#define DISPATCH_NONNULL3
+#define DISPATCH_NONNULL4
+#define DISPATCH_NONNULL5
+#define DISPATCH_NONNULL6
+#define DISPATCH_NONNULL7
+#define DISPATCH_NONNULL_ALL
+#define DISPATCH_SENTINEL
+#define DISPATCH_PURE
+#define DISPATCH_CONST
+#if (_MSC_VER >= 1700)
+#define DISPATCH_WARN_RESULT _Check_return_
+#else
+#define DISPATCH_WARN_RESULT
+#endif
+#define DISPATCH_MALLOC
+#define DISPATCH_ALWAYS_INLINE __forceinline
+#define DISPATCH_UNAVAILABLE
+#define DISPATCH_UNAVAILABLE_MSG(msg)
 #else
 /*! @parseOnly */
 #define DISPATCH_NORETURN


### PR DESCRIPTION
Added MSVC specific definitions of the DISPATCH_* macros to dispatch/base.h. This is one necessary step to make it possible to compile the Swift APIs for ibdispatch. E.g. we need a working definition of DISPATCH_NORETURN to ensure that we can successfully compile his function:

`public func dispatchMain() -> Never {
	CDispatch.dispatch_main()
}`

because its return type is `Never`.

DISPATCH_* macros which are empty are empty because MSVC has no equivalent to the corresponding clang / gcc attribute.