### PR TITLE
Temporarily disable unused-but-set-variable until it's fixed in Clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+# Remove once underlying clang warning is fixed (rdar://93596069)
+set_source_files_properties(shims/yield.c PROPERTIES COMPILE_FLAGS -Wno-error=unused-but-set-variable)
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   add_subdirectory(BlocksRuntime)
 endif()


### PR DESCRIPTION
`_dispatch_preemption_yield(++spins)` expands to `(void)++spins;` on
various platforms. A recent Clang change updated the
`unused-but-set-variable` warning to skip counting operators as a use,
but it ignores `(void)`. Disable the error until that's fixed.