### PR TITLE
semaphore: annotate fallthrough (NFC)

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -127,6 +127,33 @@
 #define DISPATCH_UNAVAILABLE_MSG(msg)
 #endif
 
+#if defined(__cplusplus)
+# if __cplusplus >= 201703L
+#  define DISPATCH_FALLTHROUGH [[fallthrough]]
+# elif __cplusplus >= 201103L
+#  if defined(__clang__)
+#   define DISPATCH_FALLTHROUGH [[clang::fallthrough]]
+#  elif defined(__GNUC__) && __GNUC__ >= 7
+#   define DISPATCH_FALLTHROUGH [[gnu::fallthrough]]
+#  else
+#   define DISPATCH_FALLTHROUGH
+#  endif
+# else
+#  define DISPATCH_FALLTHROUGH
+# endif
+#elif defined(__GNUC__) && __GNUC__ >= 7
+# define DISPATCH_FALLTHROUGH __attribute__((__fallthrough__))
+#elif defined(__clang__)
+# if __has_attribute(fallthrough) && __clang_major__ >= 5
+#  define DISPATCH_FALLTHROUGH __attribute__((__fallthrough__))
+# else
+#  define DISPATCH_FALLTHROUGH
+# endif
+#else
+# define DISPATCH_FALLTHROUGH
+#endif
+
+
 #ifdef __linux__
 #define DISPATCH_LINUX_UNAVAILABLE() \
 		DISPATCH_UNAVAILABLE_MSG( \

--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -174,6 +174,7 @@ _dispatch_muxnote_create(dispatch_unote_t du, uint32_t events)
 	}
 	case EVFILT_WRITE:
 		filter = EVFILT_READ;
+		DISPATCH_FALLTHROUGH;
 	case EVFILT_READ:
 		if (fstat(fd, &sb) < 0) {
 			return NULL;

--- a/src/io.c
+++ b/src/io.c
@@ -2085,12 +2085,12 @@ pick:
 	switch (result) {
 	case DISPATCH_OP_DELIVER:
 		flags = DOP_DEFAULT;
-		// Fall through
+		DISPATCH_FALLTHROUGH;
 	case DISPATCH_OP_DELIVER_AND_COMPLETE:
 		flags = (flags != DOP_DEFAULT) ? DOP_DELIVER | DOP_NO_EMPTY :
 				DOP_DEFAULT;
 		_dispatch_operation_deliver_data(op, flags);
-		// Fall through
+		DISPATCH_FALLTHROUGH;
 	case DISPATCH_OP_COMPLETE:
 		if (flags != DOP_DEFAULT) {
 			_dispatch_stream_complete_operation(stream, op);
@@ -2102,7 +2102,7 @@ pick:
 		break;
 	case DISPATCH_OP_COMPLETE_RESUME:
 		_dispatch_stream_complete_operation(stream, op);
-		// Fall through
+		DISPATCH_FALLTHROUGH;
 	case DISPATCH_OP_RESUME:
 		if (_dispatch_stream_operation_avail(stream)) {
 			stream->source_running = true;

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -116,8 +116,8 @@ _dispatch_semaphore_wait_slow(dispatch_semaphore_t dsema,
 		if (!_dispatch_sema4_timedwait(&dsema->dsema_sema, timeout)) {
 			break;
 		}
-		// Fall through and try to undo what the fast path did to
-		// dsema->dsema_value
+		// Try to undo what the fast path did to dsema->dsema_value
+		DISPATCH_FALLTHROUGH;
 	case DISPATCH_TIME_NOW:
 		orig = dsema->dsema_value;
 		while (orig < 0) {
@@ -126,8 +126,8 @@ _dispatch_semaphore_wait_slow(dispatch_semaphore_t dsema,
 				return _DSEMA4_TIMEOUT();
 			}
 		}
-		// Another thread called semaphore_signal().
-		// Fall through and drain the wakeup.
+		// Another thread called semaphore_signal(). Drain the wakeup.
+		DISPATCH_FALLTHROUGH;
 	case DISPATCH_TIME_FOREVER:
 		_dispatch_sema4_wait(&dsema->dsema_sema);
 		break;

--- a/src/shims/lock.c
+++ b/src/shims/lock.c
@@ -338,7 +338,7 @@ _dlock_wait(uint32_t *uaddr, uint32_t val, uint32_t timeout, uint32_t flags)
 			if (timeout == 0) {
 				continue;
 			}
-			/* FALLTHROUGH */
+			DISPATCH_FALLTHROUGH;
 		case ETIMEDOUT:
 		case EFAULT:
 			return -rc;
@@ -427,7 +427,7 @@ _futex_blocking_op(uint32_t *uaddr, int futex_op, uint32_t val,
 			if (timeout == 0) {
 				continue;
 			}
-			/* FALLTHROUGH */
+			DISPATCH_FALLTHROUGH;
 		case ETIMEDOUT:
 		case EFAULT:
 		case EWOULDBLOCK:

--- a/src/transform.c
+++ b/src/transform.c
@@ -781,11 +781,14 @@ _dispatch_transform_to_base32_with_table(dispatch_data_t data, const unsigned ch
 			case 1:
 				*ptr++ = '='; // c
 				*ptr++ = '='; // d
+				DISPATCH_FALLTHROUGH;
 			case 2:
 				*ptr++ = '='; // e
+				DISPATCH_FALLTHROUGH;
 			case 3:
 				*ptr++ = '='; // f
 				*ptr++ = '='; // g
+				DISPATCH_FALLTHROUGH;
 			case 4:
 				*ptr++ = '='; // h
 				break;


### PR DESCRIPTION
Address `-Werror,-Wimplicit-fallthrough` as identified by clang.  This fixes a
couple of build warnings which are treated as errors.  NFC.