### PR TITLE
event: create a typedef for the unote ident type

### DIFF
--- a/src/event/event.c
+++ b/src/event/event.c
@@ -51,7 +51,7 @@ _dispatch_unote_create(dispatch_source_type_t dst,
 	}
 	du->du_type = dst;
 	du->du_can_be_wlh = dst->dst_per_trigger_qos;
-	du->du_ident = (uint32_t)handle;
+	du->du_ident = (dispatch_unote_ident_t)handle;
 	du->du_filter = dst->dst_filter;
 	du->du_fflags = (__typeof__(du->du_fflags))mask;
 	if (dst->dst_flags & EV_UDATA_SPECIFIC) {

--- a/src/event/event_internal.h
+++ b/src/event/event_internal.h
@@ -123,11 +123,17 @@ _dispatch_timer_flags_from_clock(dispatch_clock_t clock)
 	return (dispatch_unote_timer_flags_t)(clock << 2);
 }
 
+#if defined(_WIN32)
+typedef uintptr_t dispatch_unote_ident_t;
+#else
+typedef uint32_t dispatch_unote_ident_t;
+#endif
+
 #define DISPATCH_UNOTE_CLASS_HEADER() \
 	dispatch_source_type_t du_type; \
 	uintptr_t du_owner_wref; /* "weak" back reference to the owner object */ \
 	os_atomic(dispatch_unote_state_t) du_state; \
-	uint32_t  du_ident; \
+	dispatch_unote_ident_t du_ident; \
 	int8_t    du_filter; \
 	uint8_t   du_is_direct : 1; \
 	uint8_t   du_is_timer : 1; \


### PR DESCRIPTION
File handles and sockets on Windows are pointer sized.  Ensure that we
have enough space in the unote to track the source properly.