### PR TITLE
Guard pthread_getname_np usage in dispatch_thread_name test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,7 +163,7 @@ if(EXTENDED_TEST_SUITE)
 endif()
 
 # add C tests for platform-specific functionality when applicable
-if(UNIX AND (HAVE_PTHREAD_SETNAME_NP OR HAVE_PTHREAD_SET_NAME_NP))
+if(UNIX AND (HAVE_PTHREAD_SETNAME_NP OR HAVE_PTHREAD_SET_NAME_NP) AND (HAVE_PTHREAD_GETNAME_NP OR HAVE_PTHREAD_GET_NAME_NP))
   list(APPEND DISPATCH_C_TESTS
        thread_name)
 endif()


### PR DESCRIPTION
With #937, building for Android < r26 fails with the following:

```
  -- Looking for pthread_setname_np - found
  -- Looking for pthread_getname_np - not found

...

ld: error: undefined symbol: pthread_getname_np
>>> referenced by dispatch_thread_name.c:74
>>>               CMakeFiles/dispatch_thread_name.dir/dispatch_thread_name.c.o:(__main_block_invoke)
```

This is because `pthread_getname_np` is only available starting at API level 26 and the `dispatch_thread_name` test calls `pthread_getname_np` unguarded by the define.