### PR TITLE
[6.0] Check for `aligned_alloc()` and use `posix_memalign()` instead on platforms that don't have it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Android)
 endif()
 
 check_function_exists(_pthread_workqueue_init HAVE__PTHREAD_WORKQUEUE_INIT)
+check_function_exists(aligned_alloc HAVE_ALIGNED_ALLOC)
 check_function_exists(getprogname HAVE_GETPROGNAME)
 check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
 check_function_exists(mach_approximate_time HAVE_MACH_APPROXIMATE_TIME)

--- a/src/io.c
+++ b/src/io.c
@@ -2373,8 +2373,13 @@ _dispatch_operation_perform(dispatch_operation_t op)
 				bQueried = true;
 			}
 			op->buf = _aligned_malloc(op->buf_siz, siInfo.dwPageSize);
-#else
+#elif defined(HAVE_ALIGNED_ALLOC)
 			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz);
+#else
+			err = posix_memalign(&op->buf, (size_t)PAGE_SIZE, op->buf_siz);
+			if (err != 0) {
+				goto error;
+			}
 #endif
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -398,7 +398,11 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 				buffer = _aligned_malloc(size, si.dwPageSize);
 #else
 				size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
+#if defined(HAVE_ALIGNED_ALLOC)
 				buffer = aligned_alloc(pagesize, size);
+#else
+				posix_memalign((void **)&buffer, pagesize, size);
+#endif
 #endif
 				ssize_t r = dispatch_test_fd_read(fd, buffer, size);
 				if (r == -1) {

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -91,7 +91,11 @@ dispatch_read2(dispatch_fd_t fd,
 		buffer = _aligned_malloc(bufsiz, pagesize);
 #else
 		size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
+#if defined(HAVE_ALIGNED_ALLOC)
 		buffer = aligned_alloc(pagesize, bufsiz);
+#else
+		posix_memalign((void **)&buffer, pagesize, bufsiz);
+#endif
 #endif
 		ssize_t actual = dispatch_test_fd_read(fd, buffer, bufsiz);
 		if (actual == -1) {


### PR DESCRIPTION
__Explanation:__ Android before API 28 didn't have `aligned_alloc()`, so this simply brings back the code that was replaced in #805 for platforms like that.

__Scope:__ Three small changes to bring back previously working code, where needed

__Issue:__ None

__Original PR:__ #811

__Risk:__ None, this just brings back working code for a few platforms

__Testing:__ Passed all CI on trunk, plus on my daily Android CI

__Reviewer:__ @compnerd