### PR TITLE
Fix a number of warnings when building on Windows

### DIFF
--- a/src/event/event.c
+++ b/src/event/event.c
@@ -766,9 +766,9 @@ _dispatch_timer_heap_update(dispatch_timer_heap_t dth,
 #pragma mark timer unote
 
 #define _dispatch_timer_du_debug(what, du) \
-		_dispatch_debug("kevent-source[%p]: %s kevent[%p] { ident = 0x%x }", \
+		_dispatch_debug("kevent-source[%p]: %s kevent[%p] { ident = 0x%llx }", \
 				_dispatch_wref2ptr((du)->du_owner_wref), what, \
-				(du), (du)->du_ident)
+				(du), (unsigned long long)((du)->du_ident))
 
 DISPATCH_ALWAYS_INLINE
 static inline unsigned int

--- a/src/event/workqueue.c
+++ b/src/event/workqueue.c
@@ -226,7 +226,7 @@ _dispatch_workq_count_runnable_workers(dispatch_workq_monitor_t mon)
 		// and Socket IO, but it is unclear if that includes normal IO.
 		HANDLE hThread = OpenThread(THREAD_QUERY_INFORMATION, FALSE, tid);
 		if (hThread == NULL) {
-			_dispatch_debug("workq: unable to open thread %u: %u", tid, GetLastError());
+			_dispatch_debug("workq: unable to open thread %u: %lu", tid, GetLastError());
 			continue;
 		}
 

--- a/src/init.c
+++ b/src/init.c
@@ -931,14 +931,15 @@ _dispatch_fault(const char *reason, const char *fmt, ...)
 	})
 
 void
-_dispatch_bug(size_t line, long val)
+_dispatch_bug(size_t line, intptr_t val)
 {
 	dispatch_once_f(&_dispatch_build_pred, NULL, _dispatch_build_init);
 
 	if (_dispatch_bug_log_is_repeated()) return;
 
-	_dispatch_log("BUG in libdispatch: %s - %lu - 0x%lx",
-			_dispatch_build, (unsigned long)line, val);
+	_dispatch_log("BUG in libdispatch: %s - %lu - 0x%llx",
+			_dispatch_build, (unsigned long)line,
+			(unsigned long long)(uintptr_t)val);
 }
 
 #if HAVE_MACH
@@ -1066,7 +1067,7 @@ _dispatch_bug_deprecated(const char *msg)
 }
 
 void
-_dispatch_abort(size_t line, long val)
+_dispatch_abort(size_t line, intptr_t val)
 {
 	_dispatch_bug(line, val);
 	abort();
@@ -1150,7 +1151,7 @@ _dispatch_logv_init(void *context DISPATCH_UNUSED)
 					szProgramName, GetCurrentProcessId(), tv.tv_sec,
 					(int)tv.tv_usec);
 			if (len > 0) {
-				len = MIN(len, sizeof(szMessage) - 1);
+				len = MIN(len, (int)sizeof(szMessage) - 1);
 				_write(dispatch_logfile, szMessage, len);
 				_write(dispatch_logfile, "\n", 1);
 			}

--- a/src/internal.h
+++ b/src/internal.h
@@ -466,7 +466,7 @@ DISPATCH_EXPORT DISPATCH_NOTHROW void dispatch_atfork_child(void);
 extern uint8_t _dispatch_mode;
 
 DISPATCH_EXPORT DISPATCH_NOINLINE DISPATCH_COLD
-void _dispatch_bug(size_t line, long val);
+void _dispatch_bug(size_t line, intptr_t val);
 
 #if HAVE_MACH
 DISPATCH_NOINLINE DISPATCH_COLD
@@ -489,7 +489,7 @@ DISPATCH_NOINLINE DISPATCH_COLD
 void _dispatch_bug_deprecated(const char *msg);
 
 DISPATCH_NOINLINE DISPATCH_NORETURN DISPATCH_COLD
-void _dispatch_abort(size_t line, long val);
+void _dispatch_abort(size_t line, intptr_t val);
 
 #if !defined(DISPATCH_USE_OS_DEBUG_LOG) && DISPATCH_DEBUG
 #if __has_include(<os/debug_private.h>)
@@ -549,11 +549,11 @@ void _dispatch_log(const char *msg, ...);
  */
 DISPATCH_ALWAYS_INLINE
 static inline void
-_dispatch_assert(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(!e)
+_dispatch_assert(intptr_t e, size_t line) DISPATCH_STATIC_ASSERT_IF(!e)
 {
 	if (unlikely(DISPATCH_DEBUG && !e)) _dispatch_abort(line, e);
 }
-#define dispatch_assert(e) _dispatch_assert((long)(e), __LINE__)
+#define dispatch_assert(e) _dispatch_assert((intptr_t)(e), __LINE__)
 
 /*
  * A lot of API return zero upon success and not-zero on fail. Let's capture
@@ -561,11 +561,11 @@ _dispatch_assert(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(!e)
  */
 DISPATCH_ALWAYS_INLINE
 static inline void
-_dispatch_assert_zero(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(e)
+_dispatch_assert_zero(intptr_t e, size_t line) DISPATCH_STATIC_ASSERT_IF(e)
 {
 	if (unlikely(DISPATCH_DEBUG && e)) _dispatch_abort(line, e);
 }
-#define dispatch_assert_zero(e) _dispatch_assert_zero((long)(e), __LINE__)
+#define dispatch_assert_zero(e) _dispatch_assert_zero((intptr_t)(e), __LINE__)
 
 /*
  * For reporting bugs or impedance mismatches between libdispatch and external
@@ -575,12 +575,12 @@ _dispatch_assert_zero(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(e)
  */
 DISPATCH_ALWAYS_INLINE
 static inline void
-_dispatch_assume(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(!e)
+_dispatch_assume(intptr_t e, size_t line) DISPATCH_STATIC_ASSERT_IF(!e)
 {
 	if (unlikely(!e)) _dispatch_bug(line, e);
 }
 #define dispatch_assume(e) \
-		({ __typeof__(e) _e = (e); _dispatch_assume((long)_e, __LINE__); _e; })
+		({ __typeof__(e) _e = (e); _dispatch_assume((intptr_t)_e, __LINE__); _e; })
 
 /*
  * A lot of API return zero upon success and not-zero on fail. Let's capture
@@ -588,12 +588,12 @@ _dispatch_assume(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(!e)
  */
 DISPATCH_ALWAYS_INLINE
 static inline void
-_dispatch_assume_zero(long e, size_t line) DISPATCH_STATIC_ASSERT_IF(e)
+_dispatch_assume_zero(intptr_t e, size_t line) DISPATCH_STATIC_ASSERT_IF(e)
 {
 	if (unlikely(e)) _dispatch_bug(line, e);
 }
 #define dispatch_assume_zero(e) \
-		({ __typeof__(e) _e = (e); _dispatch_assume_zero((long)_e, __LINE__); _e; })
+		({ __typeof__(e) _e = (e); _dispatch_assume_zero((intptr_t)_e, __LINE__); _e; })
 
 /* Make sure the debug statments don't get too stale */
 #define _dispatch_debug(x, args...) do { \

--- a/src/queue.c
+++ b/src/queue.c
@@ -773,7 +773,7 @@ _dispatch_async_redirect_invoke(dispatch_continuation_t dc,
 {
 	dispatch_thread_frame_s dtf;
 	struct dispatch_continuation_s *other_dc = dc->dc_other;
-	dispatch_invoke_flags_t ctxt_flags = (dispatch_invoke_flags_t)dc->dc_ctxt;
+	dispatch_invoke_flags_t ctxt_flags = (dispatch_invoke_flags_t)(uintptr_t)dc->dc_ctxt;
 	// if we went through _dispatch_root_queue_push_override,
 	// the "right" root queue was stuffed into dc_func
 	dispatch_queue_global_t assumed_rq = (dispatch_queue_global_t)dc->dc_func;
@@ -7013,6 +7013,7 @@ _dispatch_sig_thread(void *ctxt DISPATCH_UNUSED)
 	_dispatch_clear_stack(0);
 #if defined(_WIN32)
 	Sleep(INFINITE);
+	__builtin_unreachable();
 #else
 	_dispatch_sigsuspend();
 #endif

--- a/src/shims/time.h
+++ b/src/shims/time.h
@@ -263,7 +263,7 @@ _dispatch_time_to_clock_and_value(dispatch_time_t time,
 		if (time & DISPATCH_WALLTIME_MASK) {
 			// Wall time (value 11 in bits 63, 62)
 			*clock = DISPATCH_CLOCK_WALL;
-			actual_value = time == DISPATCH_WALLTIME_NOW ?
+			actual_value = time == (uint64_t)DISPATCH_WALLTIME_NOW ?
 					_dispatch_get_nanoseconds() : (uint64_t)-time;
 		} else {
 			// Continuous time (value 10 in bits 63, 62).

--- a/src/source.c
+++ b/src/source.c
@@ -1398,11 +1398,12 @@ _dispatch_source_debug_attr(dispatch_source_t ds, char* buf, size_t bufsiz)
 	dispatch_source_refs_t dr = ds->ds_refs;
 	dispatch_queue_flags_t dqf = _dispatch_queue_atomic_flags(ds);
 	dispatch_unote_state_t du_state = _dispatch_unote_state(dr);
-	return dsnprintf(buf, bufsiz, "target = %s[%p], ident = 0x%x, "
+	return dsnprintf(buf, bufsiz, "target = %s[%p], ident = 0x%llx, "
 			"mask = 0x%x, pending_data = 0x%llx, registered = %d, "
 			"armed = %d, %s%s%s",
 			target && target->dq_label ? target->dq_label : "", target,
-			dr->du_ident, dr->du_fflags, (unsigned long long)dr->ds_pending_data,
+			(unsigned long long)dr->du_ident, dr->du_fflags,
+			(unsigned long long)dr->ds_pending_data,
 			_du_state_registered(du_state), _du_state_armed(du_state),
 			(dqf & DSF_CANCELED) ? "cancelled, " : "",
 			(dqf & DSF_NEEDS_EVENT) ? "needs-event, " : "",


### PR DESCRIPTION
This PR fixes a number of warnings when building on Windows.

A common one involves the use of `dispatch_assert()` and related macros. Passing a pointer to these macros produces a narrowing conversion on Windows because `long` is 32 bits. This change uses `intptr_t` instead.

The following warnings are also resolved:

```
S:\SourceCache\swift-corelibs-libdispatch\src/shims/time.h(266,24): warning: comparison of integers of different signs: 'dispatch_time_t' (aka 'unsigned long long') and 'int' [-Wsign-compare]
                        actual_value = time == DISPATCH_WALLTIME_NOW ?
                                       ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~
S:\SourceCache\swift-corelibs-libdispatch\src\init.c(1153,11): warning: comparison of integers of different signs: 'int' and 'unsigned long long' [-Wsign-compare]
                                len = MIN(len, sizeof(szMessage) - 1);
                                      ^   ~~~  ~~~~~~~~~~~~~~~~~~~~~
S:\SourceCache\swift-corelibs-libdispatch\src\source.c(1405,4): warning: format specifies type 'unsigned int' but the argument has type 'dispatch_unote_ident_t' (aka 'unsigned long long') [-Wformat]
                        dr->du_ident, dr->du_fflags, (unsigned long long)dr->ds_pending_data,
                        ^~~~~~~~~~~~
S:\SourceCache\swift-corelibs-libdispatch\src\queue.c(776,39): warning: cast to smaller integer type 'dispatch_invoke_flags_t' from 'void *' [-Wvoid-pointer-to-enum-cast]
        dispatch_invoke_flags_t ctxt_flags = (dispatch_invoke_flags_t)dc->dc_ctxt;
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
S:\SourceCache\swift-corelibs-libdispatch\src\queue.c(7019,1): warning: function declared 'noreturn' should not return [-Winvalid-noreturn]
}
^
                                            ^~~~~~~~~
S:\SourceCache\swift-corelibs-libdispatch\src\event\event.c(801,2): warning: format specifies type 'unsigned int' but the argument has type 'dispatch_unote_ident_t' (aka 'unsigned long long') [-Wformat]
        _dispatch_timer_du_debug("disarmed", dt);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
S:\SourceCache\swift-corelibs-libdispatch\src\event\workqueue.c(229,59): warning: format specifies type 'unsigned int' but the argument has type 'dispatch_tid' (aka 'unsigned long') [-Wformat]
                        _dispatch_debug("workq: unable to open thread %u: %u", tid, GetLastError());
                                                                      ~~       ^~~
                                                                      %lu
```