### PR TITLE
queue: clean up a covered switch

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -1124,8 +1124,6 @@ _dispatch_qos_class_valid(dispatch_qos_class_t qos_class, int relative_priority)
 	case QOS_CLASS_USER_INTERACTIVE:
 	case QOS_CLASS_UNSPECIFIED:
 		break;
-	default:
-		return false;
 	}
 	if (relative_priority > 0 || relative_priority < QOS_MIN_RELATIVE_PRIORITY){
 		return false;


### PR DESCRIPTION
clang objects to the `default` case in a covered switch:

	src/queue.c:1127:2: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]

Remove the label, relying on the covered switch to catch the issue.