### PR TITLE
fadvise need not be mandatory.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2308,7 +2308,7 @@ _dispatch_operation_advise(dispatch_operation_t op, size_t chunk_size)
 		default: (void)dispatch_assume_zero(err); break;
 	}
 #else
-#error "_dispatch_operation_advise not implemented on this platform"
+	(void)err;
 #endif // defined(F_RDADVISE)
 #endif // defined(_WIN32)
 }


### PR DESCRIPTION
It is just a hint, after all, so it is not an error if it is unavailable.