### PR TITLE
Added missing private headers to cmake install.

### DIFF
--- a/private/CMakeLists.txt
+++ b/private/CMakeLists.txt
@@ -14,6 +14,8 @@ if (INSTALL_PRIVATE_HEADERS)
             private.h
             queue_private.h
             source_private.h
+            time_private.h
+            workloop_private.h
           DESTINATION
             "${INSTALL_DISPATCH_HEADERS_DIR}")
 endif()


### PR DESCRIPTION
These are included by private.h and should be installed alongside.