### PR TITLE
Add necessary #include for PATH_MAX on Linux

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -24,6 +24,9 @@
 // NOTE: this file must not contain any atomic operations
 
 #include "internal.h"
+#if __linux__
+#include <linux/limits.h> // for PATH_MAX
+#endif
 
 #if HAVE_MACH
 #include "protocolServer.h"


### PR DESCRIPTION
Builds fail on some linux systems, because none of the included headers imply that `<linux/limits.h>` was included.