### PR TITLE
shims: repair the build on Windows i686

### DIFF
--- a/src/shims/tsd.h
+++ b/src/shims/tsd.h
@@ -158,7 +158,7 @@ struct dispatch_tsd {
 extern _Thread_local struct dispatch_tsd __dispatch_tsd;
 
 extern void libdispatch_tsd_init(void);
-extern void _libdispatch_tsd_cleanup(void *ctx);
+extern void DISPATCH_TSD_DTOR_CC _libdispatch_tsd_cleanup(void *ctx);
 
 DISPATCH_ALWAYS_INLINE
 static inline struct dispatch_tsd *


### PR DESCRIPTION
The Windows i686 builds expect this function to use the stdcall calling
convention.  The implementation correctly decorates the function to do
so.  However, the declaration did not match, which caused a build
failure on windows i686.