### PR TITLE
Fix build break due to calling convention mismatch on Windows

### DIFF
--- a/tests/generic_win_port.c
+++ b/tests/generic_win_port.c
@@ -188,7 +188,7 @@ gettimeofday(struct timeval *tp, void *tzp)
 typedef void (WINAPI *QueryUnbiasedInterruptTimePreciseT)(PULONGLONG);
 static QueryUnbiasedInterruptTimePreciseT QueryUnbiasedInterruptTimePrecisePtr;
 
-static BOOL
+static BOOL WINAPI
 mach_absolute_time_init(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *lpContext)
 {
 	// QueryUnbiasedInterruptTimePrecise() is declared in the Windows headers


### PR DESCRIPTION
My local Windows libdispatch build recently started failing due to a calling convention mismatch with the function we use as the `PINIT_ONCE_FN` argument of a `InitOnceExecuteOnce` invocation. The fix is to specify it explicitly.