### PR TITLE
event: support workqueue monitoring on Windows

### DIFF
--- a/src/event/workqueue_internal.h
+++ b/src/event/workqueue_internal.h
@@ -30,7 +30,7 @@
 void _dispatch_workq_worker_register(dispatch_queue_global_t root_q);
 void _dispatch_workq_worker_unregister(dispatch_queue_global_t root_q);
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
 #define HAVE_DISPATCH_WORKQ_MONITORING 1
 #else
 #define HAVE_DISPATCH_WORKQ_MONITORING 0


### PR DESCRIPTION
This enables workqueue monitoring on Windows to allow for overcommitting
threads if necessary.  We use a combination of WCT (wait chain tracing)
- to determine if there is an object being waited upon - and IO checking
- to determine if there is pending IO - to identify threads which are
executing workloads.  If no threads are executing workloads, then we may
be in a starvation state and will initialize new threads.  This should
fix the issue that has been previously reported with SPM hangs.

This is non-portable and ideally we would have an alternative approach
to tracking thread state, but this should at least unblock the current
situation.