### PR TITLE
DispatchStubs: make more Windows friendly

### DIFF
--- a/src/swift/DispatchStubs.cc
+++ b/src/swift/DispatchStubs.cc
@@ -67,7 +67,11 @@ extern "C" void * objc_retainAutoreleasedReturnValue(void *obj);
 // eventually call swift_release to balance the retain below. This is a
 // workaround until the compiler no longer emits this callout on non-ObjC
 // platforms.
-extern "C" void swift_retain(void *);
+extern "C"
+#if defined(_WIN32)
+__declspec(dllimport)
+#endif
+void swift_retain(void *);
 
 DISPATCH_RUNTIME_STDLIB_INTERFACE
 extern "C" void * objc_retainAutoreleasedReturnValue(void *obj) {
@@ -77,5 +81,10 @@ extern "C" void * objc_retainAutoreleasedReturnValue(void *obj) {
     }
     else return NULL;
 }
+
+#if defined(_WIN32)
+extern "C" void *(*__imp_objc_retainAutoreleasedReturnValue)(void *) =
+    &objc_retainAutoreleasedReturnValue;
+#endif
 
 #endif // !USE_OBJC


### PR DESCRIPTION
Provide an alias for the import symbol as the ObjC runtime is normally
in a separate DLL and the compiler will annotate the function as being
DLLImport.  This allows us to resolve the symbols when building the SDK
overlay.