### PR TITLE
sys/sysctl.h is deprecated on Linux

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -272,10 +272,9 @@ upcast(dispatch_object_t dou)
 #include <sys/mount.h>
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
-#else
-#include <sys/sysctl.h>
 #endif /* __ANDROID__ */
 #if !defined(__linux__)
+#include <sys/sysctl.h>
 #include <sys/queue.h>
 #endif
 #include <sys/socket.h>

--- a/tests/Foundation/bench.mm
+++ b/tests/Foundation/bench.mm
@@ -23,7 +23,9 @@
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
+#if !defined(__linux__)
 #include <sys/sysctl.h>
+#endif
 #endif /* __ANDROID__ */
 #include <mach/mach.h>
 #include <mach/mach_time.h>

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -25,7 +25,9 @@
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
+#if !defined(__linux__)
 #include <sys/sysctl.h>
+#endif
 #endif /* __ANDROID__ */
 #endif
 #include <stdlib.h>

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -28,7 +28,9 @@
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
+#if !defined(__linux__)
 #include <sys/sysctl.h>
+#endif
 #endif /* __ANDROID__ */
 #endif
 

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -26,7 +26,9 @@
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
+#if !defined(__linux__)
 #include <sys/sysctl.h>
+#endif
 #endif /* __ANDROID__ */
 #endif
 #include <stdlib.h>

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -26,7 +26,9 @@
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
+#if !defined(__linux__)
 #include <sys/sysctl.h>
+#endif
 #endif /* __ANDROID__ */
 #endif
 #include <assert.h>

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -31,7 +31,9 @@
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
 #else
+#if !defined(__linux__)
 #include <sys/sysctl.h>
+#endif
 #endif /* __ANDROID__ */
 #include <stdarg.h>
 #include <time.h>


### PR DESCRIPTION
A warning has been added to sys/sysctl.h that is treated as an error when compiling; see https://patches-gcc.linaro.org/patch/19443/#34639 for the discussion. This patch adds a guard to prevent the file from being included when compiling on Linux.