### PR TITLE
When adding conditionally included compiler flags, dont use the CFLAGS section

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,9 +124,6 @@ if(ENABLE_SWIFT)
                     CFLAGS
                       -fblocks
                       -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
-                      $<$<PLATFORM_ID:Windows>:-D_MT>
-                      # TODO(compnerd) handle /MT builds
-                      $<$<PLATFORM_ID:Windows>:-D_DLL>
                     DEPENDS
                       module-maps
                       DispatchStubs
@@ -158,6 +155,11 @@ if(ENABLE_SWIFT)
                     SWIFT_FLAGS
                       -I ${PROJECT_SOURCE_DIR}
                       ${swift_optimization_flags}
+                      $<$<PLATFORM_ID:Windows>:-Xcc>
+                      $<$<PLATFORM_ID:Windows>:-D_MT>
+                      # TODO(compnerd) handle /MT builds
+                      $<$<PLATFORM_ID:Windows>:-Xcc>
+                      $<$<PLATFORM_ID:Windows>:-D_DLL>
                     TARGET
                       ${CMAKE_C_COMPILER_TARGET})
 endif()


### PR DESCRIPTION
- cmake/modules/SwiftSupport.cmake prepends each flag with '-Xcc' but
  if the flag evaluates to empty then an extra -Xcc is added to the
  compiler options.

- Explicitly add the option with a conditional '-Xcc' before it as well.

- This fixes the "warning: argument unused during compilation: '-Xcc'"
  seen in the error logs.