### PR TITLE
build: migrate to standard mechanism for testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 project(dispatch
         VERSION 1.3
         LANGUAGES C CXX)
-enable_testing()
 
 if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
   include(ClangClCompileRules)
@@ -36,6 +35,7 @@ include(CheckLibraryExists)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
 include(SwiftSupport)
+include(CTest)
 
 set(SWIFT_LIBDIR "lib" CACHE PATH "Library folder name, defined by swift main buildscript")
 set(INSTALL_LIBDIR "${SWIFT_LIBDIR}" CACHE PATH "Path where the libraries should be installed")
@@ -85,8 +85,6 @@ endif()
 option(DISPATCH_ENABLE_ASSERTS "enable debug assertions" FALSE)
 
 option(ENABLE_DTRACE "enable dtrace support" "")
-
-option(ENABLE_TESTING "build libdispatch tests" ON)
 
 option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via _Thread_local" ON)
 set(DISPATCH_USE_THREAD_LOCAL_STORAGE ${ENABLE_THREAD_LOCAL_STORAGE})
@@ -286,7 +284,7 @@ add_subdirectory(man)
 add_subdirectory(os)
 add_subdirectory(private)
 add_subdirectory(src)
-if(ENABLE_TESTING)
+if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 

--- a/tests/dispatch_context_for_key.c
+++ b/tests/dispatch_context_for_key.c
@@ -31,7 +31,7 @@
 
 #if DISPATCH_API_VERSION >= 20100825 && DISPATCH_API_VERSION != 20101110
 
-static char *ctxts[] = {"ctxt for app", "ctxt for key 1",
+static const char *ctxts[] = {"ctxt for app", "ctxt for key 1",
 		"ctxt for key 2", "ctxt for key 1 bis", "ctxt for key 4"};
 volatile long ctxts_destroyed;
 static dispatch_group_t g;
@@ -58,20 +58,20 @@ test_context_for_key(void)
 	dispatch_queue_t ttq = dispatch_get_global_queue(0, 0);
 	dispatch_group_enter(g);
 #if DISPATCH_API_VERSION >= 20101011
-	dispatch_queue_set_specific(tq, &ctxts[4], ctxts[4], destructor);
+	dispatch_queue_set_specific(tq, &ctxts[4], (char *)ctxts[4], destructor);
 #else
 	dispatch_set_context_for_key(tq, &ctxts[4], ctxts[4], ttq, destructor);
 #endif
 	dispatch_set_target_queue(tq, ttq);
 	dispatch_group_enter(g);
-	dispatch_set_context(q, ctxts[0]);
+	dispatch_set_context(q, (char *)ctxts[0]);
 	dispatch_set_target_queue(q, tq);
 	dispatch_set_finalizer_f(q, destructor);
 
 	dispatch_async(q, ^{
 		dispatch_group_enter(g);
 #if DISPATCH_API_VERSION >= 20101011
-		dispatch_queue_set_specific(q, &ctxts[1], ctxts[1], destructor);
+		dispatch_queue_set_specific(q, &ctxts[1], (char *)ctxts[1], destructor);
 #else
 		dispatch_set_context_for_key(q, &ctxts[1], ctxts[1], ttq, destructor);
 #endif
@@ -80,7 +80,7 @@ test_context_for_key(void)
 	dispatch_async(dispatch_get_global_queue(0, 0), ^{
 		dispatch_group_enter(g);
 #if DISPATCH_API_VERSION >= 20101011
-		dispatch_queue_set_specific(q, &ctxts[2], ctxts[2], destructor);
+		dispatch_queue_set_specific(q, &ctxts[2], (char *)ctxts[2], destructor);
 #else
 		dispatch_set_context_for_key(q, &ctxts[2], ctxts[2], ttq, destructor);
 #endif
@@ -114,7 +114,7 @@ test_context_for_key(void)
 		dispatch_group_enter(g);
 		void *ctxt;
 #if DISPATCH_API_VERSION >= 20101011
-		dispatch_queue_set_specific(q, &ctxts[1], ctxts[3], destructor);
+		dispatch_queue_set_specific(q, &ctxts[1], (char *)ctxts[3], destructor);
 		ctxt = dispatch_queue_get_specific(q, &ctxts[1]);
 #else
 		dispatch_set_context_for_key(q, &ctxts[1], ctxts[3], ttq, destructor);

--- a/tests/dispatch_data.c
+++ b/tests/dispatch_data.c
@@ -43,9 +43,9 @@ test_concat(void)
 {
 	dispatch_group_enter(g);
 	dispatch_async(dispatch_get_main_queue(), ^{
-		char* buffer1 = "This is buffer1 ";
+		const char* buffer1 = "This is buffer1 ";
 		size_t size1 = 17;
-		char* buffer2 = "This is buffer2 ";
+		const char* buffer2 = "This is buffer2 ";
 		size_t size2 = 17;
 		__block bool buffer2_destroyed = false;
 

--- a/tests/dispatch_io_muxed.c
+++ b/tests/dispatch_io_muxed.c
@@ -47,7 +47,7 @@ test_file_muxed(void)
 	printf("\nFile Muxed\n");
 
 #if defined(_WIN32)
-	char *temp_dir = getenv("TMP");
+	const char *temp_dir = getenv("TMP");
 	if (!temp_dir) {
 		temp_dir = getenv("TEMP");
 	}
@@ -55,13 +55,13 @@ test_file_muxed(void)
 		test_ptr_notnull("temporary directory", temp_dir);
 		test_stop();
 	}
-	char *path_separator = "\\";
+	const char *path_separator = "\\";
 #else
-	char *temp_dir = getenv("TMPDIR");
+	const char *temp_dir = getenv("TMPDIR");
 	if (!temp_dir) {
 		temp_dir = "/tmp";
 	}
-	char *path_separator = "/";
+	const char *path_separator = "/";
 #endif
 	char *path = NULL;
 	asprintf(&path, "%s%sdispatchtest_io.XXXXXX", temp_dir, path_separator);


### PR DESCRIPTION
Use `CTest` module rather than the custom `ENABLE_TESTING` option.  The
inclusion of `CTest` will default `BUILD_TESTING` to true, which
preserves the existing behaviour.