### PR TITLE
shims: adjust the SLPI enumeration for Windows 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,20 @@ int main(int argc, char *argv[]) {
   if(DISPATCH_HAVE_EXTENDED_SLPI_20348)
     add_compile_definitions(DISPATCH_HAVE_EXTENDED_SLPI_20348)
   endif()
+
+  check_c_source_compiles([=[
+#include <Windows.h>
+int main(int argc, char *argv[]) {
+  switch ((LOGICAL_PROCESSOR_RELATIONSHIP)0) {
+  case RelationProcessorModule:
+    return 0;
+  }
+  return 0;
+}
+]=] DISPATCH_HAVE_EXTENDED_SLPI_22000)
+  if(DISPATCH_HAVE_EXTENDED_SLPI_22000)
+    add_compile_definitions(DISPATCH_HAVE_EXTENDED_SLPI_22000)
+  endif()
 endif()
 
 set(CMAKE_C_STANDARD 11)

--- a/src/shims/hw_config.h
+++ b/src/shims/hw_config.h
@@ -166,6 +166,9 @@ _dispatch_hw_get_config(_dispatch_hw_config_t c)
 #endif
 		case RelationCache:
 		case RelationGroup:
+#if defined(DISPATCH_HAVE_EXTENDED_SLPI_22000)
+		case RelationProcessorModule:
+#endif
 		case RelationAll:
 			break;
 		}


### PR DESCRIPTION
It seems that `RelationProcessorModule` is entirely undocumented but
listed as an enumerated value in the `LOGICAL_PROCESSOR_RELATIONSHIP`
enumeration.  Update for the 10.0.22000.0 SDK (Windows 11).