### PR TITLE
[android] Update headers that were split in NDK 23

### DIFF
--- a/src/shims/atomic.h
+++ b/src/shims/atomic.h
@@ -35,7 +35,11 @@
 #if defined(__cplusplus)
 #define _Bool bool
 #endif
+#if defined(__ANDROID__) && __NDK_MAJOR__ >= 23
+#include <bits/stdatomic.h>
+#else
 #include <stdatomic.h>
+#endif
 
 #define memory_order_ordered    memory_order_seq_cst
 #define memory_order_dependency memory_order_acquire


### PR DESCRIPTION
NDK 23 split `stdatomic.h` up and that causes problems when invoked from C++ files, so use the new `bits/stdatomic.h` instead as a workaround, as seen in the test for aosp-mirror/platform_bionic@76e2b15.

[Building libdispatch for Android with the new NDK causes linkage issues in the headers](https://github.com/buttaface/swift-android-sdk/runs/3402803617?check_suite_focus=true#step:7:889), so I used this same workaround that can be seen in the C++ test for that Bionic commit that split the header up and libdispatch builds for Android again.

I don't know if there's a better way to fix these linkage issues, so let me know if there is.