### PR TITLE
Added no-op for variable to avoid a warning under Linux

### DIFF
--- a/tests/bsdtestharness.c
+++ b/tests/bsdtestharness.c
@@ -152,6 +152,7 @@ main(int argc, char *argv[])
 	assert(pid > 0);
 
 #if defined(__linux__)
+      (void)to;
 	int status;
 	struct rusage usage;
 	struct timeval tv_stop, tv_wall;


### PR DESCRIPTION
Using Clang 13, the switches ` -Werror -Wunused-but-set-variable` causes an error because the `to` variable is set, but under Linux it is never used, causing the build to fail. This PR performs a no-op on the variable in the __linux__ block to avoid this issue.