### PR TITLE
Port most remaining tests to Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,7 +196,9 @@ add_unit_test(dispatch_c99 NO_BSD_OVERLAY SOURCES dispatch_c99.c)
 add_unit_test(dispatch_plusplus SOURCES dispatch_plusplus.cpp)
 
 # test-specific link options
-if(NOT WIN32)
+if(WIN32)
+  target_link_libraries(dispatch_io_net PRIVATE WS2_32)
+else()
   target_link_libraries(dispatch_group PRIVATE m)
   target_link_libraries(dispatch_timer_short PRIVATE m)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,8 @@ if (WIN32)
   target_compile_definitions(bsdtests
                              PUBLIC
                                _CRT_NONSTDC_NO_WARNINGS
-                               _CRT_SECURE_NO_WARNINGS)
+                               _CRT_SECURE_NO_WARNINGS
+                               _USE_MATH_DEFINES)
 endif ()
 
 add_executable(bsdtestharness

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,8 +169,11 @@ if(EXTENDED_TEST_SUITE)
        pingpong
        drift
        readsync
-       cascade
-       io)
+       cascade)
+  if(NOT WIN32)
+    # Not ported to Windows yet
+    list(APPEND DISPATCH_C_TESTS io)
+  endif()
   # an oddball; dispatch_priority.c compiled with -DUSE_SET_TARGET_QUEUE=1
   add_unit_test(dispatch_priority2 SOURCES dispatch_priority.c)
   target_compile_options(dispatch_priority2 PRIVATE -DUSE_SET_TARGET_QUEUE=1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,9 @@ if (WIN32)
                                _CRT_NONSTDC_NO_WARNINGS
                                _CRT_SECURE_NO_WARNINGS
                                _USE_MATH_DEFINES)
+  target_link_libraries(bsdtests
+                        PUBLIC
+                          bcrypt)
 endif ()
 
 add_executable(bsdtestharness

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -22,6 +22,11 @@
 #include <stdio.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
+#include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 #endif
 #include <stdlib.h>
 #include <assert.h>
@@ -29,11 +34,6 @@
 #include <libkern/OSAtomic.h>
 #endif
 #include <sys/types.h>
-#ifdef __ANDROID__
-#include <linux/sysctl.h>
-#else
-#include <sys/sysctl.h>
-#endif /* __ANDROID__ */
 
 #include <bsdtests.h>
 #include "dispatch_test.h"
@@ -80,6 +80,10 @@ static void test_apply_contended(dispatch_queue_t dq)
 	uint32_t activecpu;
 #ifdef __linux__
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+#elif defined(_WIN32)
+	SYSTEM_INFO si;
+	GetSystemInfo(&si);
+	activecpu = si.dwNumberOfProcessors;
 #else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -20,17 +20,17 @@
 
 #include <dispatch/dispatch.h>
 #include <dispatch/private.h>
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
-#include <unistd.h>
-#endif
 #include <stdlib.h>
 #include <stdio.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/types.h>
+#include <unistd.h>
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
 #include <sys/sysctl.h>
 #endif /* __ANDROID__ */
+#endif
 
 #include <bsdtests.h>
 #include "dispatch_test.h"
@@ -234,6 +234,10 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 
 #ifdef __linux__
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+#elif defined(_WIN32)
+	SYSTEM_INFO si;
+	GetSystemInfo(&si);
+	activecpu = si.dwNumberOfProcessors;
 #else
 	size_t s = sizeof(activecpu);
 	sysctlbyname("hw.activecpu", &activecpu, &s, NULL, 0);

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -23,6 +23,11 @@
 #include <dispatch/private.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#ifdef __ANDROID__
+#include <linux/sysctl.h>
+#else
+#include <sys/sysctl.h>
+#endif /* __ANDROID__ */
 #endif
 #include <stdlib.h>
 #include <assert.h>
@@ -30,11 +35,6 @@
 #include <TargetConditionals.h>
 #endif
 #include <sys/types.h>
-#ifdef __ANDROID__
-#include <linux/sysctl.h>
-#else
-#include <sys/sysctl.h>
-#endif /* __ANDROID__ */
 
 #include <bsdtests.h>
 #include "dispatch_test.h"
@@ -85,6 +85,10 @@ n_blocks(void)
 	dispatch_once(&pred, ^{
 #ifdef __linux__
 		n = (int)sysconf(_SC_NPROCESSORS_CONF);
+#elif defined(_WIN32)
+		SYSTEM_INFO si;
+		GetSystemInfo(&si);
+		n = (int)si.dwNumberOfProcessors;
 #else
 		size_t l = sizeof(n);
 		int rc = sysctlbyname("hw.ncpu", &n, &l, NULL, 0);

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -23,12 +23,12 @@
 #include <stdlib.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
-#endif
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
 #include <sys/sysctl.h>
 #endif /* __ANDROID__ */
+#endif
 #include <assert.h>
 
 #include <bsdtests.h>
@@ -142,6 +142,11 @@ main(void)
 #ifdef __linux__
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 	// don't want to parse /proc/sys/kernel/threads-max
+	wq_max_threads = activecpu * NTHREADS + 2;
+#elif defined(_WIN32)
+	SYSTEM_INFO si;
+	GetSystemInfo(&si);
+	activecpu = si.dwNumberOfProcessors;
 	wq_max_threads = activecpu * NTHREADS + 2;
 #else
 	size_t s = sizeof(uint32_t);

--- a/tests/dispatch_test.h
+++ b/tests/dispatch_test.h
@@ -40,7 +40,7 @@ extern "C" {
 
 void dispatch_test_start(const char* desc);
 
-bool dispatch_test_check_evfilt_read_for_fd(int fd);
+bool dispatch_test_check_evfilt_read_for_fd(dispatch_fd_t fd);
 
 char *dispatch_test_get_large_file(void);
 void dispatch_test_release_large_file(const char *path);
@@ -52,6 +52,13 @@ void _dispatch_test_current(const char* file, long line, const char* desc, dispa
 int sysctlbyname(const char *name, void *oldp, size_t *oldlenp, void *newp,
 		size_t *newpl);
 #endif
+
+dispatch_fd_t dispatch_test_fd_open(const char *path, int flags);
+int dispatch_test_fd_close(dispatch_fd_t fd);
+off_t dispatch_test_fd_lseek(dispatch_fd_t fd, off_t offset, int whence);
+ssize_t dispatch_test_fd_pread(dispatch_fd_t fd, void *buf, size_t count, off_t offset);
+ssize_t dispatch_test_fd_read(dispatch_fd_t fd, void *buf, size_t count);
+ssize_t dispatch_test_fd_write(dispatch_fd_t fd, const void *buf, size_t count);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/tests/generic_win_port.c
+++ b/tests/generic_win_port.c
@@ -1,5 +1,6 @@
 #define _CRT_RAND_S
 #include <generic_win_port.h>
+#include <dispatch_test.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -219,6 +220,42 @@ mach_absolute_time(void)
 	ULONGLONG result = 0;
 	QueryUnbiasedInterruptTimePrecisePtr(&result);
 	return result * 100;  // Convert from 100ns units
+}
+
+static void
+randomize_name(char *out)
+{
+	static const char chars[] =
+			"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._-";
+	const size_t num_chars = sizeof(chars) - 1;
+	unsigned int lo, hi;
+	rand_s(&lo);
+	rand_s(&hi);
+	uint64_t val = ((uint64_t)hi << 32) | lo;
+	for (int j = 0; j < 6; j++) {
+		out[j] = chars[val % num_chars];
+		val /= num_chars;
+	}
+}
+
+dispatch_fd_t
+mkstemp(char *tmpl)
+{
+	size_t len = strlen(tmpl);
+	if (len < 6) {
+		errno = EINVAL;
+		return -1;
+	}
+	char *replace = &tmpl[len - 6];
+	for (int i = 0; i < 100; i++) {
+		randomize_name(replace);
+		dispatch_fd_t fd = dispatch_test_fd_open(tmpl, O_RDWR | O_CREAT | O_EXCL);
+		if (fd != -1) {
+			return fd;
+		}
+	}
+	errno = EEXIST;
+	return -1;
 }
 
 void

--- a/tests/generic_win_port.c
+++ b/tests/generic_win_port.c
@@ -1,3 +1,4 @@
+#define _CRT_RAND_S
 #include <generic_win_port.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -234,6 +235,14 @@ print_winapi_error(const char *function_name, DWORD error)
 	} else {
 		fprintf(stderr, "%s: error %lu\n", function_name, error);
 	}
+}
+
+intptr_t
+random(void)
+{
+	unsigned int x;
+	rand_s(&x);
+	return x & INT_MAX;
 }
 
 unsigned int

--- a/tests/generic_win_port.h
+++ b/tests/generic_win_port.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <dispatch/dispatch.h>
+#include <fcntl.h>
 #include <stdint.h>
+#include <sys/types.h>
 #include <Windows.h>
 
 typedef int kern_return_t;
@@ -65,8 +68,14 @@ mach_timebase_info(mach_timebase_info_t tbi)
 	return 0;
 }
 
+dispatch_fd_t
+mkstemp(char *tmpl);
+
 void
 print_winapi_error(const char *function_name, DWORD error);
+
+intptr_t
+random(void);
 
 unsigned int
 sleep(unsigned int seconds);


### PR DESCRIPTION
This patch set provides Windows support for most of the remaining test suite. Many of the tests do not pass yet, and I do not expect the test ports themselves to be perfect, but being able to easily build and run everything should be a big step towards fixing all of the remaining issues with the Windows port of Dispatch. In particular, @compnerd and I have been working on implementing socket and file event sources, and we need to be able to easily test everything.

The only test that still needs to be ported is dispatch_io, which may take some time to do since it uses <fts.h>. For now, that test is disabled on Windows just so that it's easy to build everything without ignoring errors. (It won't pass anyway until we have more event sources implemented.)

Most of the complexity here is related to file I/O, because Dispatch will use `HANDLE`s for event sources. In order to cut down on the amount of platform-specific code in tests, and to make these changes easy to inspect, I introduced wrapper functions around the `dispatch_fd_t` type. On Windows, these functions will use Win32 APIs and work with `HANDLE`s, and on other platforms they will forward to the corresponding system calls. I also replaced usages of `fstat()` (for getting file sizes) with calls to `dispatch_test_fd_lseek()` so that we don't need an `fstat()` equivalent on Windows.

While msvcrt already provides POSIX-like I/O functions, they work with virtual file descriptors instead of handles, and these custom implementations let us manage temporary files correctly. (msvcrt does not open files with `FILE_SHARE_DELETE`!)