### PR TITLE
[Do not merge] Made the semaphore API integrate better with LLP64 (Windows) systems

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -288,6 +288,34 @@
 #define DISPATCH_TRANSPARENT_UNION
 #endif
 
+#if defined(_WIN64)
+// LLP64
+typedef long long dispatch_long_t;
+typedef unsigned long long dispatch_ulong_t;
+
+#define DISPATCH_LONG_MIN LLONG_MIN
+#define DISPATCH_LONG MAX LLONG_MAX
+
+#define DISPATCH_ULONG_MIN ULLONG_MIN
+#define DISPATCH_ULONG_MAX ULLONG_MAX
+
+#define PRIDISPATCHLONG "%lld"
+#define PRIDISPATCHULONG "%llu"
+#else
+// LP64 and ILP32
+typedef long dispatch_long_t;
+typedef unsigned long dispatch_ulong_t;
+
+#define DISPATCH_LONG_MIN LONG_MIN
+#define DISPATCH_LONG MAX LONG_MAX
+
+#define DISPATCH_ULONG_MIN ULONG_MIN
+#define DISPATCH_ULONG_MAX ULONG_MAX
+
+#define PRIDISPATCHLONG "%ld"
+#define PRIDISPATCHULONG "%lu"
+#endif
+
 typedef void (*dispatch_function_t)(void *_Nullable);
 
 #endif

--- a/dispatch/semaphore.h
+++ b/dispatch/semaphore.h
@@ -61,7 +61,7 @@ API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_MALLOC DISPATCH_RETURNS_RETAINED DISPATCH_WARN_RESULT
 DISPATCH_NOTHROW
 dispatch_semaphore_t
-dispatch_semaphore_create(long value);
+dispatch_semaphore_create(dispatch_long_t value);
 
 /*!
  * @function dispatch_semaphore_wait
@@ -85,7 +85,7 @@ dispatch_semaphore_create(long value);
  */
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
-long
+dispatch_long_t
 dispatch_semaphore_wait(dispatch_semaphore_t dsema, dispatch_time_t timeout);
 
 /*!
@@ -107,7 +107,7 @@ dispatch_semaphore_wait(dispatch_semaphore_t dsema, dispatch_time_t timeout);
  */
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
-long
+dispatch_long_t
 dispatch_semaphore_signal(dispatch_semaphore_t dsema);
 
 __END_DECLS

--- a/src/semaphore_internal.h
+++ b/src/semaphore_internal.h
@@ -31,7 +31,7 @@ struct dispatch_queue_s;
 
 #define DISPATCH_SEMAPHORE_HEADER(cls, ns) \
 	DISPATCH_OBJECT_HEADER(cls); \
-	long volatile ns##_value; \
+	dispatch_long_t volatile ns##_value; \
 	_dispatch_sema4_t ns##_sema
 
 struct dispatch_semaphore_header_s {
@@ -41,7 +41,7 @@ struct dispatch_semaphore_header_s {
 DISPATCH_CLASS_DECL(semaphore);
 struct dispatch_semaphore_s {
 	DISPATCH_SEMAPHORE_HEADER(semaphore, dsema);
-	long dsema_orig;
+	dispatch_long_t dsema_orig;
 };
 
 DISPATCH_CLASS_DECL(group);


### PR DESCRIPTION
This PR is an attempt to solve the problem [discussed here](https://forums.swift.org/t/libdispatch-api-how-to-support-llp64-platforms/14012).

The short summary is that the libdispatch Swift API uses `Int` types in its API which are 64bit wide on 64bit Windows. But the underlying libdispatch C API uses `long` types which are 32bit wide on 64bit Windows. Consequently we get type conflicts when we try to build the Swift API for libdispatch.

An important goal here is to come up with a solution that ensures that we do not end up forcing users of the Swift API to sprinkle `#if os(Windows)` checks throughout their code to support both non-Windows and Windows platforms.

What does the PR do?

It replaces uses of `long` with `dispatch_long_t` and uses of `unsigned long` with `dispatch_ulong_t`. The code compiles as is on Windows and Linux and it has been verified on Linux that the unit tests for semaphores still work.

The PR is limited to semaphores because the main question at this point is whether the approach as such would be acceptable or whether a different approach would be preferred by the libdispatch maintainers.