### PR TITLE
[Linux] Enable build IDs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ include(CheckCSourceCompiles)
 include(CheckFunctionExists)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
+include(CheckLinkerFlag)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
 include(CTest)
@@ -174,6 +175,8 @@ endif()
 option(ENABLE_THREAD_LOCAL_STORAGE "enable usage of thread local storage via _Thread_local" ON)
 set(DISPATCH_USE_THREAD_LOCAL_STORAGE ${ENABLE_THREAD_LOCAL_STORAGE})
 
+
+check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
 
 check_symbol_exists(__GNU_LIBRARY__ "features.h" _GNU_SOURCE)
 if(_GNU_SOURCE)

--- a/src/BlocksRuntime/CMakeLists.txt
+++ b/src/BlocksRuntime/CMakeLists.txt
@@ -22,6 +22,10 @@ endif()
 set_target_properties(BlocksRuntime PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE)
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(BlocksRuntime PRIVATE "LINKER:--build-id=sha1")
+endif()
+
 add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
 
 install(FILES Block.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,6 +178,10 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
   set_target_properties(dispatch PROPERTIES INSTALL_RPATH "$ORIGIN")
 endif()
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(dispatch PRIVATE "LINKER:--build-id=sha1")
+endif()
+
 if(ENABLE_SWIFT)
   add_subdirectory(swift)
 endif()


### PR DESCRIPTION
We should use build IDs on Linux so that we can identify the built artefacts, and also so that we can match them up with debug information should we choose to separate it.

rdar://130582819