### PR TITLE
Fix possible crash in _dispatch_wait_for_enqueuer on Android armeabi-v7a

### DIFF
--- a/src/shims/yield.c
+++ b/src/shims/yield.c
@@ -36,7 +36,7 @@ void *
 _dispatch_wait_for_enqueuer(void **ptr)
 {
 #if !DISPATCH_HW_CONFIG_UP
-#if defined(__arm__) || defined(__arm64__)
+#if (defined(__arm__) && defined(__APPLE__)) || defined(__arm64__)
 	int spins = DISPATCH_WAIT_SPINS_WFE;
 	void *value;
 	while (unlikely(spins-- > 0)) {


### PR DESCRIPTION
Caused by `__builtin_arm_wfe()` sometimes causing a `SIGILL`.

For details please see https://bugs.swift.org/browse/SR-15166.