### PR TITLE
dispatch: remove stray semicolon (NFC

### DIFF
--- a/dispatch/source.h
+++ b/dispatch/source.h
@@ -54,7 +54,7 @@ DISPATCH_ASSUME_NONNULL_BEGIN
  * Dispatch sources are used to automatically submit event handler blocks to
  * dispatch queues in response to external events.
  */
-DISPATCH_SOURCE_DECL(dispatch_source);
+DISPATCH_SOURCE_DECL(dispatch_source)
 
 __BEGIN_DECLS
 


### PR DESCRIPTION
This cleans up a stray semicolon to allow building with `-Werror=c++98-compat-extra-semi` which is enabled by default in some versions of clang and produces an annoying number of diagnostics when building Swift.