### PR TITLE
build: add an explicit link to BlocksRuntime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,8 @@ if(ENABLE_SWIFT)
                       DispatchStubs
                     LINK_FLAGS
                       -lDispatchStubs
+                      -L $<TARGET_LINKER_FILE_DIR:BlocksRuntime>
+                      -lBlocksRuntime
                       -L $<TARGET_LINKER_FILE_DIR:dispatch>
                       -ldispatch
                     MODULE_NAME


### PR DESCRIPTION
The SDK overlay requires the BlocksRuntime but did not explicitly link
to it.  This works on most platforms, however, Windows requires that all
symbols are fully resolved (effectively `-z defs` on Linux).  Add the
missing dependency.