### PR TITLE
queue: use the default stack size on Windows

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -5769,13 +5769,8 @@ _dispatch_root_queue_poke_slow(dispatch_queue_global_t dq, int n, int floor)
 #endif
 	do {
 		_dispatch_retain(dq); // released in _dispatch_worker_thread
-#if DISPATCH_DEBUG
-		unsigned dwStackSize = 0;
-#else
-		unsigned dwStackSize = 64 * 1024;
-#endif
 		uintptr_t hThread = 0;
-		while (!(hThread = _beginthreadex(NULL, dwStackSize, _dispatch_worker_thread_thunk, dq, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL))) {
+		while (!(hThread = _beginthreadex(NULL, /* stack_size */ 0, _dispatch_worker_thread_thunk, dq, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL))) {
 			if (errno != EAGAIN) {
 				(void)dispatch_assume(hThread);
 			}


### PR DESCRIPTION
The Windows thread pool implementation is calling `_beginthreadex` with
a stack size of 64 KB. This seems like a misunderstanding to me. In the
pthread code, `_dispatch_mgr_root_queue_init` does call
`pthread_attr_setstacksize` with a 64 KB size. However, this only
applies to the pthread root queue manager, and pthread root queues are
only supported on Apple platforms anyway.

We can confirm that using the OS default stack size is the intended
semantic by looking at the `dispatch_select` test, which expects to be
able to stack-allocate a 500 KB buffer in an event handler. This test is
failing on Windows because there is not enough stack space. We've also
run into various related issues in Swift which only happen on Windows,
and I suspect that this is just because the stack size isn't so small on
other platforms.