### PR TITLE
build: build libdispatch as position independent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,11 @@ add_library(dispatch
               shims/time.h
               shims/tsd.h
               shims/yield.h)
+
+set_target_properties(dispatch
+                      PROPERTIES
+                        POSITION_INDEPENDENT_CODE YES)
+
 if(WIN32)
   target_sources(dispatch
                  PRIVATE


### PR DESCRIPTION
When building libdispatch as a static library ensure that it is built as
a PIC library.  This is implicit when building a shared library.  If the
library is not built shared, we cannot statically link it on Unix
targets.

This partially resolves SR-9384!