### PR TITLE
Use dispatch_retain instead of os_atomic_store2o

### DIFF
--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -159,7 +159,7 @@ _dispatch_group_create_with_count(uint32_t n)
 	if (n) {
 		os_atomic_store2o(dg, dg_bits,
 				(uint32_t)-n * DISPATCH_GROUP_VALUE_INTERVAL, relaxed);
-		os_atomic_store2o(dg, do_ref_cnt, 1, relaxed); // <rdar://22318411>
+		_dispatch_retain(dg);; // <rdar://22318411>
 	}
 	return dg;
 }


### PR DESCRIPTION
This is both consistent with upstream libdispatch, but most importantly, has _dispatch_retain deal with bookkeeping rather than doing it directly.