### PR TITLE
build: ensure that we link against the correct library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,9 @@ if(ENABLE_SWIFT)
                     CFLAGS
                       -fblocks
                       -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
+                      $<$<PLATFORM_ID:Windows>:-D_MT>
+                      # TODO(compnerd) handle /MT builds
+                      $<$<PLATFORM_ID:Windows>:-D_DLL>
                     DEPENDS
                       module-maps
                       DispatchStubs
@@ -134,6 +137,8 @@ if(ENABLE_SWIFT)
                       -lBlocksRuntime
                       -L $<TARGET_LINKER_FILE_DIR:dispatch>
                       -ldispatch
+                      $<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:-lmsvcrtd>
+                      $<$<AND:$<PLATFORM_ID:Windows>,$<NOT:$<CONFIG:Debug>>>:-lmsvcrt>
                     MODULE_NAME
                       Dispatch
                     MODULE_LINK_NAME


### PR DESCRIPTION
Ensure that we link against the correct VC runtime libraries.
Additionally, enable the macros to indicate that we are linking against
the VC runtimes dynamically to get proper DLL storage.  This fixes
memory issues and file descriptor table synchrony.