### PR TITLE
handled the case where /proc/*/stat output value of COMM can have space

### DIFF
--- a/src/event/workqueue.c
+++ b/src/event/workqueue.c
@@ -167,7 +167,7 @@ _dispatch_workq_count_runnable_workers(dispatch_workq_monitor_t mon)
 		if (bytes_read > 0) {
 			buf[bytes_read] = '\0';
 			char state;
-			if (sscanf(buf, "%*d %*s %c", &state) == 1) {
+			if (sscanf(strrchr(buf, ')') + 2, "%c", &state) == 1) {
 				// _dispatch_debug("workq: Worker %d, state %c\n", tid, state);
 				if (state == 'R') {
 					running_count++;


### PR DESCRIPTION
($comm) can contain space or even ) in its name. So in order to parse it correctly, we should treat comm to be between 1st '(' and last ')'.

Since this code doesn't really consume $comm, we can just skip it by getting the last ')'  and start processing after that.