### PR TITLE
Added missing queue macros for building on Android

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -269,12 +269,12 @@ upcast(dispatch_object_t dou)
 #if defined(_WIN32)
 #include <time.h>
 #else
-#include <sys/queue.h>
 #include <sys/mount.h>
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
 #include <sys/sysctl.h>
+#include <sys/queue.h>
 #endif /* __ANDROID__ */
 #include <sys/socket.h>
 #include <sys/time.h>

--- a/src/shims.h
+++ b/src/shims.h
@@ -31,8 +31,11 @@
 #include <pthread.h>
 #else // defined(_WIN32)
 #include "shims/generic_win_stubs.h"
-#include "shims/generic_sys_queue.h"
 #endif // defined(_WIN32)
+
+#if defined(_WIN32) || defined(__ANDROID__)
+#include "shims/generic_sys_queue.h"
+#endif
 
 #ifdef __ANDROID__
 #include "shims/android_stubs.h"

--- a/src/shims/generic_sys_queue.h
+++ b/src/shims/generic_sys_queue.h
@@ -110,12 +110,23 @@
 		struct type *le_prev; \
 	}
 
+#define	LIST_EMPTY(head) ((head)->lh_first == NULL)
+
 #define LIST_FIRST(head) ((head)->lh_first)
 
 #define LIST_FOREACH(var, head, field) \
 	for ((var) = LIST_FIRST((head)); \
 		(var); \
 		(var) = LIST_NEXT((var), field))
+
+#define	LIST_FOREACH_SAFE(var, head, field, tvar) \
+	for ((var) = LIST_FIRST((head)); \
+		(var) && ((tvar) = LIST_NEXT((var), field), 1); \
+		(var) = (tvar))
+
+#define	LIST_INIT(head) do { \
+	LIST_FIRST((head)) = NULL; \
+} while (0)
 
 #define LIST_NEXT(elm, field) ((elm)->field.le_next)
 


### PR DESCRIPTION
TAILQ_CONCAT() and LIST_FOREACH_SAFE() are not defined in [queue.h](https://android.googlesource.com/platform/development/+/73a5a3b/ndk/platforms/android-20/include/sys/queue.h) in the Android NDK.

I simply added the macros to internal.h, but please let me know if you’d prefer another place to add them.