### PR TITLE
tests: correct the check function (NFCI)

### DIFF
--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -69,7 +69,7 @@ stage1(int stage)
 		size_t buffer_size = 500*1024;
 		char buffer[500*1024];
 		ssize_t sz = dispatch_test_fd_read(fd, buffer, buffer_size);
-		test_double_less_than_or_equal("kevent read 1", sz, buffer_size+1);
+		test_sizet_less_than_or_equal("kevent read 1", sz, buffer_size+1);
 		dispatch_source_cancel(source);
 	});
 
@@ -128,7 +128,7 @@ stage2(void)
 
 	dispatch_source_set_event_handler(source, ^{
 		size_t est = dispatch_source_get_data(source);
-		test_double_less_than_or_equal("estimated", est, expected - actual);
+		test_sizet_less_than_or_equal("estimated", est, expected - actual);
 		char buffer[500*1024];
 		ssize_t sz = dispatch_test_fd_read(fd, buffer, sizeof(buffer));
 		actual += sz;


### PR DESCRIPTION
The tests were using `test_double_less_than_or_equal` which raised a warning
when building on Linux-x86_64:

```
tests/dispatch_select.c:72:51: error: implicit conversion from 'ssize_t' (aka 'long') to 'double' may lose precision
tests/dispatch_select.c:131:61: error: implicit conversion from 'long' to 'double' may lose precision
```

Use `test_sizet_less_than_or_equal` instead.