### PR TITLE
Fix _libdispatch_tsd_cleanup signature.

### DIFF
--- a/src/shims/tsd.h
+++ b/src/shims/tsd.h
@@ -158,7 +158,7 @@ struct dispatch_tsd {
 extern _Thread_local struct dispatch_tsd __dispatch_tsd;
 
 extern void libdispatch_tsd_init(void);
-extern void _libdispatch_tsd_cleanup(void *ctx);
+extern void DISPATCH_TSD_DTOR_CC _libdispatch_tsd_cleanup(void *ctx);
 
 DISPATCH_ALWAYS_INLINE
 static inline struct dispatch_tsd *


### PR DESCRIPTION
Fixes the following error when building for Windows x86:

```
..\src\queue.c(7376,1): error: function declared 'stdcall' here was previously declared without calling convention
_libdispatch_tsd_cleanup(void *ctx)
^
..\src/shims/tsd.h(161,13): note: previous declaration is here
extern void _libdispatch_tsd_cleanup(void *ctx);
```

`DISPATCH_TSD_DTOR_CC` is part of the `_libdispatch_tsd_cleanup` signature in queue.c, but not in the external declaration in `tsd.h`. `DISPATCH_TSD_DTOR_CC` resolves to `__stdcall` on Windows.