### PR TITLE
build: link against librt if it's available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,6 +191,9 @@ endif()
 if(BSD_OVERLAY_FOUND)
   target_link_libraries(dispatch PRIVATE ${BSD_OVERLAY_LDFLAGS})
 endif()
+if(LibRT_FOUND)
+  target_link_libraries(dispatch PRIVATE RT::rt)
+endif()
 target_link_libraries(dispatch
                       PRIVATE
                         Threads::Threads


### PR DESCRIPTION
CMakeLists.txt checks for librt's presence but the result is never used. This
causes a link failure on systems where clock_gettime() is provided by librt.