### PR TITLE
Windows: Support building with Clang using the GNU-like front end

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ if(DISPATCH_ENABLE_ASSERTS)
     DISPATCH_DEBUG=1)
 endif()
 
-if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+if("${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
   target_compile_options(dispatch PRIVATE /EHs-c-)
   target_compile_options(dispatch PRIVATE /W3)
 else()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,7 +83,7 @@ function(add_unit_test name)
   target_include_directories(${name}
                              SYSTEM BEFORE PRIVATE
                                "${BlocksRuntime_INCLUDE_DIR}")
-  if("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
+  if("${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
     target_compile_options(${name} PRIVATE -Xclang -fblocks)
     target_compile_options(${name} PRIVATE /W3 -Wno-deprecated-declarations)
   else()


### PR DESCRIPTION
On Windows, the Clang compiler can run with the GNU-like front end, or with a MSVC-like front-end.  In both cases, it will generate core which is compatible with the MSVC runtime.

The `CMAKE_C_SIMULATE_ID` CMake variable relates to the runtime/binary compatibility is always set to MSVC.
The `CMAKE_C_COMPILER_FRONTEND_VARIANT` CMake variable relates to the front-end and can be used to differentiate between the GNU and MSVC front-end (command line syntax).

Therefore, use `CMAKE_C_COMPILER_FRONTEND_VARIANT` (instead of `CMAKE_C_SIMULATE_ID`) to determine whether command line arguments should be passed using the MSVC or GNU syntax.

This fixes compiling libdispatch on Windows using a "native" clang toolchain (e.g. clang instead of clang-cl).