### PR TITLE
Add support for Musl libc

### DIFF
--- a/os/generic_unix_base.h
+++ b/os/generic_unix_base.h
@@ -25,7 +25,7 @@
 #endif
 #include <sys/param.h>
 
-#if __has_include(<sys/cdefs.h>)
+#if __has_include(<sys/cdefs.h>) && defined(__GLIBC__)
 #include <sys/cdefs.h>
 #endif
 

--- a/tests/dispatch_test.c
+++ b/tests/dispatch_test.c
@@ -33,6 +33,8 @@
 #if __has_include(<sys/event.h>)
 #define HAS_SYS_EVENT_H 1
 #include <sys/event.h>
+#elif __has_include(<poll.h>)
+#include <poll.h>
 #else
 #include <sys/poll.h>
 #endif


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires additional checks for available headers.