### PR TITLE
Mark DispatchTimeInterval Equatable

### DIFF
--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -165,7 +165,7 @@ private func toInt64Clamped(_ value: Double) -> Int64 {
 /// 	let t1 = DispatchTimeInterval.seconds(Int.max)
 ///		let t2 = DispatchTimeInterval.milliseconds(Int.max)
 ///		let result = t1 == t2   // true
-public enum DispatchTimeInterval {
+public enum DispatchTimeInterval: Equatable {
 	case seconds(Int)
 	case milliseconds(Int)
 	case microseconds(Int)


### PR DESCRIPTION
We can mark `DispatchTimeInterval` as equatable because it already implements the equality check operator `==`.

This resolves an API disparity - on Darwin `DispatchTimeInterval` is already `Equatable`.

Doing this will allow `DispatchTimeInterval` to be used with a wide range of library functions which are defined to operate on `Equatable` objects. For example this is useful in tests when you might wish to use `XCTAssertEqual`.

Resolves https://github.com/apple/swift-corelibs-libdispatch/issues/669