### PR TITLE
Optimize Windows contention performance

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -283,9 +283,6 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#if defined(_WIN32)
-#define _CRT_RAND_S
-#endif
 #include <stdlib.h>
 #include <string.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))


### PR DESCRIPTION
The dispatch_cascade test is very slow on Windows right now (often taking 4-5
minutes to execute on my machine and sometimes locking it up entirely) because
contention is not being handled correctly.

`_dispatch_contention_usleep()` is expected to put the thread to sleep, but on
Windows it spins on `QueryPerformanceCounter()`. This is causing a huge amount
of starvation in the dispatch_cascade test. Implement it using `Sleep()`, and
accordingly adjust `DISPATCH_CONTENTION_USLEEP_START` to be 1ms on Windows.

Additionally, `_dispatch_contention_spins()` is currently implemented using the
`rand_s()` function. This is slow (and experimentally seems to be slower than
not randomizing the spin count at all!) because `rand_s()` guarantees
cryptographic security, which is unnecessary for dispatch's use case. Replace it
with a basic linear congruential generator (from K&R) since there isn't any
other `rand_r()` equivalent. Based on the average wall clock times reported by
bsdtestharness, this is around 35% faster on my PC (i7-8700K).

These changes bring the runtime of the dispatch_cascade test down to around 1-2s
at most for me. (It's even faster than this if stdout isn't a console window
because that slows down the histogram display.)