### PR TITLE
Switching back _dispatch_operation_perform to use posix_memalign from aligned_malloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,6 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Android)
 endif()
 
 check_function_exists(_pthread_workqueue_init HAVE__PTHREAD_WORKQUEUE_INIT)
-check_function_exists(aligned_alloc HAVE_ALIGNED_ALLOC)
 check_function_exists(getprogname HAVE_GETPROGNAME)
 check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
 check_function_exists(mach_approximate_time HAVE_MACH_APPROXIMATE_TIME)

--- a/src/io.c
+++ b/src/io.c
@@ -2373,8 +2373,6 @@ _dispatch_operation_perform(dispatch_operation_t op)
 				bQueried = true;
 			}
 			op->buf = _aligned_malloc(op->buf_siz, siInfo.dwPageSize);
-#elif defined(HAVE_ALIGNED_ALLOC)
-			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz);
 #else
 			err = posix_memalign(&op->buf, (size_t)PAGE_SIZE, op->buf_siz);
 			if (err != 0) {

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -398,11 +398,7 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 				buffer = _aligned_malloc(size, si.dwPageSize);
 #else
 				size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
-#if defined(HAVE_ALIGNED_ALLOC)
-				buffer = aligned_alloc(pagesize, size);
-#else
 				posix_memalign((void **)&buffer, pagesize, size);
-#endif
 #endif
 				ssize_t r = dispatch_test_fd_read(fd, buffer, size);
 				if (r == -1) {

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -91,11 +91,7 @@ dispatch_read2(dispatch_fd_t fd,
 		buffer = _aligned_malloc(bufsiz, pagesize);
 #else
 		size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
-#if defined(HAVE_ALIGNED_ALLOC)
-		buffer = aligned_alloc(pagesize, bufsiz);
-#else
 		posix_memalign((void **)&buffer, pagesize, bufsiz);
-#endif
 #endif
 		ssize_t actual = dispatch_test_fd_read(fd, buffer, bufsiz);
 		if (actual == -1) {
@@ -154,7 +150,7 @@ test_read(void)
 		test_stop();
 	}
 #else
-	// investigate what the impact of lack of file cache disabling has 
+	// investigate what the impact of lack of file cache disabling has
 	// for this test
 #endif
 	size_t size = (size_t)dispatch_test_fd_lseek(fd, 0, SEEK_END);


### PR DESCRIPTION
This was caught by thread sanitizer. 