### PR TITLE
swift: cast to the appropriate type

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -40,14 +40,14 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(UInt32(flags.rawValue)),
+		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(UInt(flags.rawValue)),
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
 
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
-		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(UInt32(flags.rawValue)), noescapeBlock)
+		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(UInt(flags.rawValue)), noescapeBlock)
 	}
 
 	public func perform() {


### PR DESCRIPTION
This fixes an error from the swift compiler:
	error: cannot convert value of type 'UInt32' to expected argument type 'UInt'