### PR TITLE
[Win32] Initialize Windows Runtime on queue threads

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -6264,8 +6264,13 @@ _dispatch_worker_thread(void *context)
 static unsigned WINAPI
 _dispatch_worker_thread_thunk(LPVOID lpParameter)
 {
-  _dispatch_worker_thread(lpParameter);
-  return 0;
+	HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
+	if (FAILED(hr)) {
+		_dispatch_client_assert_fail("Error %ld initializing Windows Runtime", hr);
+	}
+	_dispatch_worker_thread(lpParameter);
+	CoUninitialize();
+	return 0;
 }
 #endif // defined(_WIN32)
 #endif // DISPATCH_USE_PTHREAD_POOL


### PR DESCRIPTION
On Windows, all threads that want to use Windows Runtime or COM components must be initialized with a call to [CoInitializeEx()](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex) or the slightly more modern [RoInitialize()](https://docs.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roinitialize) (same as `Windows::Foundation::Initialize`).

This change initializes all libdispatch threads so it’s possible to use COM and Windows Runtime APIs.