### PR TITLE
dispatch: use auto-reset event for dispatch queue

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -6560,7 +6560,7 @@ _dispatch_runloop_queue_handle_init(void *ctxt)
 	handle = fd;
 #elif defined(_WIN32)
 	HANDLE hEvent;
-	hEvent = CreateEventW(NULL, /*bManualReset=*/TRUE,
+	hEvent = CreateEventW(NULL, /*bManualReset=*/FALSE,
 		/*bInitialState=*/FALSE, NULL);
 	if (hEvent == NULL) {
 		DISPATCH_INTERNAL_CRASH(GetLastError(), "CreateEventW");


### PR DESCRIPTION
Use an auto-reset event for the dispatch queue on Windows.  On Linux,
`eventfd` is used, which is auto-reset unless `EFD_SEMAPHORE` is
specified.  This mirrors that behaviour.  The test suite continues to
pass after this change.