### PR TITLE
[6.3] Handle kevent timer delays on OpenBSD properly.

### DIFF
--- a/src/event/event_kevent.c
+++ b/src/event/event_kevent.c
@@ -50,7 +50,7 @@ DISPATCH_STATIC_GLOBAL(struct dispatch_muxnote_bucket_s _dispatch_sources[DSL_HA
 #define DISPATCH_NOTE_CLOCK_WALL      NOTE_NSECONDS | NOTE_MACH_CONTINUOUS_TIME
 #define DISPATCH_NOTE_CLOCK_MONOTONIC NOTE_MACHTIME | NOTE_MACH_CONTINUOUS_TIME
 #define DISPATCH_NOTE_CLOCK_UPTIME    NOTE_MACHTIME
-#elif __FreeBSD__
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #define DISPATCH_NOTE_CLOCK_WALL      NOTE_NSECONDS
 #define DISPATCH_NOTE_CLOCK_MONOTONIC NOTE_NSECONDS
 #define DISPATCH_NOTE_CLOCK_UPTIME    NOTE_NSECONDS
@@ -2406,9 +2406,6 @@ _dispatch_event_loop_timer_arm(dispatch_timer_heap_t dth, uint32_t tidx,
 	}
 #if !NOTE_ABSOLUTE
 	target = range.delay;
-#if defined(__OpenBSD__)
-	target /= 1000000;
-#endif
 #endif
 
 	_dispatch_event_loop_timer_program(dth, tidx, target, range.leeway,


### PR DESCRIPTION
- **Explanation**:

Fixes a timer regression for OpenBSD, so this need not be patched locally for 6.3.

- **Scope**:

Minor, since this only affects OpenBSD.

- **Issues**:

#930 

- **Original PRs**:

#931 

- **Risk**:

Minor, since the change is only scoped to the BSDs.

- **Testing**:

Passed CI and local testing.

- **Reviewers**:

@compnerd, @etcwilde, @grynspan, @akmorrison 