### PR TITLE
Prevent traces that log a bad pointer

### DIFF
--- a/src/block.cpp
+++ b/src/block.cpp
@@ -83,12 +83,12 @@ struct dispatch_block_private_data_s {
 		_dispatch_block_private_data_debug("destroy%s, block: %p",
 				dbpd_magic ? "" : " (stack)", dbpd_block);
 
+		if (dbpd_magic != DISPATCH_BLOCK_PRIVATE_DATA_MAGIC) return;
 #if DISPATCH_INTROSPECTION
 		void *db = (char *) this - sizeof(struct Block_layout);
 		_dispatch_ktrace1(DISPATCH_QOS_TRACE_private_block_dispose, db);
 #endif /* DISPATCH_INTROSPECTION */
 
-		if (dbpd_magic != DISPATCH_BLOCK_PRIVATE_DATA_MAGIC) return;
 		if (dbpd_group) {
 			if (!dbpd_performed) dispatch_group_leave(dbpd_group);
 			_os_object_release(dbpd_group->_as_os_obj);


### PR DESCRIPTION
Also present in macOS. No clue if introspection is even able to be built on other platforms, but if it is, well, we should return. before we put the information in ktrace.