### PR TITLE
BlocksRuntime: Expose NSConcrete* globals on Win32

### DIFF
--- a/src/BlocksRuntime/Block_private.h
+++ b/src/BlocksRuntime/Block_private.h
@@ -197,9 +197,17 @@ BLOCK_EXPORT bool _Block_tryRetain(const void *aBlock);
 // Callable only from the ARR weak subsystem while in exclusion zone
 BLOCK_EXPORT bool _Block_isDeallocating(const void *aBlock);
 
-
 // the raw data space for runtime classes for blocks
 // class+meta used for stack, malloc, and collectable based blocks
+#if defined(_WIN32)
+extern void * _NSConcreteMallocBlock[32];
+extern void * _NSConcreteAutoBlock[32];
+extern void * _NSConcreteFinalizingBlock[32];
+extern void * _NSConcreteWeakBlockVariable[32];
+// declared in Block.h
+// extern void * _NSConcreteGlobalBlock[32];
+// extern void * _NSConcreteStackBlock[32];
+#else
 BLOCK_EXPORT void * _NSConcreteMallocBlock[32];
 BLOCK_EXPORT void * _NSConcreteAutoBlock[32];
 BLOCK_EXPORT void * _NSConcreteFinalizingBlock[32];
@@ -207,6 +215,7 @@ BLOCK_EXPORT void * _NSConcreteWeakBlockVariable[32];
 // declared in Block.h
 // BLOCK_EXPORT void * _NSConcreteGlobalBlock[32];
 // BLOCK_EXPORT void * _NSConcreteStackBlock[32];
+#endif
 
 
 // the intercept routines that must be used under GC

--- a/src/BlocksRuntime/BlocksRuntime.def
+++ b/src/BlocksRuntime/BlocksRuntime.def
@@ -2,3 +2,7 @@ LIBRARY BlocksRuntime
 EXPORTS
   _NSConcreteGlobalBlock CONSTANT
   _NSConcreteStackBlock CONSTANT
+  _NSConcreteMallocBlock CONSTANT
+  _NSConcreteAutoBlock CONSTANT
+  _NSConcreteFinalizingBlock CONSTANT
+  _NSConcreteWeakBlockVariable CONSTANT

--- a/src/BlocksRuntime/data.c
+++ b/src/BlocksRuntime/data.c
@@ -19,12 +19,15 @@ We keep these in a separate file so that we can include the runtime code in test
 #if defined(_WIN32)
 void * _NSConcreteStackBlock[32] = { 0 };
 void * _NSConcreteGlobalBlock[32] = { 0 };
+void * _NSConcreteMallocBlock[32] = { 0 };
+void * _NSConcreteAutoBlock[32] = { 0 };
+void * _NSConcreteFinalizingBlock[32] = { 0 };
+void * _NSConcreteWeakBlockVariable[32] = { 0 };
 #else
 BLOCK_ABI void * _NSConcreteStackBlock[32] = { 0 };
 BLOCK_ABI void * _NSConcreteGlobalBlock[32] = { 0 };
-#endif
-
 BLOCK_ABI void * _NSConcreteMallocBlock[32] = { 0 };
 BLOCK_ABI void * _NSConcreteAutoBlock[32] = { 0 };
 BLOCK_ABI void * _NSConcreteFinalizingBlock[32] = { 0 };
 BLOCK_ABI void * _NSConcreteWeakBlockVariable[32] = { 0 };
+#endif


### PR DESCRIPTION
[libobjc2](https://github.com/gnustep/libobjc2) now supports external blocks runtimes, including the one bundled in libdispatch. This works on Linux, but the NSConcrete* globals are not correctly exposed on Windows resulting in a linker error. @compnerd added initial support for this in https://github.com/swiftlang/swift-corelibs-libdispatch/commit/23ce6f6e685a20fb8199d8ac8c379da81bfffce9. I have added the remaining globals to this.