### PR TITLE
Fixed printf format macro for intptr_t arguments.

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -76,7 +76,7 @@ _dispatch_semaphore_debug(dispatch_object_t dou, char *buf, size_t bufsiz)
 			dsema->dsema_sema);
 #endif
 	offset += dsnprintf(&buf[offset], bufsiz - offset,
-			"value = %" PRId64 ", orig = %" PRId64 " }", dsema->dsema_value, dsema->dsema_orig);
+			"value = %ld, orig = %" PRIdPTR " }", dsema->dsema_value, dsema->dsema_orig);
 	return offset;
 }
 


### PR DESCRIPTION
Was using PRId64 instead of PRIdPTR, which would be incorrect when compiling for 32-bit.