### PR TITLE
Use SYS_gettid on Android

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -7296,7 +7296,6 @@ libdispatch_init(void)
 #include <sys/syscall.h>
 #endif
 
-#ifndef __ANDROID__
 #ifdef SYS_gettid
 DISPATCH_ALWAYS_INLINE
 static inline pid_t
@@ -7321,7 +7320,6 @@ _gettid(void)
 #else
 #error "SYS_gettid unavailable on this system"
 #endif /* SYS_gettid */
-#endif /* ! __ANDROID__ */
 
 #define _tsd_call_cleanup(k, f)  do { \
 		if ((f) && tsd->k) ((void(*)(void*))(f))(tsd->k); \


### PR DESCRIPTION
The system-provided gettid() was previously used on Android, which broke with the recent symbol change to _gettid() (#461).

Since SYS_gettid is available in recent NDKs (at least since version 21) we can now use that instead and remove the special-casing.