### PR TITLE
Skip unneeded check if last_locked is 0

### DIFF
--- a/src/allocator.c
+++ b/src/allocator.c
@@ -542,15 +542,15 @@ _dispatch_alloc_maybe_madvise_page(dispatch_continuation_t c)
 	}
 	// They are all unallocated, so we could madvise the page. Try to
 	// take ownership of them all.
-	int last_locked = 0;
-	do {
+	unsigned int last_locked;
+	for (last_locked = 0; last_locked < BITMAPS_PER_PAGE; last_locked++) {
 		if (!os_atomic_cmpxchg(&page_bitmaps[last_locked], BITMAP_C(0),
 				BITMAP_ALL_ONES, relaxed)) {
 			// We didn't get one; since there is a cont allocated in
 			// the page, we can't madvise. Give up and unlock all.
 			goto unlock;
 		}
-	} while (++last_locked < (signed)BITMAPS_PER_PAGE);
+	}
 #if DISPATCH_DEBUG
 	//fprintf(stderr, "%s: madvised page %p for cont %p (next = %p), "
 	//		"[%u+1]=%u bitmaps at %p\n", __func__, page, c, c->do_next,
@@ -563,10 +563,10 @@ _dispatch_alloc_maybe_madvise_page(dispatch_continuation_t c)
 			MADV_FREE));
 
 unlock:
-	while (last_locked > 1) {
-		page_bitmaps[--last_locked] = BITMAP_C(0);
-	}
 	if (last_locked) {
+		while (last_locked > 1) {
+			page_bitmaps[--last_locked] = BITMAP_C(0);
+		}
 		os_atomic_store(&page_bitmaps[0], BITMAP_C(0), relaxed);
 	}
 	return;


### PR DESCRIPTION
It will be be checked anyway, and redundant checks mean more points of failure.