### PR TITLE
Make some preliminary porting changes.

### DIFF
--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -187,12 +187,16 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 		name = "hw.activecpu"; break;
 	}
 #elif defined(__FreeBSD__)
-	 (void)c; name = "kern.smp.cpus";
+	(void)c; name = "kern.smp.cpus";
+#elif defined(__OpenBSD__)
+	(void)c;
 #endif
 	if (name) {
 		size_t valsz = sizeof(val);
+#if !defined(__OpenBSD__)
 		r = sysctlbyname(name, &val, &valsz, NULL, 0);
 		(void)dispatch_assume_zero(r);
+#endif
 		dispatch_assert(valsz == sizeof(uint32_t));
 	} else {
 #if HAVE_SYSCONF && defined(_SC_NPROCESSORS_ONLN)

--- a/src/transform.c
+++ b/src/transform.c
@@ -26,7 +26,7 @@
 #include <endian.h>
 #define OSLittleEndian __LITTLE_ENDIAN
 #define OSBigEndian __BIG_ENDIAN
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #define OSLittleEndian _LITTLE_ENDIAN
 #define OSBigEndian _BIG_ENDIAN
@@ -35,7 +35,7 @@
 #define OSBigEndian 4321
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #define OSSwapLittleToHostInt16 le16toh
 #define OSSwapBigToHostInt16 be16toh
 #define OSSwapHostToLittleInt16 htole16

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -80,7 +80,7 @@ static void busythread(void *ignored)
 static void test_apply_contended(dispatch_queue_t dq)
 {
 	uint32_t activecpu;
-#ifdef __linux__
+#if defined(__linux__) || defined(__OpenBSD__)
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #elif defined(_WIN32)
 	SYSTEM_INFO si;

--- a/tests/dispatch_io_net.c
+++ b/tests/dispatch_io_net.c
@@ -55,7 +55,7 @@ extern char **environ;
 #endif
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(_WIN32)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(_WIN32) || defined(__OpenBSD__)
 #define _NSGetExecutablePath(ef,bs) (*(bs)=(size_t)snprintf(ef,*(bs),"%s",argv[0]),0)
 #endif
 

--- a/tests/dispatch_test.h
+++ b/tests/dispatch_test.h
@@ -21,7 +21,7 @@
 #include <stdbool.h>
 #include <dispatch/dispatch.h>
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <generic_unix_port.h>
 #elif defined(_WIN32)
 #include <generic_win_port.h>


### PR DESCRIPTION
These changes include:

  * hw_config.h: prevent referring to sysctlbyname on OpenBSD, as this
    is not available on all platforms.

  * transform.c: these stanzas referring to FreeBSD or Linux also apply
    to OpenBSD.

  * tests/dispatch_apply.c: stanza applying to Linux applies to OpenBSD
    and also tweak style for consistency.

  * tests/dispatch_io_net.c, tests/dispatch_test.h: stanzas applying to 
    FreeBSD also apply to OpenBSD.