### PR TITLE
Make makefile more verbose

### DIFF
--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -16,6 +16,9 @@ install(FILES
         DESTINATION
           "${INSTALL_DISPATCH_HEADERS_DIR}")
 if(ENABLE_SWIFT)
+  # NOTE(etcwilde) need to see more output to find a flaky failing modulemap copy
+  set(CMAKE_VERBOSE_MAKEFILE YES)
+
   set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}")
   if(NOT BUILD_SHARED_LIBS)
     set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}/generic_static")


### PR DESCRIPTION
We have a flaky modulemap file that is failing to get copied and we
don't know why. It could be racing with the static libdispatch build, or
it could be something else.

This is all we have to go on at the moment:

[8/30][ 26%][0.595s] Generating /home/build-user/swift-corelibs-libdispatch/dispatch/module.modulemap, /home/build-user/swift-corelibs-libdispatch/private/module.modulemap
FAILED: /home/build-user/swift-corelibs-libdispatch/dispatch/module.modulemap /home/build-user/swift-corelibs-libdispatch/private/module.modulemap

```sh
cd home/build-user/build/buildbot_linux/swift-linux-aarch64/libdispatch-linux-aarch64-static-prefix/src/libdispatch-linux-aarch64-static-build && \
  /home/build-user/build/cmake-linux-aarch64/bin/cmake \
  -E copy_if_different \
  /home/build-user/swift-corelibs-libdispatch/dispatch/generic/module.modulemap \
  /home/build-user/swift-corelibs-libdispatch/dispatch/module.modulemap && \
  /home/build-user/build/cmake-linux-aarch64/bin/cmake \
  -E copy_if_different \
  /home/build-user/swift-corelibs-libdispatch/private/generic/module.modulemap \
  /home/build-user/swift-corelibs-libdispatch/private/module.modulemap
```


Error copying file (if different) from "/home/build-user/swift-corelibs-libdispatch/dispatch/generic/module.modulemap" to "/home/build-user/swift-corelibs-libdispatch/dispatch/module.modulemap".