### PR TITLE
Add DragonFlyBSD compile-time check for missing NOTE_NSECONDS

### DIFF
--- a/src/event/event_kevent.c
+++ b/src/event/event_kevent.c
@@ -54,6 +54,14 @@ DISPATCH_STATIC_GLOBAL(struct dispatch_muxnote_bucket_s _dispatch_sources[DSL_HA
 #define DISPATCH_NOTE_CLOCK_WALL      NOTE_NSECONDS
 #define DISPATCH_NOTE_CLOCK_MONOTONIC NOTE_NSECONDS
 #define DISPATCH_NOTE_CLOCK_UPTIME    NOTE_NSECONDS
+#elif defined(__DragonFly__)
+#ifndef NOTE_NSECONDS
+#error "DragonFlyBSD EVFILT_TIMER defaults to milliseconds. Adjust timer values before enabling nanosecond timers."
+#else
+#define DISPATCH_NOTE_CLOCK_WALL      NOTE_NSECONDS
+#define DISPATCH_NOTE_CLOCK_MONOTONIC NOTE_NSECONDS
+#define DISPATCH_NOTE_CLOCK_UPTIME    NOTE_NSECONDS
+#endif
 #else
 #define DISPATCH_NOTE_CLOCK_WALL      0
 #define DISPATCH_NOTE_CLOCK_MONOTONIC 0


### PR DESCRIPTION
Fixes #933 

Add a compile-time check for DragonFlyBSD timer support by detecting the absence of NOTE_NSECONDS. This prevents silently using nanosecond timer values with EVFILT_TIMER implementations that default to milliseconds and makes the required platform-specific adjustment explicit while remaining compatible with future DragonFlyBSD versions that may add NOTE_NSECONDS support.