### PR TITLE
Don't crash due to closed socket on Windows

### DIFF
--- a/src/event/event_windows.c
+++ b/src/event/event_windows.c
@@ -219,7 +219,11 @@ _dispatch_muxnote_disarm_events(dispatch_muxnote_t dmn,
 			iResult = WSAEventSelect((SOCKET)dmn->dmn_ident, NULL, 0);
 		}
 		if (iResult != 0) {
-			DISPATCH_INTERNAL_CRASH(WSAGetLastError(), "WSAEventSelect");
+			// ignore error if socket was already closed
+			int err = WSAGetLastError();
+			if (err != WSAENOTSOCK) {
+				DISPATCH_INTERNAL_CRASH(err, "WSAEventSelect");
+			}
 		}
 		dmn->dmn_network_events = lNetworkEvents;
 		if (!lNetworkEvents && dmn->dmn_threadpool_wait) {


### PR DESCRIPTION
Fixes possible crash on Windows due to `WSAEventSelect()` failing with `WSAENOTSOCK` ("Socket operation on nonsocket") when cancelling a dispatch source after or right before closing the socket.

While the documentation for `dispatch_source_cancel()` indicates that one should wait for the cancellation handler before closing the socket, this doesn’t seem to be a hard requirement, and trying the same on macOS does not cause any errors.

Additionally, graceful handling of this error is required when using libdispatch with some 3rd party libraries like curl, which notify the caller about a socket being closed only right before closing it, and providing no facility to delay closing the socket.