### PR TITLE
build: support embedding in other CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 cmake_minimum_required(VERSION 3.4.3)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 project(dispatch
         VERSION 1.3
@@ -134,12 +134,12 @@ option(INSTALL_PRIVATE_HEADERS "installs private headers in the same location as
 
 find_package(BlocksRuntime QUIET)
 if(NOT BlocksRuntime_FOUND)
-  set(BlocksRuntime_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/BlocksRuntime)
+  set(BlocksRuntime_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/src/BlocksRuntime)
 
   add_library(BlocksRuntime
               STATIC
-                ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/data.c
-                ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/runtime.c)
+                ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/data.c
+                ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/runtime.c)
   set_target_properties(BlocksRuntime
                         PROPERTIES
                           POSITION_INDEPENDENT_CODE TRUE)
@@ -152,12 +152,12 @@ if(NOT BlocksRuntime_FOUND)
   add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
 
   install(FILES
-            ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/Block.h
+            ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/Block.h
           DESTINATION
             "${INSTALL_BLOCK_HEADERS_DIR}")
   if(INSTALL_PRIVATE_HEADERS)
     install(FILES
-              ${CMAKE_SOURCE_DIR}/src/BlocksRuntime/Block_private.h
+              ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/Block_private.h
             DESTINATION
               "${INSTALL_BLOCK_HEADERS_DIR}")
   endif()
@@ -300,35 +300,35 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   add_custom_command(OUTPUT
-                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
+                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
+                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
                      COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                       ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
                      COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/darwin/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+                       ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/private/darwin/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_custom_command(OUTPUT
-                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
+                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
+                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
                      COMMAND
-                       ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/dispatch/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                       ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
                      COMMAND
-                       ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/private/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+                       ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/private/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
 else()
   add_custom_command(OUTPUT
-                       "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${CMAKE_SOURCE_DIR}/private/module.modulemap"
+                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
+                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
                      COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/dispatch/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
+                       ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
                      COMMAND
-                       ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SOURCE_DIR}/private/generic/module.modulemap" "${CMAKE_SOURCE_DIR}/private/module.modulemap")
+                       ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}/private/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
 endif()
 add_custom_target(module-map-symlinks
                   DEPENDS
-                     "${CMAKE_SOURCE_DIR}/dispatch/module.modulemap"
-                     "${CMAKE_SOURCE_DIR}/private/module.modulemap")
-configure_file("${CMAKE_SOURCE_DIR}/cmake/config.h.in"
-               "${CMAKE_BINARY_DIR}/config/config_ac.h")
+                     "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
+                     "${PROJECT_SOURCE_DIR}/private/module.modulemap")
+configure_file("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
+               "${PROJECT_BINARY_DIR}/config/config_ac.h")
 add_definitions(-DHAVE_CONFIG_H)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/cmake/modules/DispatchWindowsSupport.cmake
+++ b/cmake/modules/DispatchWindowsSupport.cmake
@@ -64,11 +64,11 @@ function(dispatch_windows_generate_sdk_vfs_overlay flags)
   set(UCRTVersion $ENV{UCRTVersion})
 
   # TODO(compnerd) use a target to avoid re-creating this file all the time
-  configure_file("${CMAKE_SOURCE_DIR}/utils/WindowsSDKVFSOverlay.yaml.in"
-                 "${CMAKE_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
+  configure_file("${PROJECT_SOURCE_DIR}/utils/WindowsSDKVFSOverlay.yaml.in"
+                 "${PROJECT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
                  @ONLY)
 
   set(${flags}
-      -ivfsoverlay;"${CMAKE_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
+      -ivfsoverlay;"${PROJECT_BINARY_DIR}/windows-sdk-vfs-overlay.yaml"
       PARENT_SCOPE)
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,13 +110,13 @@ if(ENABLE_SWIFT)
                       ${CMAKE_C_COMPILER_TARGET}
                     CFLAGS
                       -fblocks
-                      -fmodule-map-file=${CMAKE_SOURCE_DIR}/dispatch/module.modulemap
+                      -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
                     SWIFT_FLAGS
-                      -I ${CMAKE_SOURCE_DIR}
+                      -I ${PROJECT_SOURCE_DIR}
                       -I/usr/include
                       ${swift_optimization_flags}
                     DEPENDS
-                      ${CMAKE_SOURCE_DIR}/dispatch/module.modulemap)
+                      ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
   target_sources(dispatch
                  PRIVATE
                    swift/DispatchStubs.cc
@@ -132,11 +132,11 @@ if(ENABLE_DTRACE)
 endif()
 target_include_directories(dispatch
                            PRIVATE
-                             ${CMAKE_BINARY_DIR}
-                             ${CMAKE_SOURCE_DIR}
+                             ${PROJECT_BINARY_DIR}
+                             ${PROJECT_SOURCE_DIR}
                              ${CMAKE_CURRENT_SOURCE_DIR}
                              ${CMAKE_CURRENT_BINARY_DIR}
-                             ${CMAKE_SOURCE_DIR}/private)
+                             ${PROJECT_SOURCE_DIR}/private)
 target_include_directories(dispatch
                            SYSTEM BEFORE PRIVATE
                              "${BlocksRuntime_INCLUDE_DIR}")
@@ -209,7 +209,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
                  "-Xlinker -compatibility_version -Xlinker 1"
                  "-Xlinker -current_version -Xlinker ${VERSION}"
                  "-Xlinker -dead_strip"
-                 "-Xlinker -alias_list -Xlinker ${CMAKE_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
+                 "-Xlinker -alias_list -Xlinker ${PROJECT_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
 endif()
 dispatch_set_linker(dispatch)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,14 @@
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     execute_process(COMMAND
-                      "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/private"
+                      "${CMAKE_COMMAND}" -E copy "${PROJECT_SOURCE_DIR}/private"
                       "${CMAKE_CURRENT_BINARY_DIR}/dispatch")
     execute_process(COMMAND
                       "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/leaks-wrapper.sh"
                       "${CMAKE_CURRENT_BINARY_DIR}/leaks-wrapper")
 else()
     execute_process(COMMAND
-                      "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_SOURCE_DIR}/private"
+                      "${CMAKE_COMMAND}" -E create_symlink "${PROJECT_SOURCE_DIR}/private"
                       "${CMAKE_CURRENT_BINARY_DIR}/dispatch")
     execute_process(COMMAND
                       "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/leaks-wrapper.sh"
@@ -27,7 +27,7 @@ target_include_directories(bsdtests
                            PRIVATE
                              ${CMAKE_CURRENT_BINARY_DIR}
                              ${CMAKE_CURRENT_SOURCE_DIR}
-                             ${CMAKE_SOURCE_DIR})
+                             ${PROJECT_SOURCE_DIR})
 if(BSD_OVERLAY_FOUND)
   target_compile_options(bsdtests
                          PRIVATE
@@ -41,7 +41,7 @@ target_include_directories(bsdtestharness
                            PRIVATE
                              ${CMAKE_CURRENT_BINARY_DIR}
                              ${CMAKE_CURRENT_SOURCE_DIR}
-                             ${CMAKE_SOURCE_DIR})
+                             ${PROJECT_SOURCE_DIR})
 if(BSD_OVERLAY_FOUND)
   target_compile_options(bsdtestharness
                          PRIVATE
@@ -78,7 +78,7 @@ function(add_unit_test name)
                              PRIVATE
                                ${CMAKE_CURRENT_BINARY_DIR}
                                ${CMAKE_CURRENT_SOURCE_DIR}
-                               ${CMAKE_SOURCE_DIR})
+                               ${PROJECT_SOURCE_DIR})
   if(ENABLE_SWIFT)
     # For testing in swift.org CI system; make deadlines lenient by default
     # to reduce probability of test failures due to machine load.


### PR DESCRIPTION
Allow libdispatch to be embedded in other CMake projects using
add_subdirectory(). This essentially means that `CMAKE_SOURCE_DIR` and
`CMAKE_BINARY_DIR` cannot be used directly. Use the versions of these variables
which are scoped to the current project or directory.