### PR TITLE
Use PIPE_NOWAIT on Windows to avoid blocking on writes

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2528,6 +2528,7 @@ syscall:
 				}
 				if (bSuccess && processed == 0) {
 					err = EAGAIN;
+					goto error;
 				}
 			} else {
 				bSuccess = WriteFile(hFile, buf, (DWORD)len,

--- a/src/io.c
+++ b/src/io.c
@@ -1432,9 +1432,26 @@ _dispatch_fd_entry_create_with_fd(dispatch_fd_t fd, uintptr_t hash)
 #if defined(_WIN32)
 		DWORD dwType = GetFileType((HANDLE)fd);
 		if (dwType == FILE_TYPE_PIPE) {
-			unsigned long value = 1;
-			int result = ioctlsocket((SOCKET)fd, (long)FIONBIO, &value);
-			(void)dispatch_assume_zero(result);
+			if (_dispatch_handle_is_socket((HANDLE)fd)) {
+				unsigned long value = 1;
+				int result = ioctlsocket((SOCKET)fd, (long)FIONBIO, &value);
+				(void)dispatch_assume_zero(result);
+			}
+			else {
+				// Try to make writing nonblocking, although pipes not coming
+				// from Foundation.Pipe may not have FILE_WRITE_ATTRIBUTES.
+				DWORD pipe_mode = PIPE_NOWAIT;
+				if (!SetNamedPipeHandleState((HANDLE)fd, &pipe_mode, NULL,
+						NULL)) {
+					// We may end up blocking on subsequent writes, but we
+					// don't have a good alternative. The WriteQuotaAvailable
+					// from NtQueryInformationFile erroneously returns 0 when
+					// there is a blocking read on the other end of the pipe.
+					_dispatch_fd_entry_debug("failed to set PIPE_NOWAIT",
+							fd_entry);
+				}
+			}
+
 			_dispatch_stream_init(fd_entry,
 				_dispatch_get_default_queue(false));
 		} else {
@@ -2489,24 +2506,6 @@ syscall:
 				}
 				bSuccess = TRUE;
 			} else if (GetFileType(hFile) == FILE_TYPE_PIPE) {
-				// Unfortunately there isn't a good way to achieve O_NONBLOCK
-				// semantics when writing to a pipe. SetNamedPipeHandleState()
-				// can allow pipes to be switched into a "no wait" mode, but
-				// that doesn't work on most pipe handles because Windows
-				// doesn't consistently create pipes with FILE_WRITE_ATTRIBUTES
-				// access. The best we can do is to try to query the write quota
-				// and then write as much as we can.
-				IO_STATUS_BLOCK iosb;
-				FILE_PIPE_LOCAL_INFORMATION fpli;
-				NTSTATUS status = _dispatch_NtQueryInformationFile(hFile, &iosb,
-						&fpli, sizeof(fpli), FilePipeLocalInformation);
-				if (NT_SUCCESS(status)) {
-					if (fpli.WriteQuotaAvailable == 0) {
-						err = EAGAIN;
-						goto error;
-					}
-					len = MIN(len, fpli.WriteQuotaAvailable);
-				}
 				OVERLAPPED ovlOverlapped = {};
 				bSuccess = WriteFile(hFile, buf, (DWORD)len,
 						(LPDWORD)&processed, &ovlOverlapped);
@@ -2522,6 +2521,9 @@ syscall:
 						bSuccess = TRUE;
 						processed = 0;
 					}
+				}
+				if (bSuccess && processed == 0) {
+					err = EAGAIN;
 				}
 			} else {
 				bSuccess = WriteFile(hFile, buf, (DWORD)len,


### PR DESCRIPTION
`libdispatch` depends on non-blocking writes to retry later. For pipes on Windows, we achieved this using `NtQueryInformationFile` to get the `WriteQuotaAvailable` for the pipe, but this function returns `0` when there is a blocking read on the receiver side (this appears to be an OS bug), which causes us to never proceed to the write.

This change rather sets `PIPE_NOWAIT` on the pipe's write handle, similar to what is done on other platforms. This call will fail if the pipe handle does not have `FILE_WRITE_ATTRIBUTES` set, which is not a problem with the typical case of using a `Foundation.Pipe`. If we cannot set `PIPE_NOWAIT`, we will proceed with blocking writes, which in some circumstances could lead to hangs.

This resolves an issue with `SourceKit-LSP` on Windows where tests and real-life scenarios would hang because a pipe could never be written to.