### PR TITLE
[5.3] Add modulemap for static compilation

### DIFF
--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -16,7 +16,17 @@ install(FILES
         DESTINATION
           "${INSTALL_DISPATCH_HEADERS_DIR}")
 if(ENABLE_SWIFT)
-  get_filename_component(MODULE_MAP module.modulemap REALPATH)
+  set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+  if(NOT BUILD_SHARED_LIBS)
+    set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}/generic_static")
+  endif()
+
+  get_filename_component(
+    MODULE_MAP
+    module.modulemap
+    REALPATH
+    BASE_DIR "${base_dir}")
+
   install(FILES
             ${MODULE_MAP}
           DESTINATION

--- a/dispatch/generic_static/module.modulemap
+++ b/dispatch/generic_static/module.modulemap
@@ -1,0 +1,19 @@
+module Dispatch {
+	requires blocks
+	export *
+	link "dispatch"
+	link "BlocksRuntime"
+	link "DispatchStubs"
+}
+
+module DispatchIntrospection [system] [extern_c] {
+	header "introspection.h"
+	export *
+}
+
+module CDispatch [system] [extern_c] {
+	umbrella header "dispatch.h"
+	export *
+	requires blocks
+	link "dispatch"
+}


### PR DESCRIPTION
When compiling statically, we have to link against DispatchStubs in addition to the other dependencies, so we are defining a separate modulemap for that.