### PR TITLE
Backport build and Windows fixes for 5.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ configure
 libtool
 .dirstamp
 /dispatch/module.modulemap
-/private/module.modulemap

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ config
 configure
 libtool
 .dirstamp
-/dispatch/module.modulemap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,26 +261,12 @@ endif()
 
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_custom_command(OUTPUT
-                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/private/darwin/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap>
+                      $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/private/darwin/module.modulemap>)
 else()
-  add_custom_command(OUTPUT
-                       "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                       "${PROJECT_SOURCE_DIR}/private/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                     COMMAND
-                       ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/private/generic/module.modulemap" "${PROJECT_SOURCE_DIR}/private/module.modulemap")
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap>
+                      $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fmodule-map-file=${PROJECT_SOURCE_DIR}/private/generic/module.modulemap>)
 endif()
-add_custom_target(module-maps ALL
-                  DEPENDS
-                     "${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
-                     "${PROJECT_SOURCE_DIR}/private/module.modulemap")
 
 configure_file("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
                "${PROJECT_BINARY_DIR}/config/config_ac.h")

--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -1,4 +1,13 @@
 
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap)
+else()
+  set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap)
+endif()
+configure_file(dispatch-vfs.yaml.in
+  ${CMAKE_BINARY_DIR}/dispatch-vfs-overlay.yaml
+  @ONLY)
+
 install(FILES
           base.h
           block.h
@@ -16,19 +25,8 @@ install(FILES
         DESTINATION
           "${INSTALL_DISPATCH_HEADERS_DIR}")
 if(ENABLE_SWIFT)
-  set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}")
-  if(NOT BUILD_SHARED_LIBS)
-    set(base_dir "${CMAKE_CURRENT_SOURCE_DIR}/generic_static")
-  endif()
-
-  get_filename_component(
-    MODULE_MAP
-    module.modulemap
-    REALPATH
-    BASE_DIR "${base_dir}")
-
   install(FILES
-            ${MODULE_MAP}
+            ${DISPATCH_MODULE_MAP}
           DESTINATION
             "${INSTALL_DISPATCH_HEADERS_DIR}")
 endif()

--- a/dispatch/CMakeLists.txt
+++ b/dispatch/CMakeLists.txt
@@ -1,8 +1,10 @@
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap)
-else()
+elseif(BUILD_SHARED_LIBS)
   set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap)
+else()
+  set(DISPATCH_MODULE_MAP ${PROJECT_SOURCE_DIR}/dispatch/generic_static/module.modulemap)
 endif()
 configure_file(dispatch-vfs.yaml.in
   ${CMAKE_BINARY_DIR}/dispatch-vfs-overlay.yaml

--- a/dispatch/dispatch-vfs.yaml.in
+++ b/dispatch/dispatch-vfs.yaml.in
@@ -1,0 +1,11 @@
+---
+version: 0
+case-sensitive: false
+use-external-names: false
+roots:
+  - name: "@CMAKE_CURRENT_SOURCE_DIR@"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@DISPATCH_MODULE_MAP@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ target_link_libraries(dispatch PUBLIC
   BlocksRuntime::BlocksRuntime)
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(dispatch PRIVATE
+    AdvAPI32
     ShLwApi
     WS2_32
     WinMM

--- a/src/shims/lock.c
+++ b/src/shims/lock.c
@@ -266,6 +266,7 @@ void _dispatch_sema4_init(_dispatch_sema4_t *sema, int policy DISPATCH_UNUSED)
 
 	// lazily allocate the semaphore port
 
+	os_atomic_cmpxchg(sema, *sema, 0, relaxed);
 	while (!dispatch_assume(tmp = CreateSemaphore(NULL, 0, LONG_MAX, NULL))) {
 		_dispatch_temporary_resource_shortage();
 	}

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -18,6 +18,18 @@ target_include_directories(DispatchStubs PRIVATE
 set_target_properties(DispatchStubs PROPERTIES
   POSITION_INDEPENDENT_CODE YES)
 
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
+else()
+  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
+endif()
+add_custom_target(module-map ALL
+  DEPENDS ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
+
+
 add_library(swiftDispatch
   Block.swift
   Data.swift
@@ -42,7 +54,7 @@ target_link_libraries(swiftDispatch PRIVATE
   BlocksRuntime::BlocksRuntime)
 target_link_libraries(swiftDispatch PUBLIC
   dispatch)
-add_dependencies(swiftDispatch module-maps)
+add_dependencies(swiftDispatch module-map)
 
 get_swift_host_arch(swift_arch)
 install(FILES

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -18,18 +18,6 @@ target_include_directories(DispatchStubs PRIVATE
 set_target_properties(DispatchStubs PROPERTIES
   POSITION_INDEPENDENT_CODE YES)
 
-
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/darwin/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
-else()
-  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/dispatch/generic/module.modulemap ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
-endif()
-add_custom_target(module-map ALL
-  DEPENDS ${PROJECT_SOURCE_DIR}/dispatch/module.modulemap)
-
-
 add_library(swiftDispatch
   Block.swift
   Data.swift
@@ -45,6 +33,8 @@ target_compile_options(swiftDispatch PRIVATE
   "SHELL:-Xcc -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"
   "SHELL:-Xcc -I${PROJECT_SOURCE_DIR}"
   "SHELL:-Xcc -I${PROJECT_SOURCE_DIR}/src/swift/shims")
+target_compile_options(swiftDispatch PUBLIC
+  "SHELL:-vfsoverlay ${CMAKE_BINARY_DIR}/dispatch-vfs-overlay.yaml")
 set_target_properties(swiftDispatch PROPERTIES
   Swift_MODULE_NAME Dispatch
   Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift
@@ -54,7 +44,6 @@ target_link_libraries(swiftDispatch PRIVATE
   BlocksRuntime::BlocksRuntime)
 target_link_libraries(swiftDispatch PUBLIC
   dispatch)
-add_dependencies(swiftDispatch module-map)
 
 get_swift_host_arch(swift_arch)
 install(FILES

--- a/tests/generic_win_port.c
+++ b/tests/generic_win_port.c
@@ -188,7 +188,7 @@ gettimeofday(struct timeval *tp, void *tzp)
 typedef void (WINAPI *QueryUnbiasedInterruptTimePreciseT)(PULONGLONG);
 static QueryUnbiasedInterruptTimePreciseT QueryUnbiasedInterruptTimePrecisePtr;
 
-static BOOL
+static BOOL WINAPI
 mach_absolute_time_init(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *lpContext)
 {
 	// QueryUnbiasedInterruptTimePrecise() is declared in the Windows headers


### PR DESCRIPTION
Backport a number of changes from main to the 5.9 release

- Windows fixes
  * explicitly specify the callback calling convention to prevent a miscoompilation
  * fix a semaphore initialisation issue on Windows
- Build Changes
  * Use an overlay to use the correct modulemap for dispatch that allows us to avoid a build race condition and fix building dispatch with an installed copy of libdispatch