### PR TITLE
Disable new `cast-function-type-mismatch`

### DIFF
--- a/cmake/modules/DispatchCompilerWarnings.cmake
+++ b/cmake/modules/DispatchCompilerWarnings.cmake
@@ -77,4 +77,8 @@ else()
     add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-shorten-64-to-32>)
   endif()
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-error=assign-enum>)
+
+  # Should re-enable after rdar://133498289 is fixed (ie. fixing the one mismatched cast in apply.c)
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-cast-function-type-mismatch>)
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-error=unknown-warning-option>)
 endif()


### PR DESCRIPTION
Should fix this properly, but for now just disable the warning itself.