### PR TITLE
build: slightly improve the build for libdispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ configure
 libtool
 .dirstamp
 /dispatch/module.modulemap
-/private/module.modulemap

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ config
 configure
 libtool
 .dirstamp
-/dispatch/module.modulemap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,26 +261,12 @@ endif()
 
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_custom_command(OUTPUT
-                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/private/darwin/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap>
+                      $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/private/darwin/module.modulemap>)
 else()
-  add_custom_command(OUTPUT
-                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/private/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap>
+                      $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/private/generic/module.modulemap>)
 endif()
-add_custom_target(module-maps ALL
-                  DEPENDS
-                     "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                     "${PROJECT_SOURCE_DIR}/private/module.modulemap")
 
 configure_file("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
                "${PROJECT_BINARY_DIR}/config/config_ac.h")

--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -1,4 +1,13 @@
 
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap)
+else()
+  set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap)
+endif()
+configure_file(dispatch-vfs.yaml.in
+  ${CMAKE_BINARY_DIR}/dispatch-vfs-overlay.yaml
+  @ONLY)
+
 install(FILES
           base.h
           block.h
@@ -16,19 +25,8 @@ install(FILES
         DESTINATION
           "${INSTALL_DISPATCH_HEADERS_DIR}")
 if(ENABLE_SWIFT)
-  set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}")
-  if(NOT BUILD_SHARED_LIBS)
-    set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}/generic_static")
-  endif()
-
-  get_filename_component(
-    MODULE_MAP
-    module.modulemap
-    REALPATH
-    BASE_DIR "${base_dir}")
-
   install(FILES
-            ${MODULE_MAP}
+            ${DISPATCH_MODULE_MAP}
           DESTINATION
             "${INSTALL_DISPATCH_HEADERS_DIR}")
 endif()

--- a/dispatch/dispatch-vfs.yaml.in
+++ b/dispatch/dispatch-vfs.yaml.in
@@ -1,0 +1,11 @@
+---
+version: 0
+case-sensitive: false
+use-external-names: false
+roots:
+  - name: "@CMAKE_CURRENT_SOURCE_DIR@"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@DISPATCH_MODULE_MAP@"

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -18,6 +18,18 @@ target_include_directories(DispatchStubs PRIVATE
 set_target_properties(DispatchStubs PROPERTIES
   POSITION_INDEPENDENT_CODE YES)
 
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
+else()
+  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
+endif()
+add_custom_target(module-map ALL
+  DEPENDS ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
+
+
 add_library(swiftDispatch
   Block.swift
   Data.swift
@@ -42,7 +54,7 @@ target_link_libraries(swiftDispatch PRIVATE
   BlocksRuntime::BlocksRuntime)
 target_link_libraries(swiftDispatch PUBLIC
   dispatch)
-add_dependencies(swiftDispatch module-maps)
+add_dependencies(swiftDispatch module-map)
 
 get_swift_host_arch(swift_arch)
 install(FILES

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -18,18 +18,6 @@ target_include_directories(DispatchStubs PRIVATE
 set_target_properties(DispatchStubs PROPERTIES
   POSITION_INDEPENDENT_CODE YES)
 
-
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
-else()
-  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
-endif()
-add_custom_target(module-map ALL
-  DEPENDS ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
-
-
 add_library(swiftDispatch
   Block.swift
   Data.swift
@@ -45,6 +33,8 @@ target_compile_options(swiftDispatch PRIVATE
   "SHELL:-Xcc -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
   "SHELL:-Xcc -I${PROJECT_SOURCE_DIR}"
   "SHELL:-Xcc -I${PROJECT_SOURCE_DIR}/src/swift/shims")
+target_compile_options(swiftDispatch PUBLIC
+  "SHELL:-vfsoverlay ${CMAKE_BINARY_DIR}/dispatch-vfs-overlay.yaml")
 set_target_properties(swiftDispatch PROPERTIES
   Swift_MODULE_NAME Dispatch
   Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift
@@ -54,7 +44,6 @@ target_link_libraries(swiftDispatch PRIVATE
   BlocksRuntime::BlocksRuntime)
 target_link_libraries(swiftDispatch PUBLIC
   dispatch)
-add_dependencies(swiftDispatch module-map)
 
 get_swift_host_arch(swift_arch)
 install(FILES


### PR DESCRIPTION
Avoid polluting the build directory a small amount given that we can use `-fmodule-map-file=` for the C/C++ build of libdispatch.  Unfortunately, for the Swift build, we need to have the file copied over due to the umbrella header resolution.

Hopefully this reduces some of the race conditions that we have seen in the build.

Thanks to @dgregor for reminding me of the flag!