### PR TITLE
shims: fix a subtle bug in semaphore initialisation on Windows

### DIFF
--- a/src/shims/lock.c
+++ b/src/shims/lock.c
@@ -266,6 +266,7 @@ void _dispatch_sema4_init(_dispatch_sema4_t *sema, int policy DISPATCH_UNUSED)
 
 	// lazily allocate the semaphore port
 
+	os_atomic_cmpxchg(sema, *sema, 0, relaxed);
 	while (!dispatch_assume(tmp = CreateSemaphore(NULL, 0, LONG_MAX, NULL))) {
 		_dispatch_temporary_resource_shortage();
 	}


### PR DESCRIPTION
This function is the initializer for the semaphore.  The seamphore storage itself may be stack allocated (or heap allocated) but without guarantee of 0-initialisation.  As a result, the subsequent CAS for the atomic replacement will fail silently, leaving the previously non-zero value in place, indicating that the value is a valid handle.  This would fail randomly and would ultimately result in a crash in the `CloseHandle` call associated with the clean up.

This issue was identified by SwiftLint on Windows.