### PR TITLE
dispatch: install the correct modulemap when building static

### DIFF
--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -1,8 +1,10 @@
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap)
-else()
+elseif(BUILD_SHARED_LIBS)
   set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap)
+else()
+  set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/generic_static/module.modulemap)
 endif()
 configure_file(dispatch-vfs.yaml.in
   ${CMAKE_BINARY_DIR}/dispatch-vfs-overlay.yaml


### PR DESCRIPTION
There is a subtle difference between libdispatch built dynamically and statically: DispatchStubs.  We erroneously emit ObjC runtime calls into the build and the stubs provides a shim to provide a definition on non-ObjC runtime enabled targets.  When built dynamically, this is internalised and distributed as part of dispatch.dll/libdispatch.so, however when built statically, the consumer is responsible for linking against DispatchStubs.  The modulemap reflects this and we need to ensure that we correctly provide that modulemap.

Thanks to @MaxDesiatov for the help with debugging and testing a fix for this!