### PR TITLE
Fix redundant access-level modifiers.

### DIFF
--- a/src/swift/Dispatch.swift
+++ b/src/swift/Dispatch.swift
@@ -133,7 +133,7 @@ public enum DispatchTimeoutResult {
 
 /// dispatch_group
 
-public extension DispatchGroup {
+extension DispatchGroup {
 	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> ()) {
 		if #available(macOS 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
@@ -163,7 +163,7 @@ public extension DispatchGroup {
 
 /// dispatch_semaphore
 
-public extension DispatchSemaphore {
+extension DispatchSemaphore {
 	@discardableResult
 	public func signal() -> Int {
 		return Int(dispatch_semaphore_signal(self.__wrapped))

--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -12,7 +12,7 @@
 
 import CDispatch
 
-public extension DispatchIO {
+extension DispatchIO {
 
 	public enum StreamType : UInt  {
 		case stream = 0

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -24,7 +24,7 @@ internal class _DispatchSpecificValue<T> {
 	internal init(value: T) { self.value = value }
 }
 
-public extension DispatchQueue {
+extension DispatchQueue {
 	public struct Attributes : OptionSet {
 		public let rawValue: UInt64
 		public init(rawValue: UInt64) { self.rawValue = rawValue }

--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -13,7 +13,7 @@
 import CDispatch
 import _SwiftDispatchOverlayShims
 
-public extension DispatchSourceProtocol {
+extension DispatchSourceProtocol {
 
 	public func setEventHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
 		if #available(macOS 10.10, iOS 8.0, *), let h = handler, qos != .unspecified || !flags.isEmpty {
@@ -91,7 +91,7 @@ public extension DispatchSourceProtocol {
 	}
 }
 
-public extension DispatchSource {
+extension DispatchSource {
 #if HAVE_MACH
 	public struct MachSendEvent : OptionSet, RawRepresentable {
 		public let rawValue: UInt
@@ -222,7 +222,7 @@ public extension DispatchSource {
 }
 
 #if HAVE_MACH
-public extension DispatchSourceMachSend {
+extension DispatchSourceMachSend {
 	public var handle: mach_port_t {
 		return mach_port_t(dispatch_source_get_handle(self as! DispatchSource))
 	}
@@ -240,7 +240,7 @@ public extension DispatchSourceMachSend {
 #endif
 
 #if HAVE_MACH
-public extension DispatchSourceMachReceive {
+extension DispatchSourceMachReceive {
 	public var handle: mach_port_t {
 		return mach_port_t(dispatch_source_get_handle(self as! DispatchSource))
 	}
@@ -248,7 +248,7 @@ public extension DispatchSourceMachReceive {
 #endif
 
 #if HAVE_MACH
-public extension DispatchSourceMemoryPressure {
+extension DispatchSourceMemoryPressure {
 	public var data: DispatchSource.MemoryPressureEvent {
 		let data = dispatch_source_get_data(self as! DispatchSource)
 		return DispatchSource.MemoryPressureEvent(rawValue: data)
@@ -262,7 +262,7 @@ public extension DispatchSourceMemoryPressure {
 #endif
 
 #if !os(Linux) && !os(Android)
-public extension DispatchSourceProcess {
+extension DispatchSourceProcess {
 	public var handle: pid_t {
 		return pid_t(dispatch_source_get_handle(self as! DispatchSource))
 	}
@@ -277,7 +277,7 @@ public extension DispatchSourceProcess {
 }
 #endif
 
-public extension DispatchSourceTimer {
+extension DispatchSourceTimer {
 	///
 	/// Sets the deadline and leeway for a timer event that fires once.
 	///
@@ -618,7 +618,7 @@ public extension DispatchSourceTimer {
 }
 
 #if !os(Linux) && !os(Android)
-public extension DispatchSourceFileSystemObject {
+extension DispatchSourceFileSystemObject {
 	public var handle: Int32 {
 		return Int32(dispatch_source_get_handle((self as! DispatchSource).__wrapped))
 	}
@@ -635,7 +635,7 @@ public extension DispatchSourceFileSystemObject {
 }
 #endif
 
-public extension DispatchSourceUserDataAdd {
+extension DispatchSourceUserDataAdd {
 	/// Merges data into a dispatch source of type `DISPATCH_SOURCE_TYPE_DATA_ADD`
 	/// and submits its event handler block to its target queue.
 	///
@@ -646,7 +646,7 @@ public extension DispatchSourceUserDataAdd {
 	}
 }
 
-public extension DispatchSourceUserDataOr {
+extension DispatchSourceUserDataOr {
 	/// Merges data into a dispatch source of type `DISPATCH_SOURCE_TYPE_DATA_OR` and
 	/// submits its event handler block to its target queue.
 	///
@@ -657,7 +657,7 @@ public extension DispatchSourceUserDataOr {
 	}
 }
 
-public extension DispatchSourceUserDataReplace {
+extension DispatchSourceUserDataReplace {
 	/// Merges data into a dispatch source of type `DISPATCH_SOURCE_TYPE_DATA_REPLACE`
 	/// and submits its event handler block to its target queue.
 	///


### PR DESCRIPTION
This patch aims to make corelibs-libdispatch adapted to [this PR](https://github.com/apple/swift/pull/18623), which produces warnings for redundant access-level modifiers.

Following [INSTALL.md](https://github.com/apple/swift-corelibs-libdispatch/blob/master/INSTALL.md), I have troubles building libdispatch. It seems the instructions are not up-to-date. It suggests building with `autoconf` while instead `cmake` should be used at the moment...

@mwwa Hi Matt, would you help review this, please?

