### PR TITLE
build: link against swiftOnoneSupport in debug configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ if(HAVE_OBJC)
 endif()
 if(ENABLE_SWIFT)
   set(swift_optimization_flags)
-  if(CMAKE_BUILD_TYPE MATCHES Release)
+  if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
     set(swift_optimization_flags -O)
   endif()
   add_swift_library(swiftDispatch
@@ -121,6 +121,11 @@ if(ENABLE_SWIFT)
                  PRIVATE
                    swift/DispatchStubs.cc
                    ${CMAKE_CURRENT_BINARY_DIR}/swiftDispatch.o)
+  if(CMAKE_BUILD_TYPE MATCHES Debug)
+    target_link_libraries(dispatch
+                          PRIVATE
+                            swiftSwiftOnoneSupport)
+  endif()
 endif()
 if(ENABLE_DTRACE)
   dtrace_usdt_probe(${CMAKE_CURRENT_SOURCE_DIR}/provider.d


### PR DESCRIPTION
When building debug, swift requires a supplementary library.  The swift driver
is aware of this and will make the appropriate arrangements.  However, since the
swift component is compacted into the C library, the linker driver being used
does not understand this requirement.  Explicitly link against the support
library.  This allows building the debug configuration of libdispatch with a
release configuration of the swift standard library.