### PR TITLE
Add a missing semicolon in src/io.c.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2374,7 +2374,7 @@ _dispatch_operation_perform(dispatch_operation_t op)
 			}
 			op->buf = _aligned_malloc(op->buf_siz, siInfo.dwPageSize);
 #else
-			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz)
+			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz);
 #endif
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {


### PR DESCRIPTION
I'm _really_ confused about why this doesn't fail to compile on swift-ci; I would expect that `#else` branch to be tested when building for Linux. When I recently updated our internal copy of the Linux toolchain past https://github.com/apple/swift-corelibs-libdispatch/pull/805, it failed:

```
src/io.c:2377:59: error: expected ';' after expression
 2377 |                         op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz)
      |                                                                                ^
      |                                                                                ;
```