### PR TITLE
Switching back _dispatch_operation_perform to use posix_memalign from aligned_malloc for 6.0 release

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2374,7 +2374,10 @@ _dispatch_operation_perform(dispatch_operation_t op)
 			}
 			op->buf = _aligned_malloc(op->buf_siz, siInfo.dwPageSize);
 #else
-			op->buf = aligned_alloc((size_t)PAGE_SIZE, op->buf_siz);
+			err = posix_memalign(&op->buf, (size_t)PAGE_SIZE, op->buf_siz);
+			if (err != 0) {
+				goto error;
+			}
 #endif
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -398,7 +398,7 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 				buffer = _aligned_malloc(size, si.dwPageSize);
 #else
 				size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
-				buffer = aligned_alloc(pagesize, size);
+				posix_memalign((void **)&buffer, pagesize, size);
 #endif
 				ssize_t r = dispatch_test_fd_read(fd, buffer, size);
 				if (r == -1) {

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -91,7 +91,7 @@ dispatch_read2(dispatch_fd_t fd,
 		buffer = _aligned_malloc(bufsiz, pagesize);
 #else
 		size_t pagesize = (size_t)sysconf(_SC_PAGESIZE);
-		buffer = aligned_alloc(pagesize, bufsiz);
+		posix_memalign((void **)&buffer, pagesize, bufsiz);
 #endif
 		ssize_t actual = dispatch_test_fd_read(fd, buffer, bufsiz);
 		if (actual == -1) {
@@ -150,7 +150,7 @@ test_read(void)
 		test_stop();
 	}
 #else
-	// investigate what the impact of lack of file cache disabling has 
+	// investigate what the impact of lack of file cache disabling has
 	// for this test
 #endif
 	size_t size = (size_t)dispatch_test_fd_lseek(fd, 0, SEEK_END);


### PR DESCRIPTION
This was caught by thread sanitizer.