### PR TITLE
Modify headers so that GCC can use libdispatch

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -63,8 +63,13 @@
 #define DISPATCH_WARN_RESULT __attribute__((__warn_unused_result__))
 #define DISPATCH_MALLOC __attribute__((__malloc__))
 #define DISPATCH_ALWAYS_INLINE __attribute__((__always_inline__))
+#if __has_attribute(unavailable)
 #define DISPATCH_UNAVAILABLE __attribute__((__unavailable__))
 #define DISPATCH_UNAVAILABLE_MSG(msg) __attribute__((__unavailable__(msg)))
+#else
+#define DISPATCH_UNAVAILABLE
+#define DISPATCH_UNAVAILABLE_MSG(msg)
+#endif
 #elif defined(_MSC_VER)
 #define DISPATCH_NORETURN __declspec(noreturn)
 #define DISPATCH_NOTHROW __declspec(nothrow)

--- a/os/generic_unix_base.h
+++ b/os/generic_unix_base.h
@@ -55,6 +55,14 @@
 #define os_unlikely(x) OS_EXPECT(!!(x), 0)
 #endif
 
+#ifndef __has_feature
+#define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#endif
+
+#ifndef __has_extension
+#define __has_extension __has_feature // Compatibility with pre-3.0 compilers.
+#endif
+
 #if __has_feature(assume_nonnull)
 #define OS_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
 #define OS_ASSUME_NONNULL_END   _Pragma("clang assume_nonnull end")


### PR DESCRIPTION
GCC doesn't have serveral extensions that clang has. This is fine for building libdispatch shared library, but using libdispatch's with just the function based variants should have headers which GCC can use.