### PR TITLE
build: place executable content into the root of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 
+# NOTE(compnerd) this is a horrible workaround for Windows to ensure that the
+# tests can run as there is no rpath equivalent and `PATH` is used to lookup the
+# libraries.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,7 @@ if(ENABLE_SWIFT)
                       module-maps
                       DispatchStubs
                     LINK_FLAGS
+                      -L $<TARGET_LINKER_FILE_DIR:DispatchStubs>
                       -lDispatchStubs
                       -L $<TARGET_LINKER_FILE_DIR:BlocksRuntime>
                       -lBlocksRuntime


### PR DESCRIPTION
Adjust the output location of the generated executable content to the root of
the build tree.  This is needed primarily on Windows where there is no concept
of a RPATH, and the current directory is scanned for the dependent libraries.