### PR TITLE
Support compiling on MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,26 @@ int main(int argc, char *argv[]) {
   if(HAVE_MKSTEMP)
     add_compile_definitions(HAVE_MKSTEMP)
   endif()
+
+  check_c_source_compiles([=[
+#include <sys/types.h>
+int main(int argc, char *argv[]) {
+  mode_t mode;
+}
+]=] HAVE_MODE_T)
+  if(HAVE_MODE_T)
+    add_compile_definitions(HAVE_MODE_T)
+  endif()
+
+  check_c_source_compiles([=[
+#include <sys/types.h>
+int main(int argc, char *argv[]) {
+  pid_t mode;
+}
+]=] HAVE_PID_T)
+  if(HAVE_PID_T)
+    add_compile_definitions(HAVE_PID_T)
+  endif()
 endif()
 
 set(CMAKE_C_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,14 +18,18 @@ if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  include(DispatchWindowsSupport)
-  dispatch_windows_arch_spelling(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_MSVC_ARCH)
-  dispatch_windows_include_for_arch(${DISPATCH_MSVC_ARCH} DISPATCH_INCLUDES)
-  include_directories(BEFORE SYSTEM ${DISPATCH_INCLUDES})
-  dispatch_windows_lib_for_arch(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_LIBDIR)
-  link_directories(${DISPATCH_LIBDIR})
+  if(NOT MINGW)
+    include(DispatchWindowsSupport)
+    dispatch_windows_arch_spelling(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_MSVC_ARCH)
+    dispatch_windows_include_for_arch(${DISPATCH_MSVC_ARCH} DISPATCH_INCLUDES)
+    include_directories(BEFORE SYSTEM ${DISPATCH_INCLUDES})
+    dispatch_windows_lib_for_arch(${CMAKE_SYSTEM_PROCESSOR} DISPATCH_LIBDIR)
+    link_directories(${DISPATCH_LIBDIR})
+  endif()
 
   include(CheckCSourceCompiles)
+  include(CheckSymbolExists)
+
   check_c_source_compiles([=[
 #include <Windows.h>
 int main(int argc, char *argv[]) {
@@ -53,6 +57,22 @@ int main(int argc, char *argv[]) {
 ]=] DISPATCH_HAVE_EXTENDED_SLPI_22000)
   if(DISPATCH_HAVE_EXTENDED_SLPI_22000)
     add_compile_definitions(DISPATCH_HAVE_EXTENDED_SLPI_22000)
+  endif()
+
+  check_c_source_compiles([=[
+#include <Windows.h>
+#include <winternl.h>
+int main(int argc, char *argv[]) {
+  FILE_PIPE_LOCAL_INFORMATION fpli;
+}
+]=] HAVE_FILE_PIPE_LOCAL_INFORMATION)
+  if(HAVE_FILE_PIPE_LOCAL_INFORMATION)
+    add_compile_definitions(HAVE_FILE_PIPE_LOCAL_INFORMATION)
+  endif()
+
+  check_symbol_exists(mkstemp "stdlib.h" HAVE_MKSTEMP)
+  if(HAVE_MKSTEMP)
+    add_compile_definitions(HAVE_MKSTEMP)
   endif()
 endif()
 

--- a/cmake/modules/DispatchCompilerWarnings.cmake
+++ b/cmake/modules/DispatchCompilerWarnings.cmake
@@ -1,7 +1,9 @@
 
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC" OR MINGW)
+if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
   # TODO: someone needs to provide the msvc equivalent warning flags
-  # -fms-extensions will enable __popcnt64
+elseif(WIN32)
+  # Tareting Windows but using a non-MSVC compiler.  Set -fms-extensions
+  # so that we can use __popcnt64
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fms-extensions>)
 else()
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror>)

--- a/cmake/modules/DispatchCompilerWarnings.cmake
+++ b/cmake/modules/DispatchCompilerWarnings.cmake
@@ -1,6 +1,8 @@
 
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC" OR MINGW)
   # TODO: someone needs to provide the msvc equivalent warning flags
+  # -fms-extensions will enable __popcnt64
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fms-extensions>)
 else()
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror>)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wall>)

--- a/os/generic_win_base.h
+++ b/os/generic_win_base.h
@@ -24,7 +24,10 @@
 // Unices provide `howmany` via sys/param.h
 #define howmany(x, y)  (((x) + ((y) - 1)) / (y))
 
+#ifndef _MODE_T_
+#define	_MODE_T_
 typedef int mode_t;
+#endif
 typedef void pthread_attr_t;
 
 #ifndef API_AVAILABLE

--- a/os/generic_win_base.h
+++ b/os/generic_win_base.h
@@ -24,8 +24,7 @@
 // Unices provide `howmany` via sys/param.h
 #define howmany(x, y)  (((x) + ((y) - 1)) / (y))
 
-#ifndef _MODE_T_
-#define	_MODE_T_
+#ifndef HAVE_MODE_T
 typedef int mode_t;
 #endif
 typedef void pthread_attr_t;

--- a/src/event/workqueue.c
+++ b/src/event/workqueue.c
@@ -24,6 +24,11 @@
 
 #if defined(_WIN32)
 #include <wct.h>
+
+#if !defined(WCT_MAX_NODE_COUNT)
+#define WCT_MAX_NODE_COUNT 16
+#endif
+
 #endif
 
 /*

--- a/src/shims/generic_win_stubs.h
+++ b/src/shims/generic_win_stubs.h
@@ -49,6 +49,7 @@ bool _dispatch_handle_is_socket(HANDLE hFile);
 void _dispatch_QueryInterruptTimePrecise(PULONGLONG lpInterruptTimePrecise);
 void _dispatch_QueryUnbiasedInterruptTimePrecise(PULONGLONG lpUnbiasedInterruptTimePrecise);
 
+#ifndef HAVE_FILE_PIPE_LOCAL_INFORMATION
 enum {
 	FilePipeLocalInformation = 24,
 };
@@ -65,6 +66,7 @@ typedef struct _FILE_PIPE_LOCAL_INFORMATION {
 	ULONG NamedPipeState;
 	ULONG NamedPipeEnd;
 } FILE_PIPE_LOCAL_INFORMATION, *PFILE_PIPE_LOCAL_INFORMATION;
+#endif
 
 NTSTATUS _dispatch_NtQueryInformationFile(HANDLE FileHandle,
 		PIO_STATUS_BLOCK IoStatusBlock, PVOID FileInformation, ULONG Length,

--- a/tests/generic_win_port.c
+++ b/tests/generic_win_port.c
@@ -238,6 +238,7 @@ randomize_name(char *out)
 	}
 }
 
+#ifndef HAVE_MKSTEMP
 dispatch_fd_t
 mkstemp(char *tmpl)
 {
@@ -257,6 +258,7 @@ mkstemp(char *tmpl)
 	errno = EEXIST;
 	return -1;
 }
+#endif
 
 void
 print_winapi_error(const char *function_name, DWORD error)

--- a/tests/generic_win_port.h
+++ b/tests/generic_win_port.h
@@ -7,7 +7,9 @@
 #include <Windows.h>
 
 typedef int kern_return_t;
+#ifndef _PID_T_
 typedef int pid_t;
+#endif
 
 #if defined(_WIN64)
 typedef long long ssize_t;
@@ -68,8 +70,10 @@ mach_timebase_info(mach_timebase_info_t tbi)
 	return 0;
 }
 
+#ifndef HAVE_MKSTEMP
 dispatch_fd_t
 mkstemp(char *tmpl);
+#endif
 
 void
 print_winapi_error(const char *function_name, DWORD error);

--- a/tests/generic_win_port.h
+++ b/tests/generic_win_port.h
@@ -7,7 +7,7 @@
 #include <Windows.h>
 
 typedef int kern_return_t;
-#ifndef _PID_T_
+#ifndef HAVE_PID_T
 typedef int pid_t;
 #endif
 


### PR DESCRIPTION
This patch consists of two commits:

- The first commit contains a minimal set of changes to make libdispatch compile on the MSYS2 environments.  There are slight differences in headers, which are accounted for, and the `-fms-extensions` variable is passed to clang to enable the `__popcnt64` intrinsic
- The second commit adds a GitHub actions job to validate the changes

If this project doesn't want to use GitHub actions, I can remove the second commit.