### PR TITLE
libdispatch: clean up some Win64 warnings

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -709,7 +709,7 @@ _dispatch_logv_init(void *context DISPATCH_UNUSED)
 			char path[MAX_PATH + 1] = {0};
 			DWORD dwLength = GetTempPathA(MAX_PATH, path);
 			dispatch_assert(dwLength <= MAX_PATH + 1);
-			snprintf(&path[dwLength], MAX_PATH - dwLength, "libdispatch.%d.log",
+			snprintf(&path[dwLength], MAX_PATH - dwLength, "libdispatch.%lu.log",
 					GetCurrentProcessId());
 			dispatch_logfile = _open(path, O_WRONLY | O_APPEND | O_CREAT, 0666);
 #else

--- a/src/internal.h
+++ b/src/internal.h
@@ -295,6 +295,7 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 #include <io.h>
 #include <crtdbg.h>
 #endif
+#include <inttypes.h>
 
 #if defined(__GNUC__) || defined(__clang__)
 #define DISPATCH_NOINLINE __attribute__((__noinline__))

--- a/src/io.c
+++ b/src/io.c
@@ -2568,11 +2568,11 @@ static size_t
 _dispatch_io_debug_attr(dispatch_io_t channel, char* buf, size_t bufsiz)
 {
 	dispatch_queue_t target = channel->do_targetq;
-	return dsnprintf(buf, bufsiz, "type = %s, fd = 0x%x, %sfd_entry = %p, "
+	return dsnprintf(buf, bufsiz, "type = %s, fd = 0x%" PRIxPTR ", %sfd_entry = %p, "
 			"queue = %p, target = %s[%p], barrier_queue = %p, barrier_group = "
 			"%p, err = 0x%x, low = 0x%zx, high = 0x%zx, interval%s = %llu ",
 			channel->params.type == DISPATCH_IO_STREAM ? "stream" : "random",
-			channel->fd_actual, channel->atomic_flags & DIO_STOPPED ?
+			(intptr_t)channel->fd_actual, channel->atomic_flags & DIO_STOPPED ?
 			"stopped, " : channel->atomic_flags & DIO_CLOSED ? "closed, " : "",
 			channel->fd_entry, channel->queue, target && target->dq_label ?
 			target->dq_label : "", target, channel->barrier_queue,
@@ -2601,13 +2601,13 @@ _dispatch_operation_debug_attr(dispatch_operation_t op, char* buf,
 {
 	dispatch_queue_t target = op->do_targetq;
 	dispatch_queue_t oqtarget = op->op_q ? op->op_q->do_targetq : NULL;
-	return dsnprintf(buf, bufsiz, "type = %s %s, fd = 0x%x, fd_entry = %p, "
+	return dsnprintf(buf, bufsiz, "type = %s %s, fd = 0x%" PRIxPTR ", fd_entry = %p, "
 			"channel = %p, queue = %p -> %s[%p], target = %s[%p], "
 			"offset = %lld, length = %zu, done = %zu, undelivered = %zu, "
 			"flags = %u, err = 0x%x, low = 0x%zx, high = 0x%zx, "
 			"interval%s = %llu ", op->params.type == DISPATCH_IO_STREAM ?
 			"stream" : "random", op->direction == DOP_DIR_READ ? "read" :
-			"write", op->fd_entry ? op->fd_entry->fd : -1, op->fd_entry,
+			"write", (intptr_t)(op->fd_entry ? op->fd_entry->fd : -1), op->fd_entry,
 			op->channel, op->op_q, oqtarget && oqtarget->dq_label ?
 			oqtarget->dq_label : "", oqtarget, target && target->dq_label ?
 			target->dq_label : "", target, (long long)op->offset, op->length,

--- a/src/queue.c
+++ b/src/queue.c
@@ -6435,7 +6435,9 @@ _dispatch_sig_thread(void *ctxt DISPATCH_UNUSED)
 {
 	// never returns, so burn bridges behind us
 	_dispatch_clear_stack(0);
-#if !defined(_WIN32)
+#if defined(_WIN32)
+	for (;;) SuspendThread(GetCurrentThread());
+#else
 	_dispatch_sigsuspend();
 #endif
 }

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -87,7 +87,7 @@ _dispatch_semaphore_debug(dispatch_object_t dou, char *buf, size_t bufsiz)
 			dsema->dsema_sema);
 #endif
 	offset += dsnprintf(&buf[offset], bufsiz - offset,
-			"value = %ld, orig = %ld }", dsema->dsema_value, dsema->dsema_orig);
+			"value = %" PRId64 ", orig = %" PRId64 " }", dsema->dsema_value, dsema->dsema_orig);
 	return offset;
 }
 
@@ -272,7 +272,7 @@ _dispatch_group_debug(dispatch_object_t dou, char *buf, size_t bufsiz)
 			dg->dg_sema);
 #endif
 	offset += dsnprintf(&buf[offset], bufsiz - offset,
-			"count = %ld, waiters = %d }", dg->dg_value, dg->dg_waiters);
+			"count = %" PRId64 ", waiters = %d }", dg->dg_value, dg->dg_waiters);
 	return offset;
 }
 


### PR DESCRIPTION
This cleans up the few warnings that remain when building libdispatch.
It now builds clean of warnings with clang 8.