### PR TITLE
Fixed some Swift overlay compilation problems on Windows

### DIFF
--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -113,7 +113,7 @@ public extension DispatchSource {
 	}
 #endif
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 	public struct ProcessEvent : OptionSet, RawRepresentable {
 		public let rawValue: UInt
 		public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -171,7 +171,7 @@ public extension DispatchSource {
 	}
 #endif
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 	public class func makeProcessSource(identifier: pid_t, eventMask: ProcessEvent, queue: DispatchQueue? = nil) -> DispatchSourceProcess {
 		let source = dispatch_source_create(_swift_dispatch_source_type_PROC(), UInt(identifier), eventMask.rawValue, queue?.__wrapped)
 		return DispatchSource(source: source) as DispatchSourceProcess
@@ -208,7 +208,7 @@ public extension DispatchSource {
 		return DispatchSource(source: source) as DispatchSourceUserDataReplace
 	}
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 	public class func makeFileSystemObjectSource(fileDescriptor: Int32, eventMask: FileSystemEvent, queue: DispatchQueue? = nil) -> DispatchSourceFileSystemObject {
 		let source = dispatch_source_create(_swift_dispatch_source_type_VNODE(), UInt(fileDescriptor), eventMask.rawValue, queue?.__wrapped)
 		return DispatchSource(source: source) as DispatchSourceFileSystemObject
@@ -261,7 +261,7 @@ public extension DispatchSourceMemoryPressure {
 }
 #endif
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 public extension DispatchSourceProcess {
 	public var handle: pid_t {
 		return pid_t(dispatch_source_get_handle(self as! DispatchSource))
@@ -617,7 +617,7 @@ public extension DispatchSourceTimer {
 	}
 }
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 public extension DispatchSourceFileSystemObject {
 	public var handle: Int32 {
 		return Int32(dispatch_source_get_handle((self as! DispatchSource).__wrapped))

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -181,7 +181,7 @@ extension DispatchSource : DispatchSourceMachSend,
 }
 #endif
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 extension DispatchSource : DispatchSourceProcess,
 	DispatchSourceFileSystemObject {
 }
@@ -272,7 +272,7 @@ public protocol DispatchSourceMemoryPressure : DispatchSourceProtocol {
 }
 #endif
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 public protocol DispatchSourceProcess : DispatchSourceProtocol {
 	var handle: pid_t { get }
 
@@ -302,7 +302,7 @@ public protocol DispatchSourceTimer : DispatchSourceProtocol {
 	func scheduleRepeating(wallDeadline: DispatchWallTime, interval: Double, leeway: DispatchTimeInterval)
 }
 
-#if !os(Linux) && !os(Android)
+#if !os(Linux) && !os(Android) && !os(Windows)
 public protocol DispatchSourceFileSystemObject : DispatchSourceProtocol {
 	var handle: Int32 { get }
 


### PR DESCRIPTION
This fixes some of the problems that prevent us from successfully compiling the Swift overlay on Windows. I've separated this out from a larger fix because this should be pretty much the uncontroversial part. Anyway, we simply treat Windows the same as Linux and Android which makes this part of the code compile.

There are additional (and potentially controversial) fixes needed to get the whole overlay to compile on Windows. Please see the Swift forum topic [here](https://forums.swift.org/t/libdispatch-api-how-to-support-llp64-platforms/14012/4) for more info.

Specifically, @MadCoder : what would be the preferred solution to make LLP64 and LP64 platforms happy? E.g. one proposed solution is to replace uses of `long`, etc with `size_t`. E.g. change

`dispatch_semaphore_t  dispatch_semaphore_create(long value)`

to

`dispatch_semaphore_t  dispatch_semaphore_create(ssize_t value)`

Also please see [this PR](https://github.com/apple/swift/pull/17533) over on the compiler side which fixes another problem with the Swift overlay.