### PR TITLE
Fix printf format macro for `dsema_value`

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -76,7 +76,7 @@ _dispatch_semaphore_debug(dispatch_object_t dou, char *buf, size_t bufsiz)
 			dsema->dsema_sema);
 #endif
 	offset += dsnprintf(&buf[offset], bufsiz - offset,
-			"value = %ld, orig = %" PRIdPTR " }", dsema->dsema_value, dsema->dsema_orig);
+			"value = %" PRIdPTR ", orig = %" PRIdPTR " }", dsema->dsema_value, dsema->dsema_orig);
 	return offset;
 }
 


### PR DESCRIPTION
This is a follow-up patch to #448 after the `dsema_value` field [was changed to `intptr_t`](https://github.com/apple/swift-corelibs-libdispatch/commit/55195b7a16e958c76824f1e6331345278918fc5b#diff-953320a7e70207807bfd163d535dae70) with the latest updates.