### PR TITLE
Fixed some Swift overlay link errors for Windows

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -158,6 +158,12 @@
 #else
 #define DISPATCH_EXPORT extern __declspec(dllexport)
 #endif
+#elif defined(__DISPATCH_BUILDING_SWIFT_DISPATCH__)
+#if defined(__cplusplus)
+#define DISPATCH_EXPORT extern "C"
+#else
+#define DISPATCH_EXPORT extern
+#endif
 #else
 #if defined(__cplusplus)
 #define DISPATCH_EXPORT extern "C" __declspec(dllimport)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ if(ENABLE_SWIFT)
                     TARGET
                       ${CMAKE_C_COMPILER_TARGET}
                     CFLAGS
+                      -D__DISPATCH_BUILDING_SWIFT_DISPATCH__
                       -fblocks
                       -fmodule-map-file=${CMAKE_SOURCE_DIR}/dispatch/module.modulemap
                     SWIFT_FLAGS
@@ -144,6 +145,15 @@ if(WIN32)
   target_compile_definitions(dispatch
                              PRIVATE
                                _CRT_NONSTDC_NO_WARNINGS)
+  # Tell the linker to ignore references to dispatch.lib inside the
+  # swiftDispatch.obj file. This reference was put in there by swiftc because
+  # the dispatch.modulemap contains a 'link' line. We don't want the linker to
+  # follow this reference while we are trying to build dispatch.lib.
+  set_property(TARGET
+                 dispatch
+               APPEND_STRING PROPERTY
+               LINK_FLAGS
+                 " /NODEFAULTLIB:dispatch.lib")
 endif()
 if(NOT "${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
   target_compile_options(dispatch PRIVATE -fno-exceptions)


### PR DESCRIPTION
This fixes the following two problems:

1) Linking fails because the swiftDispatch.obj file contains a /DEFAULTLIB:dispatch.lib directive. The underlying problem here is that the dispatch module map has link "dispatch" lines. That's in general okay but means that the Swift compiler ends up adding a /DEFAULTLIB:dispatch.lib directive to the generated .obj file. I think the simplest solution here is to tell the linker that it should ignore this reference when it builds the final DLL. Alternatively we could create and maintain a copy of the dispatch module map which would be used on Windows to build the dispatch.dll but we would then have to keep this in sync with the regular module map file.

2) The linker generates tons of warnings because the swiftDispatch.obj file references dispatch_* calls as library imports when we are actually statically linking everything together. To fix this we don't declare the dispatch_* functions as imports while we are building the Swift overlay. That's achieved by defining the `__DISPATCH_BUILDING_SWIFT_DISPATCH__` macro.

This makes the Swift overlay mostly link. There is one remaining problem though where the linker spits out this error:

`swiftDispatch.o : error LNK2001: unresolved external symbol $SBoWV.`
`src\dispatch.dll : fatal error LNK1120: 1 unresolved externals`

which means that it can't resolve a reference to the witness table for Builtin.NativeObject.

I actually get the same link error when I try to compile a trivial .exe which defines an empty class:

`public class TestObject {}`
`swiftc -o test.exe test.swift`

results in:

`test.o : error LNK2001: unresolved external symbol $SBoWV.`
`test.exe : fatal error LNK1120: 1 unresolved externals`

So if someone has a good idea what might be wrong here then I'm all ears :)
