### PR TITLE
[build] Silence `-Wvoid-pointer-to-int-cast`

### DIFF
--- a/cmake/modules/DispatchCompilerWarnings.cmake
+++ b/cmake/modules/DispatchCompilerWarnings.cmake
@@ -62,6 +62,7 @@ else()
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-unreachable-code-aggressive>)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-unused-macros>)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-used-but-marked-unused>)
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-void-pointer-to-int-cast>)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-vla>)
 
   if(CMAKE_SYSTEM_NAME STREQUAL Android)


### PR DESCRIPTION
libdispatch will fail to build with a newly introduced clang diagnostic
`pointer-to-int-cast`. libdispatch converts a void pointer to a
dispatch_invoke_flags_t (aka unsigned int) in a few places. Ideally we would not
be doing this, but this solution at least gets libdispatch building again
with a newer version of clang.