### PR TITLE
Non-Darwin SDKs product results in per-arch directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(ENABLE_SWIFT)
   endif()
 
   set(INSTALL_TARGET_DIR "${INSTALL_LIBDIR}/${swift_dir}/${swift_os}" CACHE PATH "Path where the libraries will be installed")
+  set(INSTALL_RSRC_DIR "${INSTALL_LIBDIR}/${swift_dir}/${swift_os}/${swift_arch}" CACHE PATH "Path where the compiler resources will be installed")
   set(INSTALL_DISPATCH_HEADERS_DIR "${INSTALL_LIBDIR}/${swift_dir}/dispatch" CACHE PATH "Path where the headers will be installed for libdispatch")
   set(INSTALL_BLOCK_HEADERS_DIR "${INSTALL_LIBDIR}/${swift_dir}/Block" CACHE PATH "Path where the headers will be installed for the blocks runtime")
   set(INSTALL_OS_HEADERS_DIR "${INSTALL_LIBDIR}/${swift_dir}/os" CACHE PATH "Path where the os/ headers will be installed")
@@ -168,6 +169,14 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
             BlocksRuntime
           DESTINATION
             ${INSTALL_TARGET_DIR})
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # Install also in the architecture subdir for platforms that do not support
+    # fat libraries
+    install(TARGETS
+              BlocksRuntime
+            DESTINATION
+              ${INSTALL_RSRC_DIR})
+  endif()
 endif()
 
 check_symbol_exists(__GNU_LIBRARY__ "features.h" _GNU_SOURCE)
@@ -347,4 +356,3 @@ add_subdirectory(src)
 if(ENABLE_TESTING)
   add_subdirectory(tests)
 endif()
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,7 +254,7 @@ if(ENABLE_SWIFT)
             ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftmodule
             ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftdoc
           DESTINATION
-            ${INSTALL_TARGET_DIR}/${swift_arch})
+            ${INSTALL_RSRC_DIR})
 
   if(BUILD_SHARED_LIBS)
     set(library_kind SHARED)
@@ -267,5 +267,17 @@ if(ENABLE_SWIFT)
             ${swiftDispatch_OUTPUT_FILE}
           DESTINATION
             ${INSTALL_TARGET_DIR})
-endif()
 
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # Install also in the architecture subdir for platforms that do not support
+    # fat libraries
+    install(TARGETS
+              dispatch
+            DESTINATION
+              ${INSTALL_RSRC_DIR})
+    install(FILES
+              ${swiftDispatch_OUTPUT_FILE}
+            DESTINATION
+              ${INSTALL_RSRC_DIR})
+  endif()
+endif()


### PR DESCRIPTION
Depends on apple/swift#19432

Unix (other than Darwin) and Windows do not support fat binaries.
However, the build system was placing the build results in the
platform/OS folder, instead of the per-architecture folder. Having two
architectures side by side was impossible.

After applying the above patch in the Swift compiler, non-Darwin
platforms will look into the per-architecture folders, so the sibling
projects need to leave the products in the right place.