### PR TITLE
shims: correct list macros

### DIFF
--- a/src/shims/generic_sys_queue.h
+++ b/src/shims/generic_sys_queue.h
@@ -107,7 +107,7 @@
 
 #define LIST_ENTRY(type) struct { \
 		struct type *le_next; \
-		struct type *le_prev; \
+		struct type **le_prev; \
 	}
 
 #define	LIST_EMPTY(head) ((head)->lh_first == NULL)
@@ -133,13 +133,14 @@
 #define LIST_REMOVE(elm, field) do { \
 		if (LIST_NEXT((elm), field) != NULL) \
 			LIST_NEXT((elm), field)->field.le_prev = (elm)->field.le_prev; \
+		*(elm)->field.le_prev = LIST_NEXT((elm), field); \
 	} while (0)
 
 #define LIST_INSERT_HEAD(head, elm, field) do { \
 		if ((LIST_NEXT((elm), field) = LIST_FIRST((head))) != NULL) \
-			LIST_FIRST((head))->field.le_prev = LIST_NEXT((elm), field); \
+			LIST_FIRST((head))->field.le_prev = &LIST_NEXT((elm), field); \
 		LIST_FIRST((head)) = (elm); \
-		(elm)->field.le_prev = LIST_FIRST((head)); \
+		(elm)->field.le_prev = &LIST_FIRST((head)); \
 	} while (0)
 
 #endif // __DISPATCH_SHIMS_SYS_QUEUE__


### PR DESCRIPTION
This adjusts the `LIST_ENTRY` to define the structure correctly.  This
allows for the `LIST_REMOVE` and `LIST_INSERT_HEAD` macros to be defined
properly and set the fields previous pointers as well when updating the
list.  This is needed to enable the use of the macros for list
manipulations.  Found while implementing file sources for Windows.