### PR TITLE
[android] Put in fixes for librt and armv7-a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,9 @@ if(__BUILTIN_TRAP)
   set(HAVE_NORETURN_BUILTIN_TRAP 1)
 endif()
 
-find_package(LibRT)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Android)
+  find_package(LibRT)
+endif()
 
 check_function_exists(_pthread_workqueue_init HAVE__PTHREAD_WORKQUEUE_INIT)
 check_function_exists(getprogname HAVE_GETPROGNAME)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,14 @@ function(add_unit_test name)
     target_compile_options(${name} PRIVATE -fblocks)
     target_compile_options(${name} PRIVATE -Wall -Wno-deprecated-declarations)
   endif()
+  # Without this flag, cross-compiling static test executables for Android armv7
+  # fails with the multiple definition errors seen in android/ndk#176, so I
+  # pulled in this workaround noted there. The tests build and run with this
+  # flag applied.
+  if(NOT BUILD_SHARED_LIBS AND CMAKE_SYSTEM_NAME STREQUAL Android AND
+     CMAKE_SYSTEM_PROCESSOR STREQUAL armv7-a)
+    target_link_options(${name} PRIVATE "LINKER:--allow-multiple-definition")
+  endif()
   target_link_libraries(${name}
                         PRIVATE
                           dispatch


### PR DESCRIPTION
Android doesn't have a separate librt, it's just part of libc. Also, the static build wasn't working for armv7-a, because the test executables wouldn't link with the multiple definition errors listed in android/ndk#176, so use the workaround given there.


I didn't have any problems when cross-compiling for 64-bit arches, but hit the first one because I happen to have an i686 libc package installed in Ubuntu and the armv7 build would try to use librt.so from that. The second libunwind issue has been around for awhile, and I worked around it before [by not building the tests for libdispatch](https://github.com/buttaface/swift-android-sdk/blob/main/swift-android-531.patch#L123), but this gets them to build and run.

@compnerd, let me know what you think.