### PR TITLE
shims: adjust the Windows path for Windows 11

### DIFF
--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -156,8 +156,14 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 			++dwProcessorPhysicalCount;
 			dwProcessorLogicalCount += __popcnt64(slpiCurrent->ProcessorMask);
 			break;
+#if defined(RelationProcessorDie)
+		case RelationProcessorDie:
+#endif
 		case RelationProcessorPackage:
 		case RelationNumaNode:
+#if defined(RelationNumaNodeEx)
+		case RelationNumaNodeEx:
+#endif
 		case RelationCache:
 		case RelationGroup:
 		case RelationAll:


### PR DESCRIPTION
The Windows 10 SDK Version 2104 (10.0.20348.0) which adds support for
Windows 11 introduces new enumerated values for the logical processor
configuration.  Only one of the two is documented at MSDN.

https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-logical_processor_relationship:
~~~
`RelationNumaNodeEx`

Introduced in TBD - Release Iron. Requests that the full affinity be
returned. Unlike the other relation types, `RelationNumaNodeEx` is not
used oninput. It is simply a request for `RelationNumaNode` with full
group information.
~~~

Treat this enumerated value as `RelationNodeNode`.  It is unclear what
the details of `RelationProcessorDie` is currently.  For now, we leave
that value ignored, though it is likely that we may have to address it
in the future once the value is explained.