### PR TITLE
Added underscores to gettid(void) to remove name clash

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -7300,21 +7300,21 @@ libdispatch_init(void)
 #ifdef SYS_gettid
 DISPATCH_ALWAYS_INLINE
 static inline pid_t
-__gettid(void)
+_gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
 #elif defined(__FreeBSD__)
 DISPATCH_ALWAYS_INLINE
 static inline pid_t
-__gettid(void)
+_gettid(void)
 {
 	return (pid_t)pthread_getthreadid_np();
 }
 #elif defined(_WIN32)
 DISPATCH_ALWAYS_INLINE
 static inline DWORD
-__gettid(void)
+_gettid(void)
 {
 	return GetCurrentThreadId();
 }
@@ -7429,7 +7429,7 @@ libdispatch_tsd_init(void)
 #else
 	FlsSetValue(__dispatch_tsd_key, &__dispatch_tsd);
 #endif // defined(_WIN32)
-	__dispatch_tsd.tid = __gettid();
+	__dispatch_tsd.tid = _gettid();
 }
 #endif
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -7272,21 +7272,21 @@ libdispatch_init(void)
 #ifdef SYS_gettid
 DISPATCH_ALWAYS_INLINE
 static inline pid_t
-gettid(void)
+__gettid(void)
 {
 	return (pid_t)syscall(SYS_gettid);
 }
 #elif defined(__FreeBSD__)
 DISPATCH_ALWAYS_INLINE
 static inline pid_t
-gettid(void)
+__gettid(void)
 {
 	return (pid_t)pthread_getthreadid_np();
 }
 #elif defined(_WIN32)
 DISPATCH_ALWAYS_INLINE
 static inline DWORD
-gettid(void)
+__gettid(void)
 {
 	return GetCurrentThreadId();
 }
@@ -7401,7 +7401,7 @@ libdispatch_tsd_init(void)
 #else
 	FlsSetValue(__dispatch_tsd_key, &__dispatch_tsd);
 #endif // defined(_WIN32)
-	__dispatch_tsd.tid = gettid();
+	__dispatch_tsd.tid = __gettid();
 }
 #endif
 


### PR DESCRIPTION
with system-provided gettid() in /usr/include/bits/unistd_ext.h that is not static. 

According to https://raw.githubusercontent.com/bminor/glibc/master/ChangeLog, Florian Weimer moved `units_ext.h` from `sysdeps/generic/bits` to `bits` and libdispatch won't compile due to the function having different declarations between the system-provided one and the one defined in `queue.c`. 

I figure that, since it's only being called in one spot in the same file, it was safe to rename the function in without having to make a special #ifdef Linux-only version.