### PR TITLE
CMake: Correctly detect MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(dispatch
         LANGUAGES C CXX)
 enable_testing()
 
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if(MSVC)
   include(ClangClCompileRules)
 endif()
 

--- a/cmake/modules/DispatchCompilerWarnings.cmake
+++ b/cmake/modules/DispatchCompilerWarnings.cmake
@@ -1,5 +1,5 @@
 
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if(MSVC)
   # TODO: someone needs to provide the msvc equivalent warning flags
   macro(dispatch_common_warnings)
   endmacro()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,7 +179,7 @@ if(WIN32)
                              PRIVATE
                                _CRT_NONSTDC_NO_WARNINGS)
 endif()
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if(MSVC)
   target_compile_options(dispatch PRIVATE /EHs-c-)
 else()
   target_compile_options(dispatch PRIVATE -fno-exceptions)
@@ -203,7 +203,7 @@ if(BSD_OVERLAY_FOUND)
                          PRIVATE
                            ${BSD_OVERLAY_CFLAGS})
 endif()
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if(MSVC)
   target_compile_options(dispatch
                          PRIVATE
                            /W3)
@@ -213,7 +213,7 @@ else()
                            -Wall)
 endif()
 # FIXME(compnerd) add check for -fblocks?
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if(MSVC)
   target_compile_options(dispatch
                          PRIVATE
                            -Xclang -fblocks)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,7 +98,7 @@ function(add_unit_test name)
                            PRIVATE
                              ${BSD_OVERLAY_CFLAGS})
   endif()
-  if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+  if(MSVC)
     target_compile_options(${name} PRIVATE -Xclang -fblocks)
     target_compile_options(${name} PRIVATE /W3 -Wno-deprecated-declarations)
   else()


### PR DESCRIPTION
CMake: Correctly detect MSVC, or other compilers in MSVC compatibility modes (e.g. clang-cl, or clang -fms-compatibility).

~~According to CMake [documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_SIMULATE_ID.html), when CMake detects a compiler is simulated, it will set the `CMAKE_<LANG>_SIMULATE_ID` variable. However it appears this isn't happening, and both MSVC and clang-cl fail to identify as MSVC during project generation.~~

`CMAKE_<LANG>_SIMULATE_ID` != `MSVC` when generating for Visual Studio. The CMake variable [MSVC](https://cmake.org/cmake/help/latest/variable/MSVC.html) is set when a compiler is simulating MSVC (by defining `_MSC_VER`).