### PR TITLE
[6.0] Add a missing semicolon in src/io.c.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2374,7 +2374,7 @@ _dispatch_operation_perform(dispatch_operation_t op)
 			}
 			op->buf = _aligned_malloc(op->buf_siz, siInfo.dwPageSize);
 #else
-			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz)
+			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz);
 #endif
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {


### PR DESCRIPTION
**Description:** Add a missing semicolon in src/io.c.
**Risk:** Low; this should have been a compiler error to begin with and I'm not sure why nothing caught it.
**Reviewed by:** @compnerd 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift-corelibs-libdispatch/pull/822
