### PR TITLE
build: give BlocksRuntime hidden visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,9 @@ if(NOT BlocksRuntime_FOUND)
                 ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/runtime.c)
   set_target_properties(BlocksRuntime
                         PROPERTIES
-                          POSITION_INDEPENDENT_CODE TRUE)
+                          POSITION_INDEPENDENT_CODE TRUE
+                          C_VISIBILITY_PRESET HIDDEN
+                          VISIBILITY_INLINES_HIDDEN YES)
   if(HAVE_OBJC AND CMAKE_DL_LIBS)
     set_target_properties(BlocksRuntime
                           PROPERTIES


### PR DESCRIPTION
Since BlocksRuntime is currently built statically, we should ensure that it does
not leak symbols into the target library or executable it is being linked into.
This will require consumers to explicitly link against the BlocksRuntime.