### PR TITLE
Changes for Musl compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,15 @@ add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:HA
 
 
 if(ENABLE_SWIFT)
-  set(INSTALL_TARGET_DIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>" CACHE PATH "Path where the libraries will be installed")
+  if(NOT SWIFT_SYSTEM_NAME)
+    if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      set(SWIFT_SYSTEM_NAME macosx)
+    else()
+      set(SWIFT_SYSTEM_NAME "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+    endif()
+  endif()
+
+  set(INSTALL_TARGET_DIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SWIFT_SYSTEM_NAME}" CACHE PATH "Path where the libraries will be installed")
   set(INSTALL_DISPATCH_HEADERS_DIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/dispatch" CACHE PATH "Path where the headers will be installed for libdispatch")
   set(INSTALL_BLOCK_HEADERS_DIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/Block" CACHE PATH "Path where the headers will be installed for the blocks runtime")
   set(INSTALL_OS_HEADERS_DIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/os" CACHE PATH "Path where the os/ headers will be installed")

--- a/tests/dispatch_test.c
+++ b/tests/dispatch_test.c
@@ -33,6 +33,8 @@
 #if __has_include(<sys/event.h>)
 #define HAS_SYS_EVENT_H 1
 #include <sys/event.h>
+#elif __has_include(<poll.h>)
+#include <poll.h>
 #else
 #include <sys/poll.h>
 #endif


### PR DESCRIPTION
We should be using `<poll.h>` and not `<sys/poll.h>`, and also we need a way to override the Swift library subdirectory name, rather than assuming we can always derive it by lowercasing `CMAKE_SYSTEM_NAME`.