### PR TITLE
dispatch: make public interfaces LLP64 friendly

### DIFF
--- a/dispatch/block.h
+++ b/dispatch/block.h
@@ -322,7 +322,7 @@ dispatch_block_perform(dispatch_block_flags_t flags,
  */
 API_AVAILABLE(macos(10.10), ios(8.0))
 DISPATCH_EXPORT DISPATCH_NONNULL1 DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_block_wait(dispatch_block_t block, dispatch_time_t timeout);
 
 /*!
@@ -415,7 +415,7 @@ dispatch_block_cancel(dispatch_block_t block);
 API_AVAILABLE(macos(10.10), ios(8.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_WARN_RESULT DISPATCH_PURE
 DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_block_testcancel(dispatch_block_t block);
 
 __END_DECLS

--- a/dispatch/group.h
+++ b/dispatch/group.h
@@ -160,7 +160,7 @@ dispatch_group_async_f(dispatch_group_t group,
  */
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_group_wait(dispatch_group_t group, dispatch_time_t timeout);
 
 /*!

--- a/dispatch/object.h
+++ b/dispatch/object.h
@@ -402,7 +402,7 @@ dispatch_resume(dispatch_object_t object);
  */
 DISPATCH_UNAVAILABLE
 DISPATCH_EXPORT DISPATCH_NONNULL1 DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_wait(void *object, dispatch_time_t timeout);
 #if __has_extension(c_generic_selections)
 #define dispatch_wait(object, timeout) \
@@ -500,7 +500,7 @@ dispatch_cancel(void *object);
 DISPATCH_UNAVAILABLE
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_WARN_RESULT DISPATCH_PURE
 DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_testcancel(void *object);
 #if __has_extension(c_generic_selections)
 #define dispatch_testcancel(object) \

--- a/dispatch/queue.h
+++ b/dispatch/queue.h
@@ -454,7 +454,7 @@ typedef unsigned int dispatch_qos_class_t;
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_CONST DISPATCH_WARN_RESULT DISPATCH_NOTHROW
 dispatch_queue_t
-dispatch_get_global_queue(long identifier, unsigned long flags);
+dispatch_get_global_queue(intptr_t identifier, uintptr_t flags);
 
 /*!
  * @typedef dispatch_queue_attr_t

--- a/dispatch/semaphore.h
+++ b/dispatch/semaphore.h
@@ -61,7 +61,7 @@ API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_MALLOC DISPATCH_RETURNS_RETAINED DISPATCH_WARN_RESULT
 DISPATCH_NOTHROW
 dispatch_semaphore_t
-dispatch_semaphore_create(long value);
+dispatch_semaphore_create(intptr_t value);
 
 /*!
  * @function dispatch_semaphore_wait
@@ -85,7 +85,7 @@ dispatch_semaphore_create(long value);
  */
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_semaphore_wait(dispatch_semaphore_t dsema, dispatch_time_t timeout);
 
 /*!
@@ -107,7 +107,7 @@ dispatch_semaphore_wait(dispatch_semaphore_t dsema, dispatch_time_t timeout);
  */
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_semaphore_signal(dispatch_semaphore_t dsema);
 
 __END_DECLS

--- a/dispatch/source.h
+++ b/dispatch/source.h
@@ -382,7 +382,7 @@ DISPATCH_NOTHROW
 dispatch_source_t
 dispatch_source_create(dispatch_source_type_t type,
 	uintptr_t handle,
-	unsigned long mask,
+	uintptr_t mask,
 	dispatch_queue_t _Nullable queue);
 
 /*!
@@ -530,7 +530,7 @@ dispatch_source_cancel(dispatch_source_t source);
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_WARN_RESULT DISPATCH_PURE
 DISPATCH_NOTHROW
-long
+intptr_t
 dispatch_source_testcancel(dispatch_source_t source);
 
 /*!
@@ -592,7 +592,7 @@ dispatch_source_get_handle(dispatch_source_t source);
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_WARN_RESULT DISPATCH_PURE
 DISPATCH_NOTHROW
-unsigned long
+uintptr_t
 dispatch_source_get_mask(dispatch_source_t source);
 
 /*!
@@ -630,7 +630,7 @@ dispatch_source_get_mask(dispatch_source_t source);
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_WARN_RESULT DISPATCH_PURE
 DISPATCH_NOTHROW
-unsigned long
+uintptr_t
 dispatch_source_get_data(dispatch_source_t source);
 
 /*!
@@ -652,7 +652,7 @@ dispatch_source_get_data(dispatch_source_t source);
 API_AVAILABLE(macos(10.6), ios(4.0))
 DISPATCH_EXPORT DISPATCH_NONNULL_ALL DISPATCH_NOTHROW
 void
-dispatch_source_merge_data(dispatch_source_t source, unsigned long value);
+dispatch_source_merge_data(dispatch_source_t source, uintptr_t value);
 
 /*!
  * @function dispatch_source_set_timer

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -23,7 +23,7 @@
 DISPATCH_NOINLINE
 static dispatch_unote_t
 _dispatch_unote_create(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask)
+		uintptr_t handle, uintptr_t mask)
 {
 	dispatch_unote_linkage_t dul;
 	dispatch_unote_class_t du;
@@ -60,7 +60,7 @@ _dispatch_unote_create(dispatch_source_type_t dst,
 DISPATCH_NOINLINE
 dispatch_unote_t
 _dispatch_unote_create_with_handle(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask)
+		uintptr_t handle, uintptr_t mask)
 {
 	if (!handle) {
 		return DISPATCH_UNOTE_NULL;
@@ -71,7 +71,7 @@ _dispatch_unote_create_with_handle(dispatch_source_type_t dst,
 DISPATCH_NOINLINE
 dispatch_unote_t
 _dispatch_unote_create_with_fd(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask)
+		uintptr_t handle, uintptr_t mask)
 {
 #if !TARGET_OS_MAC // <rdar://problem/27756657>
 	if (handle > INT_MAX) {
@@ -90,7 +90,7 @@ _dispatch_unote_create_with_fd(dispatch_source_type_t dst,
 DISPATCH_NOINLINE
 dispatch_unote_t
 _dispatch_unote_create_without_handle(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask)
+		uintptr_t handle, uintptr_t mask)
 {
 	if (handle) {
 		return DISPATCH_UNOTE_NULL;
@@ -127,7 +127,7 @@ _dispatch_unote_dispose(dispatch_unote_t du)
 
 static dispatch_unote_t
 _dispatch_source_data_create(dispatch_source_type_t dst, uintptr_t handle,
-		unsigned long mask)
+		uintptr_t mask)
 {
 	if (handle || mask) {
 		return DISPATCH_UNOTE_NULL;
@@ -210,7 +210,7 @@ const dispatch_source_type_s _dispatch_source_type_write = {
 
 static dispatch_unote_t
 _dispatch_source_signal_create(dispatch_source_type_t dst, uintptr_t handle,
-		unsigned long mask)
+		uintptr_t mask)
 {
 	if (handle >= NSIG) {
 		return DISPATCH_UNOTE_NULL;
@@ -261,14 +261,14 @@ struct dispatch_timer_heap_s _dispatch_timers_heap[] =  {
 
 static dispatch_unote_t
 _dispatch_source_timer_create(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask)
+		uintptr_t handle, uintptr_t mask)
 {
 	uint32_t fflags = dst->dst_fflags;
 	dispatch_unote_t du;
 
 	// normalize flags
 	if (mask & DISPATCH_TIMER_STRICT) {
-		mask &= ~(unsigned long)DISPATCH_TIMER_BACKGROUND;
+		mask &= ~(uintptr_t)DISPATCH_TIMER_BACKGROUND;
 	}
 
 	if (fflags & DISPATCH_TIMER_INTERVAL) {

--- a/src/event/event_internal.h
+++ b/src/event/event_internal.h
@@ -241,7 +241,7 @@ typedef struct dispatch_source_type_s {
 #endif
 
 	dispatch_unote_t (*dst_create)(dispatch_source_type_t dst,
-			uintptr_t handle, unsigned long mask);
+			uintptr_t handle, uintptr_t mask);
 #if DISPATCH_EVENT_BACKEND_KEVENT
 	bool (*dst_update_mux)(struct dispatch_muxnote_s *dmn);
 #endif
@@ -406,11 +406,11 @@ extern uint32_t _dispatch_timers_will_wake;
 #endif
 
 dispatch_unote_t _dispatch_unote_create_with_handle(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask);
+		uintptr_t handle, uintptr_t mask);
 dispatch_unote_t _dispatch_unote_create_with_fd(dispatch_source_type_t dst,
-		uintptr_t handle, unsigned long mask);
+		uintptr_t handle, uintptr_t mask);
 dispatch_unote_t _dispatch_unote_create_without_handle(
-		dispatch_source_type_t dst, uintptr_t handle, unsigned long mask);
+		dispatch_source_type_t dst, uintptr_t handle, uintptr_t mask);
 
 bool _dispatch_unote_register(dispatch_unote_t du, dispatch_wlh_t wlh,
 		dispatch_priority_t pri);

--- a/src/queue.c
+++ b/src/queue.c
@@ -511,9 +511,9 @@ struct dispatch_queue_s _dispatch_mgr_q = {
 };
 
 dispatch_queue_t
-dispatch_get_global_queue(long priority, unsigned long flags)
+dispatch_get_global_queue(intptr_t priority, uintptr_t flags)
 {
-	if (flags & ~(unsigned long)DISPATCH_QUEUE_OVERCOMMIT) {
+	if (flags & ~(uintptr_t)DISPATCH_QUEUE_OVERCOMMIT) {
 		return DISPATCH_BAD_INPUT;
 	}
 	dispatch_qos_t qos = _dispatch_qos_from_queue_priority(priority);
@@ -3267,7 +3267,7 @@ dispatch_block_cancel(dispatch_block_t db)
 	(void)os_atomic_or2o(dbpd, dbpd_atomic_flags, DBF_CANCELED, relaxed);
 }
 
-long
+intptr_t
 dispatch_block_testcancel(dispatch_block_t db)
 {
 	dispatch_block_private_data_t dbpd = _dispatch_block_get_data(db);
@@ -3278,7 +3278,7 @@ dispatch_block_testcancel(dispatch_block_t db)
 	return (bool)(dbpd->dbpd_atomic_flags & DBF_CANCELED);
 }
 
-long
+intptr_t
 dispatch_block_wait(dispatch_block_t db, dispatch_time_t timeout)
 {
 	dispatch_block_private_data_t dbpd = _dispatch_block_get_data(db);
@@ -3324,7 +3324,7 @@ dispatch_block_wait(dispatch_block_t db, dispatch_time_t timeout)
 				"run more than once and waited for");
 	}
 
-	long ret = dispatch_group_wait(_dbpd_group(dbpd), timeout);
+	intptr_t ret = dispatch_group_wait(_dbpd_group(dbpd), timeout);
 
 	if (boost_th) {
 		_dispatch_thread_override_end(boost_th, dbpd);

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -21,13 +21,13 @@
 #include "internal.h"
 
 DISPATCH_WEAK // rdar://problem/8503746
-long _dispatch_semaphore_signal_slow(dispatch_semaphore_t dsema);
+intptr_t _dispatch_semaphore_signal_slow(dispatch_semaphore_t dsema);
 
 #pragma mark -
 #pragma mark dispatch_semaphore_class_t
 
 static void
-_dispatch_semaphore_class_init(long value, dispatch_semaphore_class_t dsemau)
+_dispatch_semaphore_class_init(intptr_t value, dispatch_semaphore_class_t dsemau)
 {
 	struct dispatch_semaphore_header_s *dsema = dsemau._dsema_hdr;
 
@@ -41,7 +41,7 @@ _dispatch_semaphore_class_init(long value, dispatch_semaphore_class_t dsemau)
 #pragma mark dispatch_semaphore_t
 
 dispatch_semaphore_t
-dispatch_semaphore_create(long value)
+dispatch_semaphore_create(intptr_t value)
 {
 	dispatch_semaphore_t dsema;
 
@@ -92,7 +92,7 @@ _dispatch_semaphore_debug(dispatch_object_t dou, char *buf, size_t bufsiz)
 }
 
 DISPATCH_NOINLINE
-long
+intptr_t
 _dispatch_semaphore_signal_slow(dispatch_semaphore_t dsema)
 {
 	_dispatch_sema4_create(&dsema->dsema_sema, _DSEMA4_POLICY_FIFO);
@@ -100,7 +100,7 @@ _dispatch_semaphore_signal_slow(dispatch_semaphore_t dsema)
 	return 1;
 }
 
-long
+intptr_t
 dispatch_semaphore_signal(dispatch_semaphore_t dsema)
 {
 	long value = os_atomic_inc2o(dsema, dsema_value, release);
@@ -115,7 +115,7 @@ dispatch_semaphore_signal(dispatch_semaphore_t dsema)
 }
 
 DISPATCH_NOINLINE
-static long
+static intptr_t
 _dispatch_semaphore_wait_slow(dispatch_semaphore_t dsema,
 		dispatch_time_t timeout)
 {
@@ -146,7 +146,7 @@ _dispatch_semaphore_wait_slow(dispatch_semaphore_t dsema,
 	return 0;
 }
 
-long
+intptr_t
 dispatch_semaphore_wait(dispatch_semaphore_t dsema, dispatch_time_t timeout)
 {
 	long value = os_atomic_dec2o(dsema, dsema_value, acquire);
@@ -198,7 +198,7 @@ dispatch_group_enter(dispatch_group_t dg)
 }
 
 DISPATCH_NOINLINE
-static long
+static intptr_t
 _dispatch_group_wake(dispatch_group_t dg, bool needs_release)
 {
 	dispatch_continuation_t next, head, tail = NULL;
@@ -277,7 +277,7 @@ _dispatch_group_debug(dispatch_object_t dou, char *buf, size_t bufsiz)
 }
 
 DISPATCH_NOINLINE
-static long
+static intptr_t
 _dispatch_group_wait_slow(dispatch_group_t dg, dispatch_time_t timeout)
 {
 	long value;
@@ -325,7 +325,7 @@ _dispatch_group_wait_slow(dispatch_group_t dg, dispatch_time_t timeout)
 	return 0;
 }
 
-long
+intptr_t
 dispatch_group_wait(dispatch_group_t dg, dispatch_time_t timeout)
 {
 	if (dg->dg_value == 0) {

--- a/src/semaphore_internal.h
+++ b/src/semaphore_internal.h
@@ -31,7 +31,7 @@ struct dispatch_queue_s;
 
 #define DISPATCH_SEMAPHORE_HEADER(cls, ns) \
 	DISPATCH_OBJECT_HEADER(cls); \
-	long volatile ns##_value; \
+	intptr_t volatile ns##_value; \
 	_dispatch_sema4_t ns##_sema
 
 struct dispatch_semaphore_header_s {
@@ -41,7 +41,7 @@ struct dispatch_semaphore_header_s {
 DISPATCH_CLASS_DECL(semaphore);
 struct dispatch_semaphore_s {
 	DISPATCH_SEMAPHORE_HEADER(semaphore, dsema);
-	long dsema_orig;
+	intptr_t dsema_orig;
 };
 
 DISPATCH_CLASS_DECL(group);

--- a/src/shims/priority.h
+++ b/src/shims/priority.h
@@ -142,7 +142,7 @@ _dispatch_qos_to_qos_class(dispatch_qos_t qos)
 
 DISPATCH_ALWAYS_INLINE
 static inline dispatch_qos_t
-_dispatch_qos_from_queue_priority(long priority)
+_dispatch_qos_from_queue_priority(intptr_t priority)
 {
 	switch (priority) {
 	case DISPATCH_QUEUE_PRIORITY_BACKGROUND:      return DISPATCH_QOS_BACKGROUND;

--- a/src/source.c
+++ b/src/source.c
@@ -37,7 +37,7 @@ static inline unsigned long _dispatch_source_timer_data(
 
 dispatch_source_t
 dispatch_source_create(dispatch_source_type_t dst, uintptr_t handle,
-		unsigned long mask, dispatch_queue_t dq)
+		uintptr_t mask, dispatch_queue_t dq)
 {
 	dispatch_source_refs_t dr;
 	dispatch_source_t ds;
@@ -93,13 +93,13 @@ _dispatch_source_xref_dispose(dispatch_source_t ds)
 	dx_wakeup(ds, 0, DISPATCH_WAKEUP_MAKE_DIRTY);
 }
 
-long
+intptr_t
 dispatch_source_testcancel(dispatch_source_t ds)
 {
 	return (bool)(ds->dq_atomic_flags & DSF_CANCELED);
 }
 
-unsigned long
+uintptr_t
 dispatch_source_get_mask(dispatch_source_t ds)
 {
 	dispatch_source_refs_t dr = ds->ds_refs;
@@ -131,7 +131,7 @@ dispatch_source_get_handle(dispatch_source_t ds)
 	return dr->du_ident;
 }
 
-unsigned long
+uintptr_t
 dispatch_source_get_data(dispatch_source_t ds)
 {
 #if DISPATCH_USE_MEMORYSTATUS
@@ -146,7 +146,7 @@ dispatch_source_get_data(dispatch_source_t ds)
 #endif
 #endif // DISPATCH_USE_MEMORYSTATUS
 	uint64_t value = os_atomic_load2o(ds, ds_data, relaxed);
-	return (unsigned long)(
+	return (uintptr_t)(
 		ds->ds_refs->du_data_action == DISPATCH_UNOTE_ACTION_DATA_OR_STATUS_SET
 		? DISPATCH_SOURCE_GET_DATA(value) : value);
 }
@@ -187,7 +187,7 @@ dispatch_source_get_extended_data(dispatch_source_t ds,
 DISPATCH_NOINLINE
 void
 _dispatch_source_merge_data(dispatch_source_t ds, pthread_priority_t pp,
-		unsigned long val)
+		uintptr_t val)
 {
 	dispatch_queue_flags_t dqf = _dispatch_queue_atomic_flags(ds->_as_dq);
 	int filter = ds->ds_refs->du_filter;
@@ -214,7 +214,7 @@ _dispatch_source_merge_data(dispatch_source_t ds, pthread_priority_t pp,
 }
 
 void
-dispatch_source_merge_data(dispatch_source_t ds, unsigned long val)
+dispatch_source_merge_data(dispatch_source_t ds, uintptr_t val)
 {
 	_dispatch_source_merge_data(ds, 0, val);
 }

--- a/src/source_internal.h
+++ b/src/source_internal.h
@@ -115,7 +115,7 @@ size_t _dispatch_source_debug(dispatch_source_t ds, char* buf, size_t bufsiz);
 
 DISPATCH_EXPORT // for firehose server
 void _dispatch_source_merge_data(dispatch_source_t ds, pthread_priority_t pp,
-		unsigned long val);
+		uintptr_t val);
 
 void _dispatch_mgr_queue_push(dispatch_queue_t dq, dispatch_object_t dou,
 		dispatch_qos_t qos);


### PR DESCRIPTION
This attempts to replace the public uses of `unsigned long` with
`uintptr_t` and `long` with `intptr_t`.  The use of `long` and `unsigned
long` here was as a type suitable for matching pointer width.  However,
on LLP64 targets, this does not hold.  Replace them with `intptr_t`
which gives a proper pointer sized type.  This is done only for the
argument types and not for named types to ensure that the ABI is not
modified for C++ (where a template may be specialized on the named
type).