### PR TITLE
build: remove unnecessary `find_package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,6 @@ if(ENABLE_SWIFT)
     message(FATAL_ERROR "CMAKE_SWIFT_COMPILER must be defined to enable swift")
   endif()
 
-  find_package(Swift REQUIRED CONFIG)
-
   string(TOLOWER ${CMAKE_SYSTEM_NAME} swift_os)
   get_swift_host_arch(swift_arch)
 


### PR DESCRIPTION
Now that we link using the swift driver, we no longer need to explicitly
add in the path to the swift registrar.  Remove the unncessary
`find_package` to make it easier to build libdispatch.