### PR TITLE
[5.3][CMake] fix runpath for ELF platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,6 +155,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     "-Xlinker -alias_list -Xlinker ${PROJECT_SOURCE_DIR}/xcodeconfig/libdispatch.aliases")
 endif()
 
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  set_target_properties(dispatch PROPERTIES INSTALL_RPATH "$ORIGIN")
+endif()
+
 if(ENABLE_SWIFT)
   add_subdirectory(swift)
 endif()

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -59,4 +59,7 @@ if(NOT BUILD_SHARED_LIBS)
   install(TARGETS DispatchStubs
     EXPORT dispatchExports
     DESTINATION ${INSTALL_TARGET_DIR})
+elseif(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(swiftDispatch PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+  set_target_properties(swiftDispatch PROPERTIES INSTALL_RPATH "$ORIGIN")
 endif()


### PR DESCRIPTION
Remove the absolute path to the host stdlib for libswiftDispatch.so and add $ORIGIN to it and libdispatch.so.

It has been suggested to me by some Swift devs that this would be good to get in before the 5.3 release, a cherry-pick from #541. @compnerd, I can remove the `$ORIGIN` portions and just make this about removing the toolchain stdlib rpath if you prefer.

This should be completely safe for the 5.3 branch, as it's just removing an unused rpath and adding rpaths that are already used, in a more explicit way.