### PR TITLE
Generate libdispatch.pc on non-apple platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,10 +285,12 @@ else()
   set(INSTALL_OS_HEADERS_DIR "include/os" CACHE PATH "Path where the headers will be installed")
 endif()
 
-configure_file("${PROJECT_SOURCE_DIR}/cmake/libdispatch.pc.in"
-               "${PROJECT_BINARY_DIR}/libdispatch.pc" @ONLY)
+if(NOT APPLE)
+  configure_file("${PROJECT_SOURCE_DIR}/cmake/libdispatch.pc.in"
+                 "${PROJECT_BINARY_DIR}/libdispatch.pc" @ONLY)
 
-install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+  install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif
 
 add_subdirectory(dispatch)
 add_subdirectory(man)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ if(NOT APPLE)
                  "${PROJECT_BINARY_DIR}/libdispatch.pc" @ONLY)
 
   install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-endif
+endif()
 
 add_subdirectory(dispatch)
 add_subdirectory(man)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ endif()
 configure_file("${PROJECT_SOURCE_DIR}/cmake/libdispatch.pc.in"
                "${PROJECT_BINARY_DIR}/libdispatch.pc" @ONLY)
 
-install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${INSTALL_LIBDIR}/pkgconfig)
+install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 add_subdirectory(dispatch)
 add_subdirectory(man)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ else()
 endif()
 
 configure_file("${PROJECT_SOURCE_DIR}/cmake/libdispatch.pc.in"
-               "${PROJECT_BINARY_DIR}/libdispatch.pc")
+               "${PROJECT_BINARY_DIR}/libdispatch.pc" @ONLY)
 
 install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${INSTALL_LIBDIR}/pkgconfig)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,10 @@ else()
   set(INSTALL_OS_HEADERS_DIR "include/os" CACHE PATH "Path where the headers will be installed")
 endif()
 
+configure_file("${PROJECT_SOURCE_DIR}/cmake/libdispatch.pc.in"
+               "${PROJECT_BINARY_DIR}/libdispatch.pc")
+
+install(FILES ${PROJECT_BINARY_DIR}/libdispatch.pc DESTINATION ${INSTALL_LIBDIR}/pkgconfig)
 
 add_subdirectory(dispatch)
 add_subdirectory(man)

--- a/cmake/libdispatch.pc.in
+++ b/cmake/libdispatch.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: libdispatch
+Description: libdispatch (a.k.a. Grand Central Dispatch)
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -ldispatch
+Cflags: -I${includedir}


### PR DESCRIPTION
libdispatch should install a pkg-config file as it is the defacto standard querying mechanism on Linux, and other platforms (excluding Apple).