### PR TITLE
Remove redundant expression

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -5513,8 +5513,7 @@ _dispatch_wlh_worker_thread_init(dispatch_deferred_items_t ddi)
 		return false;
 	}
 
-	if ((pp & _PTHREAD_PRIORITY_SCHED_PRI_FLAG) ||
-			!(pp & ~_PTHREAD_PRIORITY_FLAGS_MASK)) {
+	if (pp & _PTHREAD_PRIORITY_SCHED_PRI_FLAG) {
 		// When the phtread kext is delivering kevents to us, and pthread
 		// root queues are in use, then the pthread priority TSD is set
 		// to a sched pri with the _PTHREAD_PRIORITY_SCHED_PRI_FLAG bit set.


### PR DESCRIPTION
This is either a bug-causing expression, or a redundant statement of logic.

Consider the following logic, but applied on the bit-level: Here is a tautology for every bit: A ^ -B -> A.

This means, A & -B requires A must be 1 for it to stay.

!(pp & ~_PTHREAD_PRIORITY_FLAGS_MASK) being true means every bit that is a 1 in pp is a bit that will yield 0 when XORed with _PTHREAD_PRIORITY_FLAGS_MASK.

Because of this, &= _PTHREAD_PRIORITY_FLAGS_MASK has no effect. Therefore, !(pp & ~_PTHREAD_PRIORITY_FLAGS_MASK) is redundant. However, because the comment mentions an and, there is the possibility the entire conditional may have been incorrectly written, causing bugs.