### PR TITLE
Handle kevent timer delays on OpenBSD properly.

### DIFF
--- a/src/event/event_kevent.c
+++ b/src/event/event_kevent.c
@@ -50,7 +50,7 @@ DISPATCH_STATIC_GLOBAL(struct dispatch_muxnote_bucket_s _dispatch_sources[DSL_HA
 #define DISPATCH_NOTE_CLOCK_WALL      NOTE_NSECONDS | NOTE_MACH_CONTINUOUS_TIME
 #define DISPATCH_NOTE_CLOCK_MONOTONIC NOTE_MACHTIME | NOTE_MACH_CONTINUOUS_TIME
 #define DISPATCH_NOTE_CLOCK_UPTIME    NOTE_MACHTIME
-#elif __FreeBSD__
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #define DISPATCH_NOTE_CLOCK_WALL      NOTE_NSECONDS
 #define DISPATCH_NOTE_CLOCK_MONOTONIC NOTE_NSECONDS
 #define DISPATCH_NOTE_CLOCK_UPTIME    NOTE_NSECONDS
@@ -2406,9 +2406,6 @@ _dispatch_event_loop_timer_arm(dispatch_timer_heap_t dth, uint32_t tidx,
 	}
 #if !NOTE_ABSOLUTE
 	target = range.delay;
-#if defined(__OpenBSD__)
-	target /= 1000000;
-#endif
 #endif
 
 	_dispatch_event_loop_timer_program(dth, tidx, target, range.leeway,


### PR DESCRIPTION
Dispatch likes durations specified in ns. Earlier, for whatever reason, we didn't use the flags for EVFILT_TIMER to expect ns to and instead scaled manually to match the default, which is ms. This scaling was conditioned on NOTE_ABSOLUTE not being defined. In #879, support was added to ensure uses of NOTE_ABSOLUTE were matched to the BSD-like spelling, NOTE_ABSTIME. But this then meant that we were no longer scaling the durations on OpenBSD.

This was all a terrible hack to begin with. Remove the manual scaling condition and use NOTE_NSECONDS like we should have done back in the beginning. (What was I thinking?)