### PR TITLE
[SR-10559] libdispatch fails to build with _FORTIFY_SOURCE=2

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -1046,14 +1046,14 @@ _dispatch_ktrace_impl(uint32_t code, uint64_t a, uint64_t b,
 		dispatch_assert(_length != -1); \
 		_msg = (char *)malloc((unsigned)_length + 1); \
 		dispatch_assert(_msg); \
-		snprintf(_msg, (unsigned)_length + 1, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, ##__VA_ARGS__); \
+		(void)snprintf(_msg, (unsigned)_length + 1, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, ##__VA_ARGS__); \
 		_dispatch_assert_crash(_msg); \
 		free(_msg); \
 	} while (0)
 #else
 #define _dispatch_client_assert_fail(fmt, ...)  do { \
 		char *_msg = NULL; \
-		asprintf(&_msg, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, \
+		(void)asprintf(&_msg, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, \
 				##__VA_ARGS__); \
 		_dispatch_assert_crash(_msg); \
 		free(_msg); \


### PR DESCRIPTION
The [Nix Packages collection](https://nixos.org/) on Linux routinely builds with the fortify option (`-D_FORTIFY_SOURCE=2`). Currently, libdispatch fails to build with the following error:

```
/home/michael/swift/src/swift-corelibs-libdispatch/src/queue.c:47:2: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
        _dispatch_client_assert_fail(
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/michael/swift/src/swift-corelibs-libdispatch/src/internal.h:1056:3: note: expanded from macro '_dispatch_client_assert_fail'
                asprintf(&_msg, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, \
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/sr4253np2gz2bpha4gn8gqlmiw604155-glibc-2.27-dev/include/bits/stdio2.h:199:3: note: expanded from macro 'asprintf'
  __asprintf_chk (ptr, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
  ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/michael/swift/src/swift-corelibs-libdispatch/src/queue.c:56:2: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
        _dispatch_client_assert_fail(
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/michael/swift/src/swift-corelibs-libdispatch/src/internal.h:1056:3: note: expanded from macro '_dispatch_client_assert_fail'
                asprintf(&_msg, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, \
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/sr4253np2gz2bpha4gn8gqlmiw604155-glibc-2.27-dev/include/bits/stdio2.h:199:3: note: expanded from macro 'asprintf'
  __asprintf_chk (ptr, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
  ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

Filed as [Swift bug SR-10559](https://bugs.swift.org/browse/SR-10559).