### PR TITLE
Add `_dispatch_install_thread_detach_callback()` on all platforms

### DIFF
--- a/private/queue_private.h
+++ b/private/queue_private.h
@@ -481,20 +481,18 @@ void
 dispatch_async_enforce_qos_class_f(dispatch_queue_t queue,
 		void *_Nullable context, dispatch_function_t work);
 
-#ifdef __ANDROID__
 /*!
  * @function _dispatch_install_thread_detach_callback
  *
  * @param cb
- * Function to be called before each worker thread exits to detach JVM.
+ * Function to be called before each worker thread exits.
  *
- * Hook to be able to detach threads from the Java JVM before they exit.
+ * Hook to e.g. be able to detach threads from the Java JVM before they exit.
  * If JNI has been used on a thread on Android it needs to have been
  * "detached" before the thread exits or the application will crash.
  */
 DISPATCH_EXPORT
 void _dispatch_install_thread_detach_callback(void (*cb)(void));
-#endif
 
 __END_DECLS
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -7326,7 +7326,6 @@ _gettid(void)
 		if ((f) && tsd->k) ((void(*)(void*))(f))(tsd->k); \
 	} while (0)
 
-#ifdef __ANDROID__
 static void (*_dispatch_thread_detach_callback)(void);
 
 void
@@ -7336,7 +7335,6 @@ _dispatch_install_thread_detach_callback(void (*cb)(void))
 		DISPATCH_CLIENT_CRASH(0, "Installing a thread detach callback twice");
 	}
 }
-#endif
 
 #if defined(_WIN32)
 static bool
@@ -7390,6 +7388,10 @@ _libdispatch_tsd_cleanup(void *ctx)
    }
 #endif // defined(_WIN32)
 
+	if (_dispatch_thread_detach_callback) {
+		_dispatch_thread_detach_callback();
+	}
+
 	struct dispatch_tsd *tsd = (struct dispatch_tsd*) ctx;
 
 	_tsd_call_cleanup(dispatch_priority_key, NULL);
@@ -7411,11 +7413,7 @@ _libdispatch_tsd_cleanup(void *ctx)
 	_tsd_call_cleanup(dispatch_voucher_key, _voucher_thread_cleanup);
 	_tsd_call_cleanup(dispatch_deferred_items_key,
 			_dispatch_deferred_items_cleanup);
-#ifdef __ANDROID__
-	if (_dispatch_thread_detach_callback) {
-		_dispatch_thread_detach_callback();
-	}
-#endif
+
 	tsd->tid = 0;
 }
 

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -483,11 +483,9 @@ extension DispatchQueue {
 		dispatch_queue_set_specific(self.__wrapped, k, p, _destructDispatchSpecificValue)
 	}
 
-	#if os(Android)
 	public static func setThreadDetachCallback(_ cb: @escaping @convention(c) () -> Void) {
 		_dispatch_install_thread_detach_callback(cb)
 	}
-	#endif
 }
 
 private func _destructDispatchSpecificValue(ptr: UnsafeMutableRawPointer?) {

--- a/src/swift/shims/DispatchOverlayShims.h
+++ b/src/swift/shims/DispatchOverlayShims.h
@@ -231,9 +231,7 @@ static inline void _swift_dispatch_source_set_registration_handler(
   dispatch_source_set_registration_handler(source, block);
 }
 
-#if defined(__ANDROID__)
 extern void _dispatch_install_thread_detach_callback(void (*cb)(void));
-#endif
 
 static inline void _swift_dispatch_retain(dispatch_object_t object) {
   dispatch_retain(object);


### PR DESCRIPTION
`_dispatch_install_thread_detach_callback()` is currently only available on Android specifically to detach threads from the JVM. This patch removes the `#ifdefs` to add the callback on all platforms, and moves it up in `_libdispatch_tsd_cleanup()` to be called before TSD cleanup.

This enables libraries/apps to release thread-local data when threads managed by libdispatch exit.

See https://github.com/gnustep/libs-base/issues/428.