### PR TITLE
WIP/DNM: LLP64 support for SDK Overlay

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -40,14 +40,24 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-		_block =  dispatch_block_create_with_qos_class(dispatch_block_flags_t(UInt(flags.rawValue)),
+#if os(Windows) && arch(x86_64)
+		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
+#else
+		let flags = dispatch_block_flags_t(UInt(flags.rawValue))
+#endif
+		_block =  dispatch_block_create_with_qos_class(flags,
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
 
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
-		_block = _swift_dispatch_block_create_noescape(dispatch_block_flags_t(UInt(flags.rawValue)), noescapeBlock)
+#if os(Windows) && arch(x86_64)
+		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
+#else
+		let flags = dispatch_block_flags_t(UInt(flags.rawValue))
+#endif
+		_block = _swift_dispatch_block_create_noescape(flags, noescapeBlock)
 	}
 
 	public func perform() {


### PR DESCRIPTION
If we cannot break the ABI for C++ users of libdispatch, this would
allow us to build the SDK overlay for LLP64 targets.