### PR TITLE
[6.0] Adopt Sendable in DispatchQueue and similar types

### DIFF
--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -253,7 +253,7 @@ extension DispatchQueue {
 		group: DispatchGroup? = nil,
 		qos: DispatchQoS = .unspecified,
 		flags: DispatchWorkItemFlags = [],
-		execute work: @escaping @convention(block) () -> Void)
+		execute work: @escaping @Sendable @convention(block) () -> Void)
 	{
 		if group == nil && qos == .unspecified {
 			// Fast-path route for the most common API usage
@@ -387,7 +387,7 @@ extension DispatchQueue {
 		deadline: DispatchTime,
 		qos: DispatchQoS = .unspecified,
 		flags: DispatchWorkItemFlags = [],
-		execute work: @escaping @convention(block) () -> Void)
+		execute work: @escaping @Sendable @convention(block) () -> Void)
 	{
 		if #available(macOS 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
@@ -418,7 +418,7 @@ extension DispatchQueue {
 		wallDeadline: DispatchWallTime,
 		qos: DispatchQoS = .unspecified,
 		flags: DispatchWorkItemFlags = [],
-		execute work: @escaping @convention(block) () -> Void)
+		execute work: @escaping @Sendable @convention(block) () -> Void)
 	{
 		if #available(macOS 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -44,7 +44,7 @@ public class DispatchObject {
 }
 
 
-public class DispatchGroup : DispatchObject {
+public class DispatchGroup : DispatchObject, @unchecked Sendable {
 	internal let __wrapped:dispatch_group_t;
 
 	final internal override func wrapped() -> dispatch_object_t {
@@ -68,7 +68,7 @@ public class DispatchGroup : DispatchObject {
 	}
 }
 
-public class DispatchSemaphore : DispatchObject {
+public class DispatchSemaphore : DispatchObject, @unchecked Sendable {
 	internal let __wrapped: dispatch_semaphore_t;
 
 	final internal override func wrapped() -> dispatch_object_t {
@@ -84,8 +84,8 @@ public class DispatchSemaphore : DispatchObject {
 	}
 }
 
-public class DispatchIO : DispatchObject {
-	internal let __wrapped:dispatch_io_t
+public class DispatchIO : DispatchObject, @unchecked Sendable {
+	internal let __wrapped: dispatch_io_t
 
 	final internal override func wrapped() -> dispatch_object_t {
 		return unsafeBitCast(__wrapped, to: dispatch_object_t.self)
@@ -127,7 +127,7 @@ public class DispatchIO : DispatchObject {
 	}
 }
 
-public class DispatchQueue : DispatchObject {
+public class DispatchQueue : DispatchObject, @unchecked Sendable {
 	internal let __wrapped:dispatch_queue_t;
 
 	final internal override func wrapped() -> dispatch_object_t {
@@ -156,6 +156,7 @@ public class DispatchQueue : DispatchObject {
 }
 
 public class DispatchSource : DispatchObject,
+	@unchecked Sendable,
 	DispatchSourceProtocol,	DispatchSourceRead,
 	DispatchSourceSignal, DispatchSourceTimer,
 	DispatchSourceUserDataAdd, DispatchSourceUserDataOr,


### PR DESCRIPTION
**Description:** A few well known types like DispatchSemaphore, DispatchIO, DispatchGroup, DispatchQueue, DispatchSource should all be Sendable. This also adds a missing (as compared to Apple platforms) `@Sendable` to queue.async APIs.
**Risk:** Low, missing annotations.
**Review by:** @rokhinip 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift-corelibs-libdispatch/pull/821
**Radar:** rdar://123284763