### PR TITLE
Replace bzero with memset

### DIFF
--- a/src/firehose/firehose_buffer.c
+++ b/src/firehose/firehose_buffer.c
@@ -873,9 +873,9 @@ firehose_buffer_stream_chunk_install(firehose_buffer_t fb,
 			// ring and it is dirty, when crawling the chunk, we don't see
 			// remnants of other tracepoints.
 			//
-			// We only do that when the fc_pos is non zero, because zero means
-			// we just faulted the chunk, and the kernel already bzero-ed it.
-			bzero(fc->fc_data, sizeof(fc->fc_data));
+			// We only do that when the fc_pos is non-zero, because zero means
+			// we just faulted the chunk, and the kernel already zeroed it.
+			memset(fc->fc_data, 0, sizeof(fc->fc_data));
 		}
 		dispatch_compiler_barrier();
 

--- a/src/shims.h
+++ b/src/shims.h
@@ -280,7 +280,7 @@ _dispatch_mempcpy(void *ptr, const void *data, size_t len)
 		void *a[(s)/sizeof(void*) ? (s)/sizeof(void*) : 1]; \
 		a[0] = pthread_get_stackaddr_np(pthread_self()); \
 		void* volatile const p = (void*)&a[1]; /* <rdar://32604885> */ \
-		bzero((void*)p, (size_t)(a[0] - (void*)&a[1])); \
+		memset((void*)p, 0, (size_t)(a[0] - (void*)&a[1])); \
 	} while (0)
 #else
 #define _dispatch_clear_stack(s)

--- a/src/shims/generic_win_stubs.h
+++ b/src/shims/generic_win_stubs.h
@@ -32,8 +32,6 @@ typedef __typeof__(_Generic((__SIZE_TYPE__)0,                                  \
 
 #define O_NONBLOCK 04000
 
-#define bzero(ptr,len) memset((ptr), 0, (len))
-
 // Report when an unported code path executes.
 #define WIN_PORT_ERROR() \
 		_RPTF1(_CRT_ASSERT, "WIN_PORT_ERROR in %s", __FUNCTION__)

--- a/src/voucher.c
+++ b/src/voucher.c
@@ -953,7 +953,7 @@ mach_voucher_persona_for_originator(uid_t persona_id,
 	mach_voucher_attr_recipe_t bank_modify_recipe =
 			(mach_voucher_attr_recipe_t)alloca(bank_modify_recipe_size);
 
-	bzero((void *)bank_modify_recipe, bank_modify_recipe_size);
+	memset((void *)bank_modify_recipe, 0, bank_modify_recipe_size);
 
 	bank_modify_recipe[0] = (mach_voucher_attr_recipe_data_t){
 		.key = MACH_VOUCHER_ATTR_KEY_BANK,
@@ -1700,7 +1700,7 @@ voucher_kvoucher_debug(mach_port_t task, mach_port_name_t voucher, char *buf,
 		size_t bufsiz, size_t offset, char *prefix, size_t max_hex_data)
 {
 	uint8_t voucher_contents[VOUCHER_CONTENTS_SIZE];
-	bzero(voucher_contents, VOUCHER_CONTENTS_SIZE);
+	memset(voucher_contents, 0, VOUCHER_CONTENTS_SIZE);
 	size_t recipe_size = VOUCHER_CONTENTS_SIZE;
 	unsigned v_kobject = 0;
 	unsigned v_kotype = 0;

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -163,7 +163,7 @@ main(void)
 			if (!p) {
 				break;
 			}
-			bzero(p, ALLOC_SIZE);
+			memset(p, 0, ALLOC_SIZE);
 			pages[page_count] = p;
 			if (!(OSAtomicIncrement32Barrier(&page_count) % interval)) {
 				log_msg("Allocated %ldMB\n", pg2mb(page_count));


### PR DESCRIPTION
bzero is deprecated ever since 2008, and having to define it for Windows when we can use memset directly is also unnecessary. Let us replace it with memset instead.