### PR TITLE
install: place the libraries in architecture-specific directories on ELF platforms

### DIFF
--- a/src/BlocksRuntime/CMakeLists.txt
+++ b/src/BlocksRuntime/CMakeLists.txt
@@ -31,6 +31,10 @@ if(INSTALL_PRIVATE_HEADERS)
           DESTINATION ${INSTALL_BLOCK_HEADERS_DIR})
 endif()
 set_property(GLOBAL APPEND PROPERTY DISPATCH_EXPORTS BlocksRuntime)
+if(ENABLE_SWIFT AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  get_swift_host_arch(swift_arch)
+  set(INSTALL_TARGET_DIR "${INSTALL_TARGET_DIR}/${swift_arch}")
+endif()
 install(TARGETS BlocksRuntime
         EXPORT dispatchExports
         ARCHIVE DESTINATION ${INSTALL_TARGET_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,6 +163,10 @@ if(ENABLE_SWIFT)
   add_subdirectory(swift)
 endif()
 
+if(ENABLE_SWIFT AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  get_swift_host_arch(swift_arch)
+  set(INSTALL_TARGET_DIR "${INSTALL_TARGET_DIR}/${swift_arch}")
+endif()
 set_property(GLOBAL APPEND PROPERTY DISPATCH_EXPORTS dispatch)
 install(TARGETS dispatch
         EXPORT dispatchExports

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -50,6 +50,9 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftdoc
   DESTINATION ${INSTALL_TARGET_DIR}/${swift_arch})
 set_property(GLOBAL APPEND PROPERTY DISPATCH_EXPORTS swiftDispatch)
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  set(INSTALL_TARGET_DIR "${INSTALL_TARGET_DIR}/${swift_arch}")
+endif()
 install(TARGETS swiftDispatch
   EXPORT dispatchExports
   ARCHIVE DESTINATION ${INSTALL_TARGET_DIR}


### PR DESCRIPTION
This is needed for apple/swift#63782, which changes the Unix toolchain to look for libraries in architecture-specific directories.