### PR TITLE
Revert "Use numericCast() to get the correct type when creating a dis…

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -40,7 +40,11 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
+#if os(Windows) && (arch(arm64) || arch(x86_64))
+		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
+#else
 		let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
+#endif
 		_block =  dispatch_block_create_with_qos_class(flags,
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
@@ -48,7 +52,11 @@ public class DispatchWorkItem {
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
+#if os(Windows) && (arch(arm64) || arch(x86_64))
+		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
+#else
 		let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
+#endif
 		_block = _swift_dispatch_block_create_noescape(flags, noescapeBlock)
 	}
 


### PR DESCRIPTION
…patch_block_flags_t."

This reverts commit b048490a717e08b27b835750f0f6f631f0e8af0d.

Unfortunately, the numeric cast'ed value cannot be used to construct the
dispatch_flags_t type.  Trying to change to an explicit construction
also fails.  This repairs the Windows build for the time being.