### PR TITLE
tests: fix -Werror,-Wimplicit-int-float-conversion

### DIFF
--- a/tests/dispatch_timer_short.c
+++ b/tests/dispatch_timer_short.c
@@ -52,10 +52,11 @@ static
 void
 test_fin(void *cxt)
 {
-	unsigned long finalCount = (unsigned long)count;
+	uint32_t finalCount = (uint32_t)count;
 	fprintf(stderr, "Called back every %llu us on average\n",
 			(delay/finalCount)/NSEC_PER_USEC);
-	test_long_less_than("Frequency", 1, (long)ceil((double)delay/(finalCount*interval)));
+	test_long_less_than("Frequency", 1,
+		(long)ceil((double)delay/(double)(finalCount*interval)));
 	int i;
 	for (i = 0; i < N; i++) {
 		dispatch_source_cancel(t[i]);


### PR DESCRIPTION
```
testes/dispatch_timer_short.c:58:74: error: implicit conversion from 'unsigned long long' to 'double' may loose precision [-Werror,-Wimplicit-int-float-conversion]
	test_long_less_than("Frequency", 1, (long)ceil((double)delay/(finalCount*interval)));
	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```

Fix the casting for `finalCount` and explicitly cast the result which would be
an `unsigned long long` due to the multiplication by `interval`.