### PR TITLE
Fix unused variable errors

### DIFF
--- a/tests/bsdtestharness.c
+++ b/tests/bsdtestharness.c
@@ -72,13 +72,6 @@ main(int argc, char *argv[])
 	assert(res == 0);
 #endif
 
-	uint64_t to = 0;
-	char *tos = getenv("BSDTEST_TIMEOUT");
-	if (tos) {
-		to = strtoul(tos, NULL, 0);
-		to *= NSEC_PER_SEC;
-	}
-
 #ifdef __APPLE__
 	char *arch = getenv("BSDTEST_ARCH");
 	if (arch) {
@@ -244,6 +237,13 @@ main(int argc, char *argv[])
 		exit((WIFEXITED(status) && WEXITSTATUS(status)) || WIFSIGNALED(status));
 	});
 	dispatch_resume(tmp_ds);
+
+	uint64_t to = 0;
+	char *tos = getenv("BSDTEST_TIMEOUT");
+	if (tos) {
+		to = strtoul(tos, NULL, 0);
+		to *= NSEC_PER_SEC;
+	}
 
 	if (!to) {
 #if TARGET_OS_EMBEDDED

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -65,6 +65,7 @@ static void busythread(void *ignored)
 		j += i;
 		i += 1;
 	}
+	(void)j;
 
 	OSAtomicIncrement32(&busy_threads_finished);
 }


### PR DESCRIPTION
There are build errors due to unused variables in two of the tests.
The build system builds these with `-Werror` so instead of a warning, it is a hard failure.

This is affecting the swift rebranch work, which has a newer clang that emits warnings in more cases, which is why we are seeing this now.

Failing build log:
https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-incremental-RA-linux-ubuntu-18_04/23/console