### PR TITLE
swift: remove Windows special case in `Block.swift`

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -40,15 +40,7 @@ public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
 
 	public init(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], block: @escaping @convention(block) () -> ()) {
-#if os(Windows)
-#if arch(arm64) || arch(x86_64)
-		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
-#else
-		let flags = dispatch_block_flags_t(UInt(flags.rawValue))
-#endif
-#else
-		let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
-#endif
+		let flags: dispatch_block_flags_t = dispatch_block_flags_t(CUnsignedLong(flags.rawValue))
 		_block =  dispatch_block_create_with_qos_class(flags,
 			qos.qosClass.rawValue.rawValue, Int32(qos.relativePriority), block)
 	}
@@ -56,15 +48,7 @@ public class DispatchWorkItem {
 	// Used by DispatchQueue.synchronously<T> to provide a path through
 	// dispatch_block_t, as we know the lifetime of the block in question.
 	internal init(flags: DispatchWorkItemFlags = [], noescapeBlock: () -> ()) {
-#if os(Windows)
-#if arch(arm64) || arch(x86_64)
-		let flags = dispatch_block_flags_t(UInt32(flags.rawValue))
-#else
-		let flags = dispatch_block_flags_t(UInt(flags.rawValue))
-#endif
-#else
-		let flags: dispatch_block_flags_t = numericCast(flags.rawValue)
-#endif
+		let flags: dispatch_block_flags_t = dispatch_block_flags_t(CUnsignedLong(flags.rawValue))
 		_block = _swift_dispatch_block_create_noescape(flags, noescapeBlock)
 	}
 


### PR DESCRIPTION
`DISPATCH_ENUM` will use a typed enum which creates a typedef to an
elaborated type.  This fails to be imported into Swift as a numeric
type.  Explicitly convert the `numericCast`'ed value from the Swift
`OptionSet` to the `dispatch_block_flags_t` as a portable alternate
spelling.  This allows us to continue to import the enum as a typed
value.

Thanks to @beccadax for the pointer that this pattern may not work on
Darwin (which it does not!) and the suggestion for the explicit type
conversion!