### PR TITLE
Prevent unused but set variable warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-# Remove once underlying clang warning is fixed (rdar://93596069)
-set_source_files_properties(shims/yield.c PROPERTIES COMPILE_FLAGS -Wno-error=unused-but-set-variable)
-
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   add_subdirectory(BlocksRuntime)
 endif()

--- a/src/shims/yield.c
+++ b/src/shims/yield.c
@@ -25,6 +25,11 @@ static void *
 __DISPATCH_WAIT_FOR_ENQUEUER__(void **ptr)
 {
 	int spins = 0;
+        // Different platforms may expand `_dispatch_preemption_yield` to a
+        // no-op, but `(void)++spins` is not considered a use like
+        // `(void)spins` is. Add a use to avoid unused var warnings.
+        (void)spins;
+
 	void *value;
 	while ((value = os_atomic_load(ptr, relaxed)) == NULL) {
 		_dispatch_preemption_yield(++spins);


### PR DESCRIPTION
`_dispatch_preemption_yield(++spins)` has an expansion to
`(void)++spins`, but this isn't considered a use of `spins` in Clang.
Add a `(void)spins` to prevent an unused variable warning.

Resolves rdar://93596069.