### PR TITLE
Add missing `Sendable` conformances

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -13,7 +13,7 @@
 import CDispatch
 @_implementationOnly import _DispatchOverlayShims
 
-public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
+public struct DispatchWorkItemFlags : OptionSet, RawRepresentable, Sendable {
 	public let rawValue: UInt
 	public init(rawValue: UInt) { self.rawValue = rawValue }
 

--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -13,14 +13,14 @@
 import CDispatch
 @_implementationOnly import _DispatchOverlayShims
 
-public struct DispatchData : RandomAccessCollection {
+public struct DispatchData : RandomAccessCollection, Sendable {
 	public typealias Iterator = DispatchDataIterator
 	public typealias Index = Int
 	public typealias Indices = DefaultIndices<DispatchData>
 
 	public static let empty: DispatchData = DispatchData(data: _swift_dispatch_data_empty())
 
-	public enum Deallocator {
+	public enum Deallocator : Sendable {
 		/// Use `free`
 		case free
 
@@ -34,7 +34,7 @@ public struct DispatchData : RandomAccessCollection {
 		//        However, adding the annotation here results in Data.o containing
 		//        a reference to _TMBO (opaque metadata for Builtin.UnknownObject)
 		//        which is only made available on platforms with Objective-C.
-		case custom(DispatchQueue?, () -> Void)
+		@preconcurrency case custom(DispatchQueue?, () -> Void)
 
 		fileprivate var _deallocator: (DispatchQueue?, @convention(block) () -> Void) {
 			switch self {
@@ -329,7 +329,7 @@ public struct DispatchData : RandomAccessCollection {
 	}
 }
 
-public struct DispatchDataIterator : IteratorProtocol, Sequence {
+public struct DispatchDataIterator : IteratorProtocol, Sequence, @unchecked Sendable {
         public typealias Element = UInt8
 
 	/// Create an iterator over the given DispatchData

--- a/src/swift/IO.swift
+++ b/src/swift/IO.swift
@@ -17,19 +17,19 @@ import WinSDK
 
 extension DispatchIO {
 
-	public enum StreamType : UInt  {
+	public enum StreamType : UInt, Sendable  {
 		case stream = 0
 		case random = 1
 	}
 
-	public struct CloseFlags : OptionSet, RawRepresentable {
+	public struct CloseFlags : OptionSet, RawRepresentable, Sendable {
 		public let rawValue: UInt
 		public init(rawValue: UInt) { self.rawValue = rawValue }
 
 		public static let stop = CloseFlags(rawValue: 1)
 	}
 
-	public struct IntervalFlags : OptionSet, RawRepresentable {
+	public struct IntervalFlags : OptionSet, RawRepresentable, Sendable {
 		public let rawValue: UInt
 		public init(rawValue: UInt) { self.rawValue = rawValue }
 		public init(nilLiteral: ()) { self.rawValue = 0 }

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -28,7 +28,7 @@ internal class _DispatchSpecificValue<T> {
 }
 
 extension DispatchQueue {
-	public struct Attributes : OptionSet {
+	public struct Attributes : OptionSet, Sendable {
 		public let rawValue: UInt64
 		public init(rawValue: UInt64) { self.rawValue = rawValue }
 
@@ -52,7 +52,7 @@ extension DispatchQueue {
 		}
 	}
 
-	public enum GlobalQueuePriority {
+	public enum GlobalQueuePriority : Sendable {
 		@available(macOS, deprecated: 10.10, message: "Use qos attributes instead")
 		@available(iOS, deprecated: 8.0, message: "Use qos attributes instead")
 		@available(tvOS, deprecated, message: "Use qos attributes instead")
@@ -87,7 +87,7 @@ extension DispatchQueue {
 		}
 	}
 
-	public enum AutoreleaseFrequency {
+	public enum AutoreleaseFrequency : Sendable {
 		case inherit
 
 		@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)


### PR DESCRIPTION
### Description

In the SDK that ships with Xcode, these types are marked as `Sendable`, which causes source compatibility issues.

Adds missing `Sendable` conformance to the following types:
- `DispatchQueue.Attributes`
- `DispatchQueue.GlobalQueuePriority`
- `DispatchQueue.AutoreleaseFrequency`
- `DispatchWorkItemFlags`
- `DispatchIO.StreamType`
- `DispatchIO.CloseFlags`
- `DispatchIO.IntervalFlags`
- `DispatchData`
- `DispatchData.Deallocator`
- `DispatchDataIterator`

Related issues: #779, #910

### Reproduction

```swift
import Dispatch

@main
struct swift_dispatch_sendable {
    static func main() async {
        let sendables: [Sendable] = [
            DispatchQueue.Attributes.concurrent,
            DispatchQueue.GlobalQueuePriority.background,
            DispatchQueue.AutoreleaseFrequency.inherit,
            DispatchWorkItemFlags.assignCurrentContext,
            DispatchIO.StreamType.random,
            DispatchIO.CloseFlags.stop,
            DispatchIO.IntervalFlags.strictInterval,
            DispatchData.empty,
            DispatchData.Deallocator.free,
            DispatchData.empty.makeIterator(), // DispatchDataIterator
        ]
    }
}
```

### Expected behavior

The example program should compile without errors.