### PR TITLE
Add missing DISPATCH_COCOA_COMPAT preprocessor symbol.

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -202,9 +202,11 @@ _dispatch_xref_dispose(dispatch_object_t dou)
 		_dispatch_mach_xref_dispose(dou._dm);
 		break;
 #endif
+#if DISPATCH_COCOA_COMPAT
 	case DISPATCH_QUEUE_RUNLOOP_TYPE:
 		_dispatch_runloop_queue_xref_dispose(dou._dl);
 		break;
+#endif
 	}
 	return _dispatch_release_tailcall(dou._os_obj);
 }


### PR DESCRIPTION
_dispatch_runloop_queue_xref_dispose is declared in src/queue_internal.h
but the declaration is hidden behind DISPATCH_COCOA_COMPAT. This means
the call to _dispatch_runloop_queue_xref_dispose must also be put behind
this preprocessor symbol.