### PR TITLE
tests: support the timer source tests on Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,8 +192,10 @@ add_unit_test(dispatch_c99 NO_BSD_OVERLAY SOURCES dispatch_c99.c)
 add_unit_test(dispatch_plusplus SOURCES dispatch_plusplus.cpp)
 
 # test-specific link options
-target_link_libraries(dispatch_group PRIVATE m)
-target_link_libraries(dispatch_timer_short PRIVATE m)
+if(NOT WIN32)
+  target_link_libraries(dispatch_group PRIVATE m)
+  target_link_libraries(dispatch_timer_short PRIVATE m)
+endif()
 
 # test-specific compile options
 set_target_properties(dispatch_c99 PROPERTIES C_STANDARD 99)

--- a/tests/dispatch_drift.c
+++ b/tests/dispatch_drift.c
@@ -22,8 +22,8 @@
 #include <mach/mach_time.h>
 #endif
 #include <dispatch/dispatch.h>
-#include <sys/time.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <sys/time.h>
 #include <unistd.h>
 #endif
 #include <stdio.h>
@@ -46,8 +46,13 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	__block uint32_t count = 0;
 	__block double last_jitter = 0;
 	__block double drift_sum = 0;
+#if defined(_WIN32)
+	// 25 times a second (Windows timer resolution is poor)
+	uint64_t interval = 1000000000 / 25;
+#else
 	// 100 times a second
 	uint64_t interval = 1000000000 / 100;
+#endif
 	double interval_d = interval / 1000000000.0;
 	// for 25 seconds
 	unsigned int target = (unsigned int)(25.0 / interval_d);

--- a/tests/dispatch_timer_bit31.c
+++ b/tests/dispatch_timer_bit31.c
@@ -21,7 +21,9 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/time.h>
+#endif
 
 #include <dispatch/dispatch.h>
 

--- a/tests/dispatch_timer_bit63.c
+++ b/tests/dispatch_timer_bit63.c
@@ -21,7 +21,9 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/time.h>
+#endif
 
 #include <dispatch/dispatch.h>
 

--- a/tests/dispatch_timer_set_time.c
+++ b/tests/dispatch_timer_set_time.c
@@ -18,11 +18,12 @@
  * @APPLE_APACHE_LICENSE_HEADER_END@
  */
 
-#include <sys/time.h>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/time.h>
+#endif
 
 #include <dispatch/dispatch.h>
 

--- a/tests/dispatch_timer_timeout.c
+++ b/tests/dispatch_timer_timeout.c
@@ -21,7 +21,9 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/time.h>
+#endif
 
 #include <dispatch/dispatch.h>
 

--- a/tests/generic_win_port.h
+++ b/tests/generic_win_port.h
@@ -12,6 +12,14 @@ typedef long long ssize_t;
 typedef long ssize_t;
 #endif
 
+struct mach_timebase_info {
+	uint32_t numer;
+	uint32_t denom;
+};
+
+typedef struct mach_timebase_info *mach_timebase_info_t;
+typedef struct mach_timebase_info mach_timebase_info_data_t;
+
 static inline int32_t
 OSAtomicIncrement32(volatile int32_t *var)
 {
@@ -44,6 +52,18 @@ getpid(void);
 
 int
 gettimeofday(struct timeval *tp, void *tzp);
+
+uint64_t
+mach_absolute_time(void);
+
+static inline
+int
+mach_timebase_info(mach_timebase_info_t tbi)
+{
+	tbi->numer = 1;
+	tbi->denom = 1;
+	return 0;
+}
 
 void
 print_winapi_error(const char *function_name, DWORD error);


### PR DESCRIPTION
PR #453 provides an initial implementation for timer support on Windows. Support
building and running the `DISPATCH_SOURCE_TYPE_TIMER` tests so we can easily
verify that timers work correctly.

These tests should pass on Windows with this and #453 applied:

- dispatch_drift
- dispatch_suspend_timer
- dispatch_timer
- dispatch_timer_bit31
- dispatch_timer_bit63
- dispatch_timer_set_time
- dispatch_timer_short
- dispatch_timer_timeout