### PR TITLE
IO: match the signature for `DispatchIO` with `dispatch_io_create`

### DIFF
--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -67,7 +67,7 @@ extension DispatchIO {
 
 	public convenience init(
 		type: StreamType,
-		fileDescriptor: Int32,
+		fileDescriptor: dispatch_fd_t,
 		queue: DispatchQueue,
 		cleanupHandler: @escaping (_ error: Int32) -> Void)
 	{

--- a/src/swift/Private.swift
+++ b/src/swift/Private.swift
@@ -27,7 +27,7 @@ public func dispatch_queue_create_with_target(_ label: UnsafePointer<Int8>?, _ a
 }
 
 @available(*, unavailable, renamed:"DispatchIO.init(type:fileDescriptor:queue:cleanupHandler:)")
-public func dispatch_io_create(_ type: UInt, _ fd: Int32, _ queue: DispatchQueue, _ cleanup_handler: @escaping (Int32) -> Void) -> DispatchIO
+public func dispatch_io_create(_ type: UInt, _ fd: dispatch_fd_t, _ queue: DispatchQueue, _ cleanup_handler: @escaping (Int32) -> Void) -> DispatchIO
 {
 	fatalError()
 }

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -91,7 +91,7 @@ public class DispatchIO : DispatchObject {
 		return unsafeBitCast(__wrapped, to: dispatch_object_t.self)
 	}
 
-	internal init(__type: UInt, fd: Int32, queue: DispatchQueue,
+	internal init(__type: UInt, fd: dispatch_fd_t, queue: DispatchQueue,
 				  handler: @escaping (_ error: Int32) -> Void) {
 		__wrapped = dispatch_io_create(dispatch_io_type_t(__type), dispatch_fd_t(fd), queue.__wrapped, handler)
 	}


### PR DESCRIPTION
The `DispatchIO` constructor maps to `dispatch_io_create`.  The value on
Windows for the `fd` (which is actually a `HANDLE`) is being truncated
since `dispatch_fd_t` is actually `Int` not `Int32` on Windows.  Use the
`dispatch_fd_t` to ensure that the right size is always passed along.