### PR TITLE
shims: always replace `_Bool` with `bool` in C++

### DIFF
--- a/src/shims/atomic.h
+++ b/src/shims/atomic.h
@@ -32,7 +32,7 @@
 #endif
 
 // FreeBSD only defines _Bool in C mode. In C++ mode _Bool is not being defined.
-#if defined(__cplusplus) && (defined(__FreeBSD__) || defined(_WIN32))
+#if defined(__cplusplus)
 #define _Bool bool
 #endif
 #include <stdatomic.h>


### PR DESCRIPTION
This generalises the path to always perform this substitution in C++
mode.  This should repair the build of libdispatch on android.