### PR TITLE
build: add a link against AdvAPI32 on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ target_link_libraries(dispatch PUBLIC
   BlocksRuntime::BlocksRuntime)
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(dispatch PRIVATE
+    AdvAPI32
     ShLwApi
     WS2_32
     WinMM


### PR DESCRIPTION
The `WaitChain*` functions require linking against AdvAPI32.