### PR TITLE
build: remove "/usr/include" for swift

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,6 @@ if(ENABLE_SWIFT)
                       -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
                     SWIFT_FLAGS
                       -I ${PROJECT_SOURCE_DIR}
-                      -I/usr/include
                       ${swift_optimization_flags}
                     DEPENDS
                       ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)


### PR DESCRIPTION
Remove the explicit /usr/include search path for the swift library build.  This
allows us to build for Windows as well.