### PR TITLE
Replace GetSystemInfo with GetNativeSystemInfo

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -35,7 +35,7 @@ static DWORD
 getpagesize(void)
 {
 	SYSTEM_INFO siInfo;
-	GetSystemInfo(&siInfo);
+	GetNativeSystemInfo(&siInfo);
 	return siInfo.dwPageSize;
 }
 #endif

--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -85,7 +85,7 @@ static void test_apply_contended(dispatch_queue_t dq)
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #elif defined(_WIN32)
 	SYSTEM_INFO si;
-	GetSystemInfo(&si);
+	GetNativeSystemInfo(&si);
 	activecpu = si.dwNumberOfProcessors;
 #else
 	size_t s = sizeof(activecpu);

--- a/tests/dispatch_concur.c
+++ b/tests/dispatch_concur.c
@@ -238,7 +238,7 @@ main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 #elif defined(_WIN32)
 	SYSTEM_INFO si;
-	GetSystemInfo(&si);
+	GetNativeSystemInfo(&si);
 	activecpu = si.dwNumberOfProcessors;
 #else
 	size_t s = sizeof(activecpu);

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -394,7 +394,7 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 				char* buffer = NULL;
 #if defined(_WIN32)
 				SYSTEM_INFO si;
-				GetSystemInfo(&si);
+				GetNativeSystemInfo(&si);
 				buffer = _aligned_malloc(size, si.dwPageSize);
 #else
 				size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);

--- a/tests/dispatch_priority.c
+++ b/tests/dispatch_priority.c
@@ -89,7 +89,7 @@ n_blocks(void)
 		n = (int)sysconf(_SC_NPROCESSORS_CONF);
 #elif defined(_WIN32)
 		SYSTEM_INFO si;
-		GetSystemInfo(&si);
+		GetNativeSystemInfo(&si);
 		n = (int)si.dwNumberOfProcessors;
 #else
 		size_t l = sizeof(n);

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -86,7 +86,7 @@ dispatch_read2(dispatch_fd_t fd,
 		char *buffer = NULL;
 #if defined(_WIN32)
 		SYSTEM_INFO si;
-		GetSystemInfo(&si);
+		GetNativeSystemInfo(&si);
 		size_t pagesize = (size_t)si.dwPageSize;
 		buffer = _aligned_malloc(bufsiz, pagesize);
 #else

--- a/tests/dispatch_readsync.c
+++ b/tests/dispatch_readsync.c
@@ -147,7 +147,7 @@ main(void)
 	wq_max_threads = activecpu * NTHREADS + 2;
 #elif defined(_WIN32)
 	SYSTEM_INFO si;
-	GetSystemInfo(&si);
+	GetNativeSystemInfo(&si);
 	activecpu = si.dwNumberOfProcessors;
 	wq_max_threads = activecpu * NTHREADS + 2;
 #else


### PR DESCRIPTION
GetNativeSystemInfo is more accurate, whereas GetSystemInfo is affected by compatibility mode