### PR TITLE
Replace valloc() usages in portable code

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2320,7 +2320,10 @@ _dispatch_operation_perform(dispatch_operation_t op)
 			}
 			op->buf = _aligned_malloc(op->buf_siz, siInfo.dwPageSize);
 #else
-			op->buf = valloc(op->buf_siz);
+			err = posix_memalign(&op->buf, (size_t)PAGE_SIZE, op->buf_siz);
+			if (err != 0) {
+				goto error;
+			}
 #endif
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -372,7 +372,9 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 		case DISPATCH_ASYNC_READ_ON_CONCURRENT_QUEUE:
 		case DISPATCH_ASYNC_READ_ON_SERIAL_QUEUE:
 			dispatch_async(queue, ^{
-				char* buffer = valloc(size);
+				char* buffer = NULL;
+				size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
+				posix_memalign((void **)&buffer, pagesize, size);
 				ssize_t r = read(fd, buffer, size);
 				if (r == -1) {
 					test_errno("async read error", errno, 0);

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -81,7 +81,9 @@ dispatch_read2(dispatch_fd_t fd,
 	__block int err = 0;
 	dispatch_source_set_event_handler(reader, ^{
 		const ssize_t bufsiz = 1024*512; // 512KB buffer
-		char *buffer = valloc(bufsiz);
+		char *buffer = NULL;
+		size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
+		posix_memalign((void **)&buffer, pagesize, bufsiz);
 		ssize_t actual = read(fd, buffer, bufsiz);
 		if (actual == -1) {
 			err = errno;


### PR DESCRIPTION
valloc() is obsolete and 64-bit Android does not provide it at all. When
portability is required, use posix_memalign() instead.