### PR TITLE
Some simple parallel processing primitives?

### DIFF
--- a/src/swift/Parallel.swift
+++ b/src/swift/Parallel.swift
@@ -14,6 +14,7 @@ import Dispatch
 
 /// Wrapper for os_unfair_lock mutex primitve from the
 /// project: https://github.com/Alamofire/Alamofire
+// Copyright (c) 2014-2018 Alamofire Software Foundation (http://alamofire.org/)
 @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 public class UnfairLock {
     private let unfairLock: os_unfair_lock_t
@@ -55,6 +56,8 @@ public class UnfairLock {
     }
 }
 
+/// A wrapper for data to that is mutable across threads.
+@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 public class Synchronized<Wrapped>: UnfairLock {
     private var data: Wrapped
 
@@ -62,8 +65,41 @@ public class Synchronized<Wrapped>: UnfairLock {
         self.data = data
     }
 
+    /// Access to wrapped data after taking out a lock on it.
+    ///
+    /// - Parameter body: closure executed while wrapped data is locked
     public func synchronized<T>(_ body: (inout Wrapped) throws -> T) rethrows -> T {
         return try around { try body(&self.data) }
+    }
+}
+
+/// Simple synchronized cache
+@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+public class Cached<Key: Hashable, Value>: Synchronized<[Key: Value]> {
+
+    private let getter: (Key) -> Value
+
+    /// Initializer
+    ///
+    /// - Parameter getter: a closure used when key is not already cached.
+    public init(getter: @escaping (Key) -> Value) {
+        self.getter = getter
+        super.init([Key: Value]())
+    }
+
+    /// Get value for key, opulating if necessary
+    ///
+    /// - Parameter key: key of cache to fetch/generate value
+    public final func get(key: Key) -> Value {
+        return synchronized { data in
+            if let value = data[key] {
+                return value
+            }
+
+            let value = getter(key)
+            data[key] = value
+            return value
+        }
     }
 }
 
@@ -73,20 +109,21 @@ extension Sequence {
     /// and processes them on the number of threads specified.
     ///
     /// - Parameter maxConcurrency: Maximum number of threads to start.
-    /// - Parameter queueName: Name used for the concurrent queue
-    /// - Parameter priority: Quality of service of threads created
-    /// - Parameter worker: Closure to call to perform work
+    /// - Parameter initializer: a prototype to initialize output array.
+    /// - Parameter queueName: Name used for the concurrent queue.
+    /// - Parameter priority: Quality of service of threads created.
+    /// - Parameter worker: Closure to call to perform work.
     ///
     /// Up to maxConcurrency threads used to execute the `worker` closure
     /// passing in each value in the sequence and a closure to call when
     /// the work is complete and an output value is available.
     @available(OSX 10.12, iOS 13, tvOS 13, watchOS 6, *)
     @discardableResult
-    func concurrentMap<Output>(maxConcurrency: Int = 4,
-                               initializer: Output? = nil,
-                               queueName: String = "concurrentMap",
-                               priority: DispatchQoS = .default,
-                               worker: @escaping (Element,
+    public func concurrentMap<Output>(maxConcurrency: Int = 4,
+                                      initializer: Output? = nil,
+                                      queueName: String = "concurrentMap",
+                                      priority: DispatchQoS = .default,
+                                      worker: @escaping (Element,
                             @escaping (Output) -> Void) -> Void) -> [Output] {
         let input = Array(self)
         var output: [Output]

--- a/src/swift/Parallel.swift
+++ b/src/swift/Parallel.swift
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+/// Wrapper for os_unfair_lock mutex primitve from the
+/// project: https://github.com/Alamofire/Alamofire
+@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+final public class UnfairLock {
+    private let unfairLock: os_unfair_lock_t
+
+    public init() {
+        unfairLock = .allocate(capacity: 1)
+        unfairLock.initialize(to: os_unfair_lock())
+    }
+
+    deinit {
+        unfairLock.deinitialize(count: 1)
+        unfairLock.deallocate()
+    }
+
+    private func lock() {
+        os_unfair_lock_lock(unfairLock)
+    }
+
+    private func unlock() {
+        os_unfair_lock_unlock(unfairLock)
+    }
+
+    /// Executes a closure returning a value while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    ///
+    /// - Returns:           The value the closure generated.
+    public func synchronized<T>(_ closure: () -> T) -> T {
+        lock(); defer { unlock() }
+        return closure()
+    }
+
+    /// Execute a closure while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    public func synchronized(_ closure: () -> Void) {
+        lock(); defer { unlock() }
+        return closure()
+    }
+}
+
+/// Property wrapper to make read/write access to the
+/// wrapped value synchronous across multiple threads.
+@available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+@propertyWrapper
+public struct Atomic<Value> {
+
+    private let lock = UnfairLock()
+    var _stored: Value
+
+    public init(wrappedValue initialValue: Value) {
+      _stored = initialValue
+    }
+
+    public var wrappedValue: Value {
+        get {
+            return lock.synchronized { _stored }
+        }
+        set(newValue) {
+            lock.synchronized {
+                _stored = newValue
+            }
+        }
+    }
+}
+
+extension Sequence {
+
+    /// A form of map that reads the Elements of the Sequnce
+    /// and presents them on a number of threads determined by
+    /// the concurrentPerform class method on DispatchQueue.
+    ///
+    /// - Parameter closure: The closure to run.
+    @available(OSX 10.12, iOS 13, tvOS 13, watchOS 6, *)
+    @discardableResult
+    public func concurrentMap<Output>(queueName: String = "concurrentMap",
+                 priority: DispatchQoS = .default,
+                 worker: @escaping (Element) -> Output) -> [Output] {
+        let input = Array(self)
+        var output = Array<Output>(unsafeUninitializedCapacity: input.count,
+                                   initializingWith: {
+                                    (buffer, initializedCount) in
+                                    let stride = MemoryLayout<Output>.stride
+                                    memset(buffer.baseAddress, 0,
+                                           stride * buffer.count)
+                                    initializedCount = buffer.count
+        })
+        let concurrentQueue = DispatchQueue(label: queueName, qos: priority,
+                                            attributes: .concurrent)
+
+        output.withUnsafeMutableBufferPointer {
+            buffer in
+            concurrentQueue.sync {
+                DispatchQueue.concurrentPerform(iterations: input.count) {
+                    index in
+                    buffer.baseAddress![index] = worker(input[index])
+                }
+            }
+        }
+
+        return output
+    }
+}

--- a/src/swift/Parallel.swift
+++ b/src/swift/Parallel.swift
@@ -15,7 +15,7 @@ import Dispatch
 /// Wrapper for os_unfair_lock mutex primitve from the
 /// project: https://github.com/Alamofire/Alamofire
 @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
-final public class UnfairLock {
+public final class UnfairLock {
     private let unfairLock: os_unfair_lock_t
 
     public init() {
@@ -41,9 +41,53 @@ final public class UnfairLock {
     /// - Parameter closure: The closure to run.
     ///
     /// - Returns:           The value the closure generated.
-    public func synchronized<T>(_ closure: () -> T) -> T {
+    func synchronized<T>(_ closure: () -> T) -> T {
         lock(); defer { unlock() }
         return closure()
+    }
+
+    /// Execute a closure while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    func synchronized(_ closure: () -> Void) {
+        lock(); defer { unlock() }
+        return closure()
+    }
+}
+
+public typealias SynchronizableLock = UnfairLock
+private var allLocks = [OpaquePointer: SynchronizableLock]()
+private var lockLock = SynchronizableLock()
+
+protocol Synchronizable {
+    mutating func synchronized<T>(_ closure: (inout Self) -> T) -> T
+}
+
+extension Dictionary: Synchronizable {}
+extension Array: Synchronizable {}
+extension Int: Synchronizable {}
+
+extension Synchronizable {
+
+    public mutating func synchronized<T>(_ closure: (inout Self) -> T) -> T {
+        let lockee = UnsafeMutablePointer(&self)
+        let lock = lockLock.synchronized { () -> SynchronizableLock in
+            let key = OpaquePointer(lockee)
+            var lock = allLocks[key]
+            if lock == nil {
+                lock = SynchronizableLock()
+                allLocks[key] = lock
+            }
+            return lock!
+        }
+        return lock.synchronized { closure(&lockee.pointee) }
+    }
+
+    public mutating func desynchronize() {
+        let lockee = UnsafeMutablePointer(&self)
+        lockLock.synchronized {
+            allLocks[OpaquePointer(lockee)] = nil
+        }
     }
 }
 
@@ -88,20 +132,27 @@ extension Sequence {
     @available(OSX 10.12, iOS 13, tvOS 13, watchOS 6, *)
     @discardableResult
     func concurrentMap<Output>(maxConcurrency: Int = 4,
+                               initializer: Output? = nil,
                                queueName: String = "concurrentMap",
                                priority: DispatchQoS = .default,
                                worker: @escaping (Element,
                             @escaping (Output) -> Void) -> Void) -> [Output] {
         let input = Array(self)
-        var output = Array<Output>(unsafeUninitializedCapacity: input.count,
-                                   initializingWith: {
-                                    (buffer, initializedCount) in
-                                    let stride = MemoryLayout<Output>.stride
-                                    memset(buffer.baseAddress, 0,
-                                           stride * input.count)
-                                    initializedCount = input.count})
+        var output: [Output]
+        if initializer != nil {
+            output = Array(repeating: initializer!, count: input.count)
+        } else {
+            output = Array(unsafeUninitializedCapacity: input.count,
+                          initializingWith: {
+                            (buffer, initializedCount) in
+                            let stride = MemoryLayout<Output>.stride
+                            memset(buffer.baseAddress, 0,
+                                   stride * input.count)
+                            initializedCount = input.count})
+        }
 
-        output.withUnsafeMutableBufferPointer { buffer in
+        output.withUnsafeMutableBufferPointer {
+            buffer in
             let buffro = buffer
             let concurrentQueue = DispatchQueue(label: queueName, qos: priority,
                                                 attributes: .concurrent)


### PR DESCRIPTION
Hi Apple,

As a result of my own recent work and a couple of threads on [swift](https://forums.swift.org/t/multi-thread-processing-operator-for-stdlib/30421), [evolution](https://forums.swift.org/t/atomic-property-wrapper-for-standard-library/30468), I'd like to put forward the file in this PR for inclusion in Dispatch and am not at all sure sure the procedure would be. It defines a new `map` method `concurentMap` on `Sequence` that distributes work across multiple cores backed up by a wrapper on os_unfair_lock and a property wrapper that would be of use with such asynchronous code. I know there is a longer term full [manifesto for concurrency](https://gist.github.com/lattner/31ed37682ef1576b16bca1432ea9f782) in Swift but this requires changes to the swift compiler and language itself and is probably a longer term goal. This PR has a much more limited scope not covered by the manifesto and can be available in the interim.

I'm interested in the thoughts of the dispatch team against this PR or on the evolution forum.

John