### PR TITLE
Drop @_downgrade_exhaustivity_check attribute

### DIFF
--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -170,7 +170,6 @@ public enum DispatchTimeInterval {
 	case milliseconds(Int)
 	case microseconds(Int)
 	case nanoseconds(Int)
-	@_downgrade_exhaustivity_check
 	case never
 
 	internal var rawValue: Int64 {


### PR DESCRIPTION
This hack was only needed for Swift 3 mode in a narrow case.  Now that
we're dropping Swift 3 from master, the source break this was working
around is no longer relevant.