### PR TITLE
Fixed conflicting method signature for _dispatch_install_thread_detach_callback()

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -7303,7 +7303,7 @@ gettid(void)
 static void (*_dispatch_thread_detach_callback)(void);
 
 void
-_dispatch_install_thread_detach_callback(dispatch_function_t cb)
+_dispatch_install_thread_detach_callback(void (*cb)(void))
 {
 	if (os_atomic_xchg(&_dispatch_thread_detach_callback, cb, relaxed)) {
 		DISPATCH_CLIENT_CRASH(0, "Installing a thread detach callback twice");


### PR DESCRIPTION
This fixes various "conflicting types for XXX" errors I get when building the project for Android after the recent libdispatch-1121 merge. The changes are not Android-specific though and probably result in warnings or errors on other platforms (depending on -Werror).