### PR TITLE
build: install swiftDispatch.dll to bin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -270,19 +270,24 @@ if(ENABLE_SWIFT)
   else()
     set(library_kind STATIC)
   endif()
+
   set(swiftDispatch_OUTPUT_FILE
       ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_${library_kind}_LIBRARY_PREFIX}swiftDispatch${CMAKE_${library_kind}_LIBRARY_SUFFIX})
-  install(FILES
-            ${swiftDispatch_OUTPUT_FILE}
-          DESTINATION
-            ${INSTALL_TARGET_DIR})
-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    if(BUILD_SHARED_LIBS)
-      install(FILES
-                ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}swiftDispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
-              DESTINATION
-                ${INSTALL_TARGET_DIR})
-    endif()
+
+  if(CMAKE_SYSTEM_NAME STREQUAL Windows AND BUILD_SHARED_LIBS)
+    install(FILES
+              ${swiftDispatch_OUTPUT_FILE}
+            DESTINATION
+              bin)
+    install(FILES
+              ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}swiftDispatch${CMAKE_IMPORT_LIBRARY_SUFFIX}
+            DESTINATION
+              ${INSTALL_TARGET_DIR})
+  else()
+    install(FILES
+              ${swiftDispatch_OUTPUT_FILE}
+            DESTINATION
+              ${INSTALL_TARGET_DIR})
   endif()
 endif()
 


### PR DESCRIPTION
The DLLs are runtime components.  The Windows target installs the
runtime components into the bin directory, and the import libraries into
the lib directory.  This enables the runtime setup to be simplified on
Windows.