### PR TITLE
Update man page for makeSignalSource

### DIFF
--- a/man/dispatch_source_create.3
+++ b/man/dispatch_source_create.3
@@ -447,7 +447,12 @@ safe interfaces defined in
 Furthermore, multiple observers of a given signal are supported; thus allowing
 applications and libraries to cooperate safely. However, a dispatch source
 .Em does not
-install a signal handler or otherwise alter the behavior of signal delivery.
+install a signal handler or otherwise alter the behavior of signal delivery
+on BSD systems. It does call
+.Fn sigaction
+on Linux, thus preventing any previous handler installed via
+.Fn sigaction
+to be called.
 Therefore, applications must ignore or at least catch any signal that terminates
 a process by default. For example, near the top of
 .Fn main :


### PR DESCRIPTION
The following test on Linux shows the doc was not up-to-date for Linux:
```
var newAction = sigaction()
newAction.sa_flags = SA_SIGINFO
sigemptyset(&newAction.sa_mask)
newAction.__sigaction_handler.sa_sigaction = { signal, siginfo, threadUserContext in
	print("got \(signal) from sigaction")
}
sigaction(15, &newAction, nil)
let s = DispatchSource.makeSignalSource(signal: 15)
s.setEventHandler{
	print("got \(s.data) signal 15 from dispatch")
}
s.activate()
usleep(5000)
kill(getpid(), 15)
sleep(1)
```

**Expected output**: `got signal` from both `sigaction` and `dispatch`.
**Actual output**: `got signal` from `dispatch` only.

If we run the test on macOS, we do get the signal from both sources.
If the dispatch source is not activated, we do get the signal from `sigaction` on Linux.

Tested on Docker, using the `swift:5.3.3` image and macOS 11.