### PR TITLE
shims: fix TAILQ_CONCAT() edge cases

### DIFF
--- a/src/shims/generic_sys_queue.h
+++ b/src/shims/generic_sys_queue.h
@@ -94,7 +94,11 @@
 
 #define TAILQ_CONCAT(head1, head2, field) do { \
 		if (!TAILQ_EMPTY(head2)) { \
-			(head1)->tq_last = (head2)->tq_first; \
+			if ((head1)->tq_last) { \
+				(head1)->tq_last->field.te_next = (head2)->tq_first; \
+			} else { \
+				(head1)->tq_first = (head2)->tq_first; \
+			} \
 			(head2)->tq_first->field.te_prev = (head1)->tq_last; \
 			(head1)->tq_last = (head2)->tq_last; \
 			TAILQ_INIT((head2)); \


### PR DESCRIPTION
This needs to set the `te_next` of the last element in `head1` and also
handle the case where `head1` is empty. This fixes a hang in the
dispatch_context_for_key test on Windows because the the queue-specific
list was getting corrupted in `_dispatch_queue_specific_head_dispose()`.