### PR TITLE
tests: read from a temporary file instead of vi on non-Apple platforms

### DIFF
--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -240,7 +240,7 @@ test_io_stop(void) // rdar://problem/8250057
 static void
 test_io_read_write(void)
 {
-	const char *path_in = "/usr/bin/vi";
+	char *path_in = dispatch_test_get_large_file();
 	char path_out[] = "/tmp/dispatchtest_io.XXXXXX";
 
 	int in = open(path_in, O_RDONLY);
@@ -248,6 +248,8 @@ test_io_read_write(void)
 		test_errno("open", errno, 0);
 		test_stop();
 	}
+	dispatch_test_release_large_file(path_in);
+	free(path_in);
 	struct stat sb;
 	if (fstat(in, &sb)) {
 		test_errno("fstat", errno, 0);

--- a/tests/dispatch_read.c
+++ b/tests/dispatch_read.c
@@ -47,7 +47,7 @@ test_fin(void *cxt)
 int
 main(void)
 {
-	const char *path = "/usr/bin/vi";
+	char *path = dispatch_test_get_large_file();
 	struct stat sb;
 
 	dispatch_test_start("Dispatch Source Read");
@@ -57,6 +57,8 @@ main(void)
 		perror(path);
 		exit(EXIT_FAILURE);
 	}
+	dispatch_test_release_large_file(path);
+	free(path);
 	if (fstat(infd, &sb) == -1) {
 		perror(path);
 		exit(EXIT_FAILURE);

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -122,12 +122,14 @@ dispatch_read2(dispatch_fd_t fd,
 static void
 test_read(void)
 {
-	const char *path = "/usr/bin/vi";
+	char *path = dispatch_test_get_large_file();
 	int fd = open(path, O_RDONLY);
 	if (fd == -1) {
 		test_errno("open", errno, 0);
 		test_stop();
 	}
+	dispatch_test_release_large_file(path);
+	free(path);
 #ifdef F_NOCACHE
 	if (fcntl(fd, F_NOCACHE, 1)) {
 		test_errno("fcntl F_NOCACHE", errno, 0);

--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -86,7 +86,7 @@ stage1(int stage)
 void
 stage2(void)
 {
-	const char *path = "/usr/bin/vi";
+	char *path = dispatch_test_get_large_file();
 	struct stat sb;
 
 	int fd = open(path, O_RDONLY);
@@ -95,6 +95,8 @@ stage2(void)
 		perror(path);
 		exit(EXIT_FAILURE);
 	}
+	dispatch_test_release_large_file(path);
+	free(path);
 
 	if (!dispatch_test_check_evfilt_read_for_fd(fd)) {
 		test_skip("EVFILT_READ kevent not firing for test file");

--- a/tests/dispatch_test.c
+++ b/tests/dispatch_test.c
@@ -82,6 +82,83 @@ dispatch_test_check_evfilt_read_for_fd(int fd)
 #endif
 }
 
+char *
+dispatch_test_get_large_file(void)
+{
+#if defined(__APPLE__)
+	return strdup("/usr/bin/vi");
+#elif defined(__unix__)
+	// Depending on /usr/bin/vi being present is unreliable (especially on
+	// Android), so fill up a large-enough temp file with random bytes
+
+	const char *temp_dir = getenv("TMPDIR");
+	if (temp_dir == NULL || temp_dir[0] == '\0') {
+		temp_dir = "/tmp";
+	}
+	const char *const suffix = "/dispatch_test.XXXXXX";
+	size_t temp_dir_len = strlen(temp_dir);
+	size_t suffix_len = strlen(suffix);
+	char *path = malloc(temp_dir_len + suffix_len + 1);
+	assert(path != NULL);
+	memcpy(path, temp_dir, temp_dir_len);
+	memcpy(&path[temp_dir_len], suffix, suffix_len + 1);
+	int temp_fd = mkstemp(path);
+	if (temp_fd == -1) {
+		perror("mkstemp");
+		exit(EXIT_FAILURE);
+	}
+
+	const size_t file_size = 2 * 1024 * 1024;
+	char *file_buf = malloc(file_size);
+	assert(file_buf != NULL);
+
+	int urandom_fd = open("/dev/urandom", O_RDONLY);
+	if (urandom_fd == -1) {
+		perror("/dev/urandom");
+		exit(EXIT_FAILURE);
+	}
+	ssize_t num;
+	size_t pos = 0;
+	while (pos < file_size) {
+		num = read(urandom_fd, &file_buf[pos], file_size - pos);
+		if (num > 0) {
+			pos += (size_t)num;
+		} else if (num == -1 && errno != EINTR) {
+			perror("read");
+			exit(EXIT_FAILURE);
+		}
+	}
+	close(urandom_fd);
+
+	do {
+		num = write(temp_fd, file_buf, file_size);
+	} while (num == -1 && errno == EINTR);
+	if (num == -1) {
+		perror("write");
+		exit(EXIT_FAILURE);
+	}
+	assert(num == file_size);
+	close(temp_fd);
+	free(file_buf);
+	return path;
+#else
+#error "dispatch_test_get_large_file not implemented on this platform"
+#endif
+}
+
+void
+dispatch_test_release_large_file(const char *path)
+{
+#if defined(__APPLE__)
+	// The path is fixed to a system file - do nothing
+	(void)path;
+#elif defined(__unix__)
+	unlink(path);
+#else
+#error "dispatch_test_release_large_file not implemented on this platform"
+#endif
+}
+
 void
 _dispatch_test_current(const char* file, long line, const char* desc, dispatch_queue_t expected)
 {

--- a/tests/dispatch_test.h
+++ b/tests/dispatch_test.h
@@ -39,6 +39,9 @@ void dispatch_test_start(const char* desc);
 
 bool dispatch_test_check_evfilt_read_for_fd(int fd);
 
+char *dispatch_test_get_large_file(void);
+void dispatch_test_release_large_file(const char *path);
+
 void _dispatch_test_current(const char* file, long line, const char* desc, dispatch_queue_t expected);
 #define dispatch_test_current(a,b) _dispatch_test_current(__SOURCE_FILE__, __LINE__, a, b)
 


### PR DESCRIPTION
Some tests hardcode `/usr/bin/vi` as a path to a file to read from. This is
definitely not going to exist on Android and Windows. Instead of hardcoding this
path in each test, create a `dispatch_test_get_test_file()` function to retrieve
the path. On Linux and Windows, return the path to the test executable, because
this should be significantly more reliable.