### PR TITLE
Add string.h for memcpy in Data.swift.

### DIFF
--- a/dispatch/dispatch.h
+++ b/dispatch/dispatch.h
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#include <string.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif


### PR DESCRIPTION
In `Data.swift` the C function `memcpy` is used as part of `_copyBytesHelper`.
The function is declared in `string.h`, but that header is not referenced
directly by any of the headers in `dispatch/` or by `DispatchOverlayShims.h`
in the compiler, which are the only two headers imported by the swift
file.

For some reason, this is working on Darwin and Ubuntu, probably because
some included header includes `string.h` or declares `memcpy`, avoiding the
problem. For those platforms that this already works, adding an extra
include should not affect them.