### PR TITLE
build: add executable suffix for `-fuse-ld=`

### DIFF
--- a/cmake/modules/DispatchUtilities.cmake
+++ b/cmake/modules/DispatchUtilities.cmake
@@ -1,15 +1,19 @@
 
 function(dispatch_set_linker target)
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
+    set(CMAKE_HOST_EXECUTABLE_SUFFIX .exe)
+  endif()
+
   if(USE_GOLD_LINKER)
     set_property(TARGET ${target}
                  APPEND_STRING
                  PROPERTY LINK_FLAGS
-                   -fuse-ld=gold)
+                   -fuse-ld=gold${CMAKE_HOST_EXECUTABLE_SUFFIX})
   endif()
   if(USE_LLD_LINKER)
     set_property(TARGET ${target}
                  APPEND_STRING
                  PROPERTY LINK_FLAGS
-                   -fuse-ld=lld)
+                   -fuse-ld=lld${CMAKE_HOST_EXECUTABLE_SUFFIX})
   endif()
 endfunction()


### PR DESCRIPTION
The `-fuse-ld=` parameter requires the executable suffix for this to work on
Windows.  This allows us to cross-compile for android on Windows.