### PR TITLE
swift: repair the Windows x86 build

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -40,8 +40,12 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-#if os(Windows) && (arch(arm64) || arch(x86_64))
+#if os(Windows)
+#if arch(arm64) || arch(x86_64)
 		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
+#else
+		let flags = dispatch_block_flags_t(UInt(flags.rawValue))
+#endif
 #else
 		let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
 #endif
@@ -52,8 +56,12 @@ public class DispatchWorkItem {
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
-#if os(Windows) && (arch(arm64) || arch(x86_64))
+#if os(Windows)
+#if arch(arm64) || arch(x86_64)
 		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
+#else
+		let flags = dispatch_block_flags_t(UInt(flags.rawValue))
+#endif
 #else
 		let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
 #endif


### PR DESCRIPTION
For some reason `numericCast` does not permit casting the flags value:

~~~
S:\SourceCache\swift-corelibs-libdispatch\src\swift\Block.swift:46:39: error: global function 'numericCast' requires that 'dispatch_block_flags_t' conform to 'BinaryInteger'
                                                                                   let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
                                                                                             ^
Swift.numericCast:1:24: note: where 'U' = 'dispatch_block_flags_t'
@inlinable public func numericCast<T, U>(_ x: T) -> U where T : BinaryInteger, U : BinaryInteger
                       ^
S:\SourceCache\swift-corelibs-libdispatch\src\swift\Block.swift:46:39: note: did you mean to use '.rawValue'?
                           let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
                                                               ^
                                                                           .rawValue
~~~