### PR TITLE
shims: correct the check for newer SLPI enumerators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   include_directories(BEFORE SYSTEM ${DISPATCH_INCLUDES})
   dispatch_windows_lib_for_arch(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_LIBDIR)
   link_directories(${DISPATCH_LIBDIR})
+
+  include(CheckCSourceCompiles)
+  check_c_source_compiles([=[
+#include <Windows.h>
+int main(int argc, char *argv[]) {
+  switch ((LOGICAL_PROCESSOR_RELATIONSHIP)0) {
+  case RelationProcessorDie:
+  case RelationNumaNodeEx:
+    return 0;
+  }
+  return 0;
+}
+]=] DISPATCH_HAVE_EXTENDED_SLPI_20348)
+  if(DISPATCH_HAVE_EXTENDED_SLPI_20348)
+    add_compile_definitions(DISPATCH_HAVE_EXTENDED_SLPI_20348)
+  endif()
 endif()
 
 set(CMAKE_C_STANDARD 11)

--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -156,8 +156,14 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 			++dwProcessorPhysicalCount;
 			dwProcessorLogicalCount += __popcnt64(slpiCurrent->ProcessorMask);
 			break;
+#if defined(DISPATCH_HAVE_EXTENDED_SLPI_20348)
+		case RelationProcessorDie:
+#endif
 		case RelationProcessorPackage:
 		case RelationNumaNode:
+#if defined(DISPATCH_HAVE_EXTENDED_SLPI_20348)
+		case RelationNumaNodeEx:
+#endif
 		case RelationCache:
 		case RelationGroup:
 		case RelationAll:


### PR DESCRIPTION
The previous check did not work as the enumertors are not defines but
rather a proper enumerator.  This adds a build time check for the
support and conditionalises the compilation.