### PR TITLE
build: sink BlocksRuntime into its own directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,53 +116,6 @@ endif()
 
 option(INSTALL_PRIVATE_HEADERS "installs private headers in the same location as the public ones" OFF)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  set(BlocksRuntime_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/src/BlocksRuntime)
-
-  # NOTE(compnerd) use the `BUILD_SHARED_LIBS` variable to determine what type
-  # of library to build.  If it is true, we will generate shared libraries,
-  # otherwise we will generate static libraries.
-  add_library(BlocksRuntime
-              ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/data.c
-              ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/runtime.c)
-  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    target_sources(BlocksRuntime
-                   PRIVATE
-                     ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/BlocksRuntime.def)
-    if(NOT BUILD_SHARED_LIBS)
-      target_compile_definitions(BlocksRuntime
-                                 PRIVATE
-                                   BlocksRuntime_STATIC)
-    endif()
-  endif()
-  set_target_properties(BlocksRuntime
-                        PROPERTIES
-                          POSITION_INDEPENDENT_CODE TRUE)
-  if(HAVE_OBJC AND CMAKE_DL_LIBS)
-    target_link_libraries(BlocksRuntime
-                          PUBLIC
-                            ${CMAKE_DL_LIBS})
-  endif()
-
-  add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
-
-  install(FILES
-            ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/Block.h
-          DESTINATION
-            "${INSTALL_BLOCK_HEADERS_DIR}")
-  if(INSTALL_PRIVATE_HEADERS)
-    install(FILES
-              ${PROJECT_SOURCE_DIR}/src/BlocksRuntime/Block_private.h
-            DESTINATION
-              "${INSTALL_BLOCK_HEADERS_DIR}")
-  endif()
-  install(TARGETS
-            BlocksRuntime
-          ARCHIVE DESTINATION ${INSTALL_TARGET_DIR}
-          LIBRARY DESTINATION ${INSTALL_TARGET_DIR}
-          RUNTIME DESTINATION bin)
-endif()
-
 check_symbol_exists(__GNU_LIBRARY__ "features.h" _GNU_SOURCE)
 if(_GNU_SOURCE)
   set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} -D_GNU_SOURCE)

--- a/src/BlocksRuntime/CMakeLists.txt
+++ b/src/BlocksRuntime/CMakeLists.txt
@@ -1,0 +1,34 @@
+
+add_library(BlocksRuntime
+  data.c
+  runtime.c)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_sources(BlocksRuntime PRIVATE
+    BlocksRuntime.def)
+
+  if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(BlocksRuntime PRIVATE
+      BlocksRuntime_STATIC)
+  endif()
+endif()
+
+set_target_properties(BlocksRuntime PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+if(HAVE_OBJC AND CMAKE_DL_LIBS)
+  target_link_libraries(BlocksRuntime PUBLIC
+    ${CMAKE_DL_LIBS})
+endif()
+
+add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
+
+install(FILES Block.h
+        DESTINATION ${INSTALL_BLOCK_HEADERS_DIR})
+if(INSTALL_PRIVATE_HEADERS)
+  install(FILES Block_private.h
+          DESTINATION ${INSTALL_BLOCK_HEADERS_DIR})
+endif()
+install(TARGETS BlocksRuntime
+        ARCHIVE DESTINATION ${INSTALL_TARGET_DIR}
+        LIBRARY DESTINATION ${INSTALL_TARGET_DIR}
+        RUNTIME DESTINATION bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ include(CheckCCompilerFlag)
 include(SwiftSupport)
 include(DTrace)
 
+add_subdirectory(BlocksRuntime)
+
 add_library(dispatch
               allocator.c
               apply.c


### PR DESCRIPTION
This follows the CMake recommendations for the tree layout.  It makes it
easier to follow the build infrastructure, and prepares the tree for
migration to CMake 3.15 to enable Swift support.