### PR TITLE
HAVE_MACH is unnecessary here.

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -961,7 +961,6 @@ _dispatch_continuation_get_function_symbol(dispatch_continuation_t dc)
 	return dc->dc_func;
 }
 
-#if HAVE_MACH
 void
 _dispatch_bug_kevent_client(const char *msg, const char *filter,
 		const char *operation, int err, uint64_t ident, uint64_t udata,
@@ -1005,7 +1004,6 @@ _dispatch_bug_kevent_client(const char *msg, const char *filter,
 				msg, strerror(err), err, udata, filter, ident, ident, func);
 	}
 }
-#endif // HAVE_MACH
 
 #if RDAR_49023449
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -475,12 +475,10 @@ void _dispatch_bug_mach_client(const char *msg, mach_msg_return_t kr);
 
 struct dispatch_unote_class_s;
 
-#if HAVE_MACH
 DISPATCH_NOINLINE DISPATCH_COLD
 void _dispatch_bug_kevent_client(const char *msg, const char *filter,
 		const char *operation, int err, uint64_t ident, uint64_t udata,
 		struct dispatch_unote_class_s *du);
-#endif // HAVE_MACH
 
 DISPATCH_NOINLINE DISPATCH_COLD
 void _dispatch_bug_kevent_vanished(struct dispatch_unote_class_s *du);


### PR DESCRIPTION
The kevent backend requires _dispatch_bug_kevent_client unconditionally.
We don't need to require this entire function require HAVE_MACH, just the
inner few that is already present behind this conditional.