### PR TITLE
build: allow system-supplied libBlocksRuntime on systems other than Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,8 @@ endif()
 
 find_package(LibRT)
 
+find_package(BlocksRuntime QUIET)
+
 check_function_exists(_pthread_workqueue_init HAVE__PTHREAD_WORKQUEUE_INIT)
 check_function_exists(getprogname HAVE_GETPROGNAME)
 check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)

--- a/cmake/modules/FindBlocksRuntime.cmake
+++ b/cmake/modules/FindBlocksRuntime.cmake
@@ -45,4 +45,6 @@ if(BlocksRuntime_FOUND)
                             INTERFACE_INCLUDE_DIRECTORIES
                               ${BlocksRuntime_INCLUDE_DIR})
   endif()
+else()
+  set(BlocksRuntime_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src/BlocksRuntime")
 endif()

--- a/cmake/modules/FindBlocksRuntime.cmake
+++ b/cmake/modules/FindBlocksRuntime.cmake
@@ -45,6 +45,4 @@ if(BlocksRuntime_FOUND)
                             INTERFACE_INCLUDE_DIRECTORIES
                               ${BlocksRuntime_INCLUDE_DIR})
   endif()
-else()
-  set(BlocksRuntime_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src/BlocksRuntime")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+if(NOT BlocksRuntime_FOUND)
   add_subdirectory(BlocksRuntime)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,9 +78,6 @@ function(add_unit_test name)
     # to reduce probability of test failures due to machine load.
     target_compile_options(${name} PRIVATE -DLENIENT_DEADLINES=1)
   endif()
-  target_include_directories(${name}
-                             SYSTEM BEFORE PRIVATE
-                               "${BlocksRuntime_INCLUDE_DIR}")
   if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
     target_compile_options(${name} PRIVATE -Xclang -fblocks)
     target_compile_options(${name} PRIVATE /W3 -Wno-deprecated-declarations)


### PR DESCRIPTION
In the past, the GNUstep project has used the ability so link (a fairly ancient version of) libdispatch against a custom libBlocksRuntime in order to ensure interoperability with its Objective-C runtime (which bundles a BlocksRuntime implementation). It seems that this facility was removed in PR #396 in favour of a check on whether it's building for Darwin to decide whether the in-tree version should be built.
That seems accidental, given the stated purpose of that PR, so I would very much like to re-add that facility. I have now done this by re-adding the elided  `find_package(BlocksRuntime QUIET)` statement and deciding whether to build the in-tree version depending on `BlocksRuntime_FOUND` (also the same as prior to PR #396). I hope this is what's intended here. I've checked that this works on a Linux system both with and without a custom libBlocksRuntime.
Unfortunately, I couldn't convince libdispatch to build on my macOS machine – either with or without this change, so that is probably due to my lack of expertise. But it could very well be possible that building the in-tree libBlocksRuntime needs to be conditional on `NOT (CMAKE_SYSTEM_NAME STREQUAL Darwin OR BlocksRuntime_FOUND)`.

Additionally, yet relatedly, there was an extraneous `target_include_directories` directive in the CMakeLists.txt for the `tests/` subdirectory. The effect of that is already achieved by linking the  `BlocksRuntime::BlocksRuntime` target and it started tripping up things once switching back to `find_package()` for the runtime lib.

Please let me know what you think!

Thanks,

Niels