### PR TITLE
[5.9] Mark `DispatchTimeInterval` as `Sendable`

### DIFF
--- a/src/swift/Time.swift
+++ b/src/swift/Time.swift
@@ -165,7 +165,7 @@ private func toInt64Clamped(_ value: Double) -> Int64 {
 /// 	let t1 = DispatchTimeInterval.seconds(Int.max)
 ///		let t2 = DispatchTimeInterval.milliseconds(Int.max)
 ///		let result = t1 == t2   // true
-public enum DispatchTimeInterval: Equatable {
+public enum DispatchTimeInterval: Equatable, Sendable {
 	case seconds(Int)
 	case milliseconds(Int)
 	case microseconds(Int)


### PR DESCRIPTION
This is an `enum` with associated values of `Int` type that are all `Sendable`, so should be safe mark the whole `enum` as such.

This change is low to no risk for 5.9 as it's additive and doesn't touch any other types or functions.

Resolves https://github.com/apple/swift-corelibs-libdispatch/issues/787.