### PR TITLE
[CMake] fix runpath for ELF platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,6 +155,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     "-Xlinker -alias_list -Xlinker ${PROJECT_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
 endif()
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  set_target_properties(dispatch PROPERTIES INSTALL_RPATH "$ORIGIN")
+endif()
+
 if(ENABLE_SWIFT)
   add_subdirectory(swift)
 endif()

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -59,4 +59,7 @@ if(NOT BUILD_SHARED_LIBS)
   install(TARGETS DispatchStubs
     EXPORT dispatchExports
     DESTINATION ${INSTALL_TARGET_DIR})
+elseif(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(swiftDispatch PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+  set_target_properties(swiftDispatch PROPERTIES INSTALL_RPATH "$ORIGIN")
 endif()


### PR DESCRIPTION
Remove the absolute path to the host stdlib for libswiftDispatch.so and add `$ORIGIN` to it and libdispatch.so.

Otherwise, you see the following in the current official release for linux:
```
> readelf -d swift-5.2.3-RELEASE-ubuntu18.04/usr/lib/swift/linux/lib*ispatch.so | ag "File:|runpath"
File: swift-5.2.3-RELEASE-ubuntu18.04/usr/lib/swift/linux/libdispatch.so
File: swift-5.2.3-RELEASE-ubuntu18.04/usr/lib/swift/linux/libswiftDispatch.so
0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.2-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux]
```