### PR TITLE
[CMake] Make sure to link swiftrt.o when building the Swift Dispatch overlay.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,8 @@ if(ENABLE_SWIFT)
   target_sources(dispatch
                  PRIVATE
                    swift/DispatchStubs.cc
-                   ${CMAKE_CURRENT_BINARY_DIR}/swiftDispatch.o)
+                   ${CMAKE_CURRENT_BINARY_DIR}/swiftDispatch.o
+                   ${SWIFT_RUNTIME_LIBDIR}/swiftrt.o)
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     target_link_libraries(dispatch
                           PRIVATE


### PR DESCRIPTION
Because we are linking libdispatch through clang rather than swift, we need to
explicitly add swiftrt.o, which is needed by ELF and COFF to register metadata
sections. Fixes rdar://problem/44941707.