### PR TITLE
Fix the signature of _dispatch_install_thread_detach_callback()

### DIFF
--- a/private/queue_private.h
+++ b/private/queue_private.h
@@ -342,7 +342,7 @@ dispatch_async_enforce_qos_class_f(dispatch_queue_t queue,
  * "detached" before the thread exits or the application will crash.
  */
 DISPATCH_EXPORT
-void _dispatch_install_thread_detach_callback(dispatch_function_t cb);
+void _dispatch_install_thread_detach_callback(void (*cb)(void));
 #endif
 
 __END_DECLS

--- a/src/queue.c
+++ b/src/queue.c
@@ -953,7 +953,7 @@ gettid(void)
 static void (*_dispatch_thread_detach_callback)(void);
 
 void
-_dispatch_install_thread_detach_callback(dispatch_function_t cb)
+_dispatch_install_thread_detach_callback(void (*cb)(void))
 {
     if (os_atomic_xchg(&_dispatch_thread_detach_callback, cb, relaxed)) {
         DISPATCH_CLIENT_CRASH(0, "Installing a thread detach callback twice");


### PR DESCRIPTION
This function is declared as accepting a `dispatch_function_t` callback, which
is a function pointer with a `void *` argument. However, the implementation and
Swift overlay declare the callback without arguments, causing a conflict which
Clang warns about. Change the function signature to accept the correct type.