### PR TITLE
build: use the new `-libc` flag for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required(VERSION 3.4.3)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+# NOTE(compnerd) enable CMP0091 - select MSVC Runtime Library via the
+# CMAKE_MSVC_RUNTIME_LIBRARY setting
+if(POLICY CMP0091)
+  cmake_policy(CMP0091 NEW)
+endif()
+
 project(dispatch
         VERSION 1.3
         LANGUAGES C CXX)
@@ -18,6 +24,9 @@ set(CMAKE_C_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_C_VISIBILITY_PRESET hidden)
+
+# NOTE(compnerd) default to /MD or /MDd based on the configuration on Windows
+set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>DLL)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,8 +134,6 @@ if(ENABLE_SWIFT)
                       -lBlocksRuntime
                       -L $<TARGET_LINKER_FILE_DIR:dispatch>
                       -ldispatch
-                      $<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:-lmsvcrtd>
-                      $<$<AND:$<PLATFORM_ID:Windows>,$<NOT:$<CONFIG:Debug>>>:-lmsvcrt>
                     MODULE_NAME
                       Dispatch
                     MODULE_LINK_NAME
@@ -155,11 +153,7 @@ if(ENABLE_SWIFT)
                     SWIFT_FLAGS
                       -I ${PROJECT_SOURCE_DIR}
                       ${swift_optimization_flags}
-                      $<$<PLATFORM_ID:Windows>:-Xcc>
-                      $<$<PLATFORM_ID:Windows>:-D_MT>
-                      # TODO(compnerd) handle /MT builds
-                      $<$<PLATFORM_ID:Windows>:-Xcc>
-                      $<$<PLATFORM_ID:Windows>:-D_DLL>
+                      $<$<PLATFORM_ID:Windows>:-libc;${CMAKE_MSVC_RUNTIME_LIBRARY}>
                     TARGET
                       ${CMAKE_C_COMPILER_TARGET})
 endif()


### PR DESCRIPTION
Windows has ABI incompatible system libraries which must be explicitly
selected.  Adjust the build system to enable the user to control the
variant of the library that we build against.  This simplifies the build
and ensures that the correct library is selected.