### PR TITLE
[6.2.1] [Build] Enable frame pointers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ include(DispatchCompilerWarnings)
 include(DTrace)
 include(SwiftSupport)
 
+include(EnableFramePointers)
+
 # NOTE(abdulras) this is the CMake supported way to control whether we generate
 # shared or static libraries.  This impacts the behaviour of `add_library` in
 # what type of library it generates.

--- a/cmake/modules/EnableFramePointers.cmake
+++ b/cmake/modules/EnableFramePointers.cmake
@@ -1,0 +1,13 @@
+#
+# Including this file enables frame pointers, if we know how.
+#
+
+include(CheckCompilerFlag)
+
+# Check if the compiler supports -fno-omit-frame-pointer
+check_compiler_flag(C -fno-omit-frame-pointer SUPPORTS_NO_OMIT_FP)
+
+# If it does, use it
+if (SUPPORTS_NO_OMIT_FP)
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-fno-omit-frame-pointer>)
+endif()


### PR DESCRIPTION
Frame pointers should be enabled everywhere.

rdar://160759746
(cherry picked from commit a8b689a278a045b8ea6bd1f2ddfd3c52369db89d)