### PR TITLE
dispatch_c99: remove unnecessary __printflike() definition

### DIFF
--- a/tests/dispatch_c99.c
+++ b/tests/dispatch_c99.c
@@ -21,14 +21,6 @@
 #include <dispatch/dispatch.h>
 #include <stdlib.h>
 
-#ifdef __linux__
-// On Linux normally comes from libbsd overlay files,
-// but the headers are not c99 compliant so we compile
-// this test case without $(BSD_OVERLAY_CFLAGS)
-#define __printflike(a,b) __attribute__((format(printf, a, b)))
-#include <inttypes.h>
-#endif
-
 #include <bsdtests.h>
 #include "dispatch_test.h"
 


### PR DESCRIPTION
Some C libraries (e.g. Bionic on Android) provide a `__printflike()` macro but
this test always redefines it on Linux-based systems. bsdtests.h already has
better logic to ensure it is available.