### PR TITLE
Remove Android Platform level for swiftc invocations

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -12,6 +12,13 @@ function(add_swift_target target)
   set(link_flags ${CMAKE_SWIFT_LINK_FLAGS})
 
   if(AST_TARGET)
+    if(ANDROID)
+      # Android target strings provided by the NDK toolchain look like
+      # "x86_64-none-linux-android21". swiftc doesn't understand the
+      # numbers at the end, so remove them here if they are present:
+      string(REGEX REPLACE "[0-9]+$" "" AST_TARGET "${AST_TARGET}")
+    endif()
+
     list(APPEND compile_flags -target;${AST_TARGET})
     list(APPEND link_flags -target;${AST_TARGET})
   endif()


### PR DESCRIPTION
`swiftc` breaks when calling it from a CMake context with the `-DCMAKE_TOOLCHAIN_FILE` parameter referencing the Android NDK's CMake toolchain. The issue reported is `<unknown>:0: error: unable to load standard library for target 'x86_64-none-linux-android21'`

By removing the Android API level number from the end of the LLVM triple in the swift support we can ensure the triple containing the API level still gets provided to `clang` for C compilation without breaking `swiftc`.

Note: this change only affects Android. I am pretty sure there are no other Android triples that end with a number that we'd be breaking here.