### PR TITLE
build: Opt-in to CMP0181, if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)
 endif()
 
+if(POLICY CMP0181)
+  cmake_policy(SET CMP0181 NEW)
+endif()
+
 project(dispatch
   VERSION 1.3
   LANGUAGES C CXX)


### PR DESCRIPTION
This is necessary for CMake 4.0+ support. All this does is enable CMake to handled `LINKER:arg1,arg2` syntax for
`CMAKE_[EXE|SHARED|MODULE|_LINKER_FLAGS`. It does not mandate that syntax.