### PR TITLE
[Android] Add driver script for running tests in emulator when cross-compiling

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,3 +197,9 @@ endif()
 
 # test-specific compile options
 set_target_properties(dispatch_c99 PROPERTIES C_STANDARD 99)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Android)
+  configure_file(ctest-android.sh.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/ctest-android.sh
+                 @ONLY NEWLINE_STYLE LF)
+endif()

--- a/tests/ctest-android.sh.in
+++ b/tests/ctest-android.sh.in
@@ -1,0 +1,45 @@
+#!/system/bin/sh
+
+# Run tests in Android emulator when cross-compiling:
+# $ adb push <binary-dir> /data/local/tmp"
+# $ adb shell "sh /data/local/tmp/tests/ctest-android.sh"
+
+BINARY_DIR=$(dirname "$0")/..
+UTILITY="$BINARY_DIR/bsdtestharness"
+if [ ! -f "$UTILITY" ]; then
+    echo "Utility not found: $UTILITY."
+    exit 1
+fi
+
+# CMake injects test executables at configuration time
+TESTS="@DISPATCH_C_TESTS@"
+COUNT=$(echo "$TESTS" | tr ';' '\n' | wc -l)
+echo "Running $COUNT test-cases from $BINARY_DIR"
+
+# Tests depend on libdispatch.so and libBlocksRuntime.so
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BINARY_DIR"
+
+TIMOUT=120
+FAILURE=0
+IFS=';'
+chmod +x "$UTILITY"
+
+for TEST in $TESTS; do
+    chmod +x "$BINARY_DIR/dispatch_$TEST"
+    OUTPUT=$(timeout "${TIMOUT}s" "$UTILITY" "$BINARY_DIR/dispatch_$TEST" 2>&1)
+    EC=$?
+    if [ $EC -eq 124 ]; then
+        echo "Error: dispatch_$TEST timed out after $TIMOUT seconds"
+        echo "************\nOutput:\n$OUTPUT\n************"
+        FAILURE=1
+    elif [ $EC -ne 0 ]; then
+        echo "Error: dispatch_$TEST failed"
+        echo "************\nOutput:\n$OUTPUT\n************"
+        FAILURE=1
+    else
+        echo "dispatch_$TEST passed"
+    fi
+done
+
+unset IFS
+exit $FAILURE


### PR DESCRIPTION
When building for the host, ctest is a fast and straightforward test driver. When cross-compiling and running in an emulator like the one for Android, it causes some issues though:
* We need a different `ctest` binary for each target arch (and build it from source in many cases)
* The config file `CTestTestfile.cmake` uses absolute paths from the host machine to refer to the executables
* We still have to travers all executables and `chmod +x` them in the emulator manually

Given that the task of ctest is simple here, it seems reasonable to provide a script for that. With CMake filling in the test targets at configuration time, we can simply push the binary directory to the emulator and run the script in order to execute all tests.