### PR TITLE
tests: port dispatch_io and dispatch_io_pipe_close to Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,11 +146,8 @@ if(EXTENDED_TEST_SUITE)
        pingpong
        drift
        readsync
-       cascade)
-  if(NOT WIN32)
-    # Not ported to Windows yet
-    list(APPEND DISPATCH_C_TESTS io)
-  endif()
+       cascade
+       io)
   # an oddball; dispatch_priority.c compiled with -DUSE_SET_TARGET_QUEUE=1
   add_unit_test(dispatch_priority2 SOURCES dispatch_priority.c)
   target_compile_options(dispatch_priority2 PRIVATE -DUSE_SET_TARGET_QUEUE=1)


### PR DESCRIPTION
This lets us build and run the full extended test suite for Windows! I
caught several bugs in Dispatch's Windows port while I was working on
this and I submitted pull requests to fix them (#493, #494). The only
dispatch_io test case which fails right now is test_io_stop, and that's
because we don't have pipe support on Windows yet.