### PR TITLE
shims: correct `TAILQ_CONCAT`

### DIFF
--- a/src/shims/generic_sys_queue.h
+++ b/src/shims/generic_sys_queue.h
@@ -95,7 +95,7 @@
 #define TAILQ_CONCAT(head1, head2, field) do { \
 		if (!TAILQ_EMPTY(head2)) { \
 			(head1)->tq_last = (head2)->tq_first; \
-			(head1)->tq_first->field.te_prev = (head1)->tq_last; \
+			(head2)->tq_first->field.te_prev = (head1)->tq_last; \
 			(head1)->tq_last = (head2)->tq_last; \
 			TAILQ_INIT((head2)); \
 		} \


### PR DESCRIPTION
This fixes libdispatch on Windows where we use the shims rather than a
system provided `sys/queue.h` as that is a BSD extension.