### PR TITLE
dispatch: fix logging to a file on Windows

### DIFF
--- a/tests/dispatch_debug.c
+++ b/tests/dispatch_debug.c
@@ -31,7 +31,11 @@
 int
 main(void)
 {
+#if defined(_WIN32)
+	_putenv_s("LIBDISPATCH_LOG", "stderr");
+#else
 	setenv("LIBDISPATCH_LOG", "stderr", 1); // rdar://problem/8493990
+#endif
 	dispatch_test_start("Dispatch Debug");
 
 	dispatch_queue_t main_q = dispatch_get_main_queue();


### PR DESCRIPTION
Port the dispatch_debug test to Windows and fix a bug that it found related to
logfile initialization.

_dispatch_logv_init()'s Windows implementation uses _fdopen() and fprintf() to
write the log header. However, this gives ownership of the file to stdio, so
fclose() closes the descriptor and causes future writes to trigger CRT assertion
failures. Avoid this by using snprintf() and _write() instead.